### PR TITLE
Measure conformance against PostgREST, and close the gaps it found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ loadtest
 gen_targets.http
 gen_jwk.json
 gen_private.json
+scripts/conformance/.work

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ gen_targets.http
 gen_jwk.json
 gen_private.json
 scripts/conformance/.work
+scripts/conformance/.work-probe

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ gen_jwk.json
 gen_private.json
 scripts/conformance/.work
 scripts/conformance/.work-probe
+scripts/hasura-conformance/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Postrust is a high-performance, serverless-first REST API server for PostgreSQL 
 | **Filtering** | ✅ | `eq`, `neq`, `gt`, `lt`, `gte`, `lte`, `like`, `ilike`, `in`, `is` |
 | **Full-Text Search** | ✅ | `fts`, `plfts`, `phfts`, `wfts` operators |
 | **Ordering** | ✅ | `order=column.asc`, `order=column.desc.nullsfirst` |
-| **Pagination** | ✅ | `limit`, `offset`, Range headers |
+| **Pagination** | ✅ | `limit`, `offset`, and `Range` headers (`0-9`, `100-149`, `100-`) |
 | **Column Selection** | ✅ | `select=col1,col2,relation(nested)` |
 | **Resource Embedding** | ✅ | Nested resources via foreign keys |
 | **RPC Functions** | ✅ | Call stored procedures via `/api/rpc/function_name` (`/rpc/...` in [compatibility mode](#postgrest-compatibility)) |
@@ -182,8 +182,14 @@ curl "http://localhost:3000/users?order=role.asc,name.desc"
 # Pagination
 curl "http://localhost:3000/users?limit=10&offset=20"
 
-# Range header
+# Range header -- any window, not only one starting at the first row
 curl http://localhost:3000/users -H "Range: 0-9"
+curl http://localhost:3000/users -H "Range: 100-149"   # -> 206, Content-Range: 100-149/1000
+curl http://localhost:3000/users -H "Range: 100-"      # row 100 to the end
+
+# What a resource allows, derived from the schema
+curl -i -X OPTIONS http://localhost:3000/users
+# Allow: OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE
 ```
 
 #### Resource Embedding
@@ -580,11 +586,19 @@ the rest are documented here so you don't assume bit-for-bit compatibility.
 | REST base path | `/` (e.g. `POST /rpc/foo`) | Nested under `/api` (e.g. `POST /api/rpc/foo`) — leaves room for `/api/graphql`, `/admin` on the same server | Also served at `/` |
 | RPC response shape | Bare result: `{...}` for a single/scalar return, a top-level array for set-returning functions | Array-wrapped, function-name-keyed: `[{"foo": {...}}]` | Un-wrapped to match PostgREST |
 | Config source | Config file **and** env vars | Environment variables only | — |
-| Root endpoint `/` | OpenAPI spec | Small JSON server-info document | Unchanged |
+| Root endpoint `/` | OpenAPI spec | Small JSON server-info document | Serves neither yet — see below |
+| Object key order | Select order | Alphabetical, or select order with the `compat-key-order` build feature | Unchanged — it is a build-time choice |
+| `Prefer: tx=rollback` | Honoured | Not implemented, and not reported as applied | — |
+| JWT `exp` / `nbf` | All checked to the second | `exp` to the second; 30s clock skew on `nbf` and `iat` | — |
 
-Other known gaps (contributions welcome): the OpenAPI spec lives under
-`/admin` (behind the `admin-ui` feature) rather than at `/`, and not every
-PostgREST config knob is implemented yet.
+The differences that are deliberate — including cases where PostgREST is the
+one that is wrong — are listed with their evidence in
+[PostgREST conformance](docs/postgrest-conformance.md).
+
+The largest gap is the OpenAPI document. PostgREST serves Swagger 2.0 at `/`;
+Postrust serves OpenAPI 3.0 for its own surface under `/admin`, behind the
+`admin-ui` feature, and does not yet generate PostgREST's. Not every PostgREST
+config knob is implemented either. Contributions welcome.
 
 ### PostgREST compatibility
 
@@ -611,6 +625,14 @@ curl -X POST http://localhost:3000/rpc/get_statistics
 ```
 
 This is opt-in so existing Postrust deployments keep their current behavior.
+
+How closely the two agree is measured rather than asserted: the harness in
+`scripts/conformance/` replays PostgREST's own test cases over HTTP against
+both servers on identically loaded fixture databases. Over 1499 cases against
+PostgREST v16.1, **96.1% agree on status and body, and 94.3% on the full
+contract** — status, body, and every header that is part of the answer. See
+[PostgREST conformance](docs/postgrest-conformance.md) for what that covers,
+where the two disagree on purpose, and what is still open.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ This is opt-in so existing Postrust deployments keep their current behavior.
 How closely the two agree is measured rather than asserted: the harness in
 `scripts/conformance/` replays PostgREST's own test cases over HTTP against
 both servers on identically loaded fixture databases. Over 1499 cases against
-PostgREST v16.1, **96.1% agree on status and body, and 94.3% on the full
+PostgREST v16.1, **96.7% agree on status and body, and 94.9% on the full
 contract** — status, body, and every header that is part of the answer. See
 [PostgREST conformance](docs/postgrest-conformance.md) for what that covers,
 where the two disagree on purpose, and what is still open.

--- a/crates/postrust-auth/src/jwt.rs
+++ b/crates/postrust-auth/src/jwt.rs
@@ -25,6 +25,12 @@ pub fn validate_token(token: &str, config: &JwtConfig) -> Result<AuthResult, Jwt
     let mut validation = Validation::new(Algorithm::HS256);
     validation.validate_exp = true;
     validation.validate_nbf = true;
+    // A token without `exp` does not expire, which is a thing a token is
+    // allowed to be: the claim is optional in RFC 7519 and PostgREST treats it
+    // so. The library requires it by default, which rejected every unexpiring
+    // token as unreadable -- and reported it as a key problem, which it is
+    // not.
+    validation.required_spec_claims.clear();
 
     if let Some(aud) = &config.audience {
         validation.set_audience(&[aud]);
@@ -82,9 +88,13 @@ pub struct Claims {
     /// Issued at
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iat: Option<i64>,
-    /// Audience
+    /// Audience.
+    ///
+    /// Not narrowed to a string: the claim may be a list, or anything else a
+    /// client put there, and refusing to read the token because one claim is
+    /// shaped unexpectedly loses the rest of it.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aud: Option<String>,
+    pub aud: Option<serde_json::Value>,
     /// Custom claims
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,

--- a/crates/postrust-auth/src/jwt.rs
+++ b/crates/postrust-auth/src/jwt.rs
@@ -1,16 +1,25 @@
 //! JWT token validation.
+//!
+//! The signature is checked by the library; the claims are checked here. That
+//! split is deliberate: a claim can be wrong in two different ways -- absent,
+//! or present and not the kind of thing that claim is -- and the client needs
+//! to be told which. A library that folds both into "invalid token" answers a
+//! question nobody asked.
 
-use super::{AuthResult, JwtConfig, JwtError};
+use super::{AuthResult, ClaimFault, JwtConfig, JwtError};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
+/// How far out of step with the server a token's clock may be.
+///
+/// A token minted a moment ago on a machine whose clock runs a little fast is
+/// not a forgery, and rejecting it would make a working deployment fail
+/// intermittently and unreproducibly.
+const ALLOWED_SKEW: i64 = 30;
 
 /// Validate a JWT token and extract claims.
 pub fn validate_token(token: &str, config: &JwtConfig) -> Result<AuthResult, JwtError> {
-    let secret = config
-        .secret
-        .as_ref()
-        .ok_or_else(|| JwtError::InvalidToken("No JWT secret configured".into()))?;
+    let secret = config.secret.as_ref().ok_or(JwtError::SecretMissing)?;
 
     // Decode secret
     let key_bytes = if config.secret_is_base64 {
@@ -21,91 +30,122 @@ pub fn validate_token(token: &str, config: &JwtConfig) -> Result<AuthResult, Jwt
 
     let key = DecodingKey::from_secret(&key_bytes);
 
-    // Set up validation
+    // Signature only. Every claim the library could check here, it checks
+    // differently from the way this API's contract says to -- a missing `exp`
+    // is not an error, an `aud` that is not a string has a code of its own --
+    // so all of it is done below, where the answers can be the right ones.
     let mut validation = Validation::new(Algorithm::HS256);
-    validation.validate_exp = true;
-    validation.validate_nbf = true;
-    // A token without `exp` does not expire, which is a thing a token is
-    // allowed to be: the claim is optional in RFC 7519 and PostgREST treats it
-    // so. The library requires it by default, which rejected every unexpiring
-    // token as unreadable -- and reported it as a key problem, which it is
-    // not.
+    validation.validate_exp = false;
+    validation.validate_nbf = false;
+    validation.validate_aud = false;
     validation.required_spec_claims.clear();
 
-    if let Some(aud) = &config.audience {
-        validation.set_audience(&[aud]);
-    } else {
-        validation.validate_aud = false;
-    }
-
-    // Decode and validate
-    let token_data = decode::<Claims>(token, &key, &validation).map_err(map_jwt_error)?;
-
+    let token_data = decode::<HashMap<String, serde_json::Value>>(token, &key, &validation)
+        .map_err(map_jwt_error)?;
     let claims = token_data.claims;
 
-    // Extract role
+    check_claims(&claims, config, now())?;
+
+    // The role decides what the request may do, so a token naming none, on a
+    // server with no anonymous role, is a request with no identity at all.
     let role = claims
-        .extra
         .get(&config.role_claim_key)
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
+        .map(|value| match value {
+            serde_json::Value::String(role) => role.clone(),
+            other => other.to_string(),
+        })
         .or_else(|| config.anon_role.clone())
-        .ok_or(JwtError::MissingRole)?;
+        .ok_or(JwtError::MissingHeader)?;
 
-    // Build claims map
-    let mut claims_map = claims.extra;
-    if let Some(sub) = claims.sub {
-        claims_map.insert("sub".into(), serde_json::Value::String(sub));
-    }
-    if let Some(iss) = claims.iss {
-        claims_map.insert("iss".into(), serde_json::Value::String(iss));
-    }
-    if let Some(exp) = claims.exp {
-        claims_map.insert("exp".into(), serde_json::Value::Number(exp.into()));
-    }
-
-    Ok(AuthResult {
-        role,
-        claims: claims_map,
-    })
+    Ok(AuthResult { role, claims })
 }
 
-/// Standard and custom JWT claims.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Claims {
-    /// Subject
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sub: Option<String>,
-    /// Issuer
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub iss: Option<String>,
-    /// Expiration time
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exp: Option<i64>,
-    /// Not before
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub nbf: Option<i64>,
-    /// Issued at
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub iat: Option<i64>,
-    /// Audience.
-    ///
-    /// Not narrowed to a string: the claim may be a list, or anything else a
-    /// client put there, and refusing to read the token because one claim is
-    /// shaped unexpectedly loses the rest of it.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub aud: Option<serde_json::Value>,
-    /// Custom claims
-    #[serde(flatten)]
-    pub extra: HashMap<String, serde_json::Value>,
+/// The registered claims, checked in the order the contract checks them.
+///
+/// Order is part of the answer: a token that is both expired and out of
+/// audience is reported as expired, because that is the first thing wrong with
+/// it and the one the client can act on.
+fn check_claims(
+    claims: &HashMap<String, serde_json::Value>,
+    config: &JwtConfig,
+    now: i64,
+) -> Result<(), JwtError> {
+    // A claim that is absent is not a claim that is wrong. Only one that is
+    // present in the wrong shape is.
+    let number = |name: &'static str| -> Result<Option<i64>, JwtError> {
+        match claims.get(name) {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(value) => value
+                .as_f64()
+                .map(|seconds| seconds as i64)
+                .map(Some)
+                .ok_or(JwtError::Claim(ClaimFault::NotANumber(name))),
+        }
+    };
+
+    if let Some(exp) = number("exp")? {
+        if now - ALLOWED_SKEW > exp {
+            return Err(JwtError::Claim(ClaimFault::Expired));
+        }
+    }
+    if let Some(nbf) = number("nbf")? {
+        if now + ALLOWED_SKEW < nbf {
+            return Err(JwtError::Claim(ClaimFault::NotYetValid));
+        }
+    }
+    if let Some(iat) = number("iat")? {
+        if now + ALLOWED_SKEW < iat {
+            return Err(JwtError::Claim(ClaimFault::IssuedInFuture));
+        }
+    }
+
+    // With no audience configured the server accepts any, but the claim still
+    // has to *be* an audience: a list with an object in it is a malformed
+    // token, not a token meant for somebody else. That is the difference
+    // between a client fixing how it mints tokens and hunting for a setting
+    // this server does not have.
+    let matches = |aud: &str| match &config.audience {
+        Some(wanted) => aud == wanted,
+        None => true,
+    };
+    match claims.get("aud") {
+        None | Some(serde_json::Value::Null) => {}
+        Some(serde_json::Value::String(aud)) => {
+            if !matches(aud) {
+                return Err(JwtError::Claim(ClaimFault::NotInAudience));
+            }
+        }
+        Some(serde_json::Value::Array(auds)) => {
+            if !auds.iter().all(serde_json::Value::is_string) {
+                return Err(JwtError::Claim(ClaimFault::AudienceNotStrings));
+            }
+            // A list naming no audience excludes nobody.
+            let admitted = auds
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .any(matches);
+            if !auds.is_empty() && !admitted {
+                return Err(JwtError::Claim(ClaimFault::NotInAudience));
+            }
+        }
+        Some(_) => return Err(JwtError::Claim(ClaimFault::AudienceNotStrings)),
+    }
+
+    Ok(())
+}
+
+/// Seconds since the epoch.
+fn now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or_default()
 }
 
 /// Decode base64 secret.
 fn base64_decode(s: &str) -> Result<Vec<u8>, JwtError> {
     use base64::{engine::general_purpose::STANDARD, Engine};
-    STANDARD
-        .decode(s)
-        .map_err(|e| JwtError::InvalidToken(format!("Invalid base64 secret: {}", e)))
+    STANDARD.decode(s).map_err(|_| JwtError::NoSuitableKey)
 }
 
 /// Map jsonwebtoken error to JwtError.
@@ -113,76 +153,118 @@ fn map_jwt_error(e: jsonwebtoken::errors::Error) -> JwtError {
     use jsonwebtoken::errors::ErrorKind;
 
     match e.kind() {
-        ErrorKind::ExpiredSignature => JwtError::Expired,
-        ErrorKind::ImmatureSignature => JwtError::NotYetValid,
         ErrorKind::InvalidSignature => JwtError::InvalidSignature,
-        ErrorKind::InvalidAudience => JwtError::InvalidAudience,
-        _ => JwtError::InvalidToken(e.to_string()),
+        // The token was read and its claims were not a JSON object, which is a
+        // different failure from a key that could not decode it at all.
+        ErrorKind::Json(_) => JwtError::Claim(ClaimFault::Unparsable),
+        _ => JwtError::NoSuitableKey,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonwebtoken::{encode, EncodingKey, Header};
 
-    fn make_token(claims: &Claims, secret: &str) -> String {
-        let key = EncodingKey::from_secret(secret.as_bytes());
-        encode(&Header::default(), claims, &key).unwrap()
+    fn config() -> JwtConfig {
+        JwtConfig {
+            secret: Some("reallyreallyreallyreallyverysafe".into()),
+            ..JwtConfig::default()
+        }
     }
 
-    #[test]
-    fn test_validate_valid_token() {
-        let secret = "test_secret_key_at_least_32_bytes!";
-
-        let claims = Claims {
-            sub: Some("user123".into()),
-            iss: None,
-            exp: Some(chrono::Utc::now().timestamp() + 3600),
-            nbf: None,
-            iat: None,
-            aud: None,
-            extra: {
-                let mut m = HashMap::new();
-                m.insert("role".into(), serde_json::Value::String("web_user".into()));
-                m
-            },
-        };
-
-        let token = make_token(&claims, secret);
-
-        let config = JwtConfig {
-            secret: Some(secret.into()),
-            ..Default::default()
-        };
-
-        let result = validate_token(&token, &config).unwrap();
-        assert_eq!(result.role, "web_user");
-        assert_eq!(result.get_claim("sub").unwrap(), "user123");
+    fn claims(json: serde_json::Value) -> HashMap<String, serde_json::Value> {
+        match json {
+            serde_json::Value::Object(map) => map.into_iter().collect(),
+            _ => panic!("claims must be an object"),
+        }
     }
 
+    /// The token in PostgREST's own suite carries `"aud": [{...}, "test"]`,
+    /// which is neither an audience nor a list of them.
     #[test]
-    fn test_validate_expired_token() {
-        let secret = "test_secret_key_at_least_32_bytes!";
+    fn an_audience_that_is_not_a_string_is_a_malformed_token() {
+        assert!(matches!(
+            check_claims(
+                &claims(serde_json::json!({"aud": [{"invalid": "value"}, "test"]})),
+                &config(),
+                0
+            ),
+            Err(JwtError::Claim(ClaimFault::AudienceNotStrings))
+        ));
+    }
 
-        let claims = Claims {
-            sub: None,
-            iss: None,
-            exp: Some(chrono::Utc::now().timestamp() - 3600), // Expired
-            nbf: None,
-            iat: None,
-            aud: None,
-            extra: HashMap::new(),
+    /// With no audience configured, any audience is this server's.
+    #[test]
+    fn any_audience_is_accepted_when_none_is_configured() {
+        assert!(check_claims(
+            &claims(serde_json::json!({"aud": ["someone", "else"]})),
+            &config(),
+            0
+        )
+        .is_ok());
+    }
+
+    /// A list naming no audience excludes nobody.
+    #[test]
+    fn an_empty_audience_list_excludes_no_one() {
+        let configured = JwtConfig {
+            audience: Some("us".into()),
+            ..config()
         };
+        assert!(check_claims(&claims(serde_json::json!({"aud": []})), &configured, 0).is_ok());
+        assert!(matches!(
+            check_claims(
+                &claims(serde_json::json!({"aud": ["them"]})),
+                &configured,
+                0
+            ),
+            Err(JwtError::Claim(ClaimFault::NotInAudience))
+        ));
+    }
 
-        let token = make_token(&claims, secret);
+    /// A token that does not say when it expires does not expire.
+    #[test]
+    fn a_token_without_exp_is_not_rejected_for_having_none() {
+        assert!(check_claims(&claims(serde_json::json!({"role": "x"})), &config(), 0).is_ok());
+    }
 
-        let config = JwtConfig {
-            secret: Some(secret.into()),
-            ..Default::default()
-        };
+    /// Present, but not the kind of thing that claim is.
+    #[test]
+    fn a_timestamp_claim_that_is_not_a_number_is_reported_as_such() {
+        assert!(matches!(
+            check_claims(&claims(serde_json::json!({"exp": "soon"})), &config(), 0),
+            Err(JwtError::Claim(ClaimFault::NotANumber("exp")))
+        ));
+    }
 
-        let result = validate_token(&token, &config);
-        assert!(matches!(result, Err(JwtError::Expired)));
+    /// A clock a few seconds out of step is not a forgery.
+    #[test]
+    fn a_small_clock_difference_is_tolerated_at_both_ends() {
+        let expired_moments_ago = claims(serde_json::json!({"exp": 1_000}));
+        assert!(check_claims(&expired_moments_ago, &config(), 1_010).is_ok());
+        assert!(matches!(
+            check_claims(&expired_moments_ago, &config(), 1_100),
+            Err(JwtError::Claim(ClaimFault::Expired))
+        ));
+
+        let issued_moments_hence = claims(serde_json::json!({"iat": 1_000}));
+        assert!(check_claims(&issued_moments_hence, &config(), 990).is_ok());
+        assert!(matches!(
+            check_claims(&issued_moments_hence, &config(), 900),
+            Err(JwtError::Claim(ClaimFault::IssuedInFuture))
+        ));
+    }
+
+    /// The first thing wrong with the token is what the client is told.
+    #[test]
+    fn an_expired_token_is_reported_as_expired_whatever_else_is_wrong() {
+        assert!(matches!(
+            check_claims(
+                &claims(serde_json::json!({"exp": 1_000, "aud": [{"bad": 1}]})),
+                &config(),
+                9_000
+            ),
+            Err(JwtError::Claim(ClaimFault::Expired))
+        ));
     }
 }

--- a/crates/postrust-auth/src/jwt.rs
+++ b/crates/postrust-auth/src/jwt.rs
@@ -10,11 +10,18 @@ use super::{AuthResult, ClaimFault, JwtConfig, JwtError};
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use std::collections::HashMap;
 
-/// How far out of step with the server a token's clock may be.
+/// How far ahead of the server a token's clock may be.
 ///
 /// A token minted a moment ago on a machine whose clock runs a little fast is
 /// not a forgery, and rejecting it would make a working deployment fail
 /// intermittently and unreproducibly.
+///
+/// Only in that direction. `exp` is checked to the second, because leniency
+/// there is leniency about a token that has been *withdrawn* -- it keeps a
+/// revoked session alive past the moment its issuer said it ended, and it is a
+/// window an attacker holding a stale token gets for free. `nbf` and `iat`
+/// describe a token that is not valid *yet*, where the same slack costs
+/// nothing and is the only remedy for a clock nobody controls.
 const ALLOWED_SKEW: i64 = 30;
 
 /// Validate a JWT token and extract claims.
@@ -48,16 +55,24 @@ pub fn validate_token(token: &str, config: &JwtConfig) -> Result<AuthResult, Jwt
 
     // The role decides what the request may do, so a token naming none, on a
     // server with no anonymous role, is a request with no identity at all.
-    let role = claims
-        .get(&config.role_claim_key)
-        .map(|value| match value {
-            serde_json::Value::String(role) => role.clone(),
-            other => other.to_string(),
-        })
-        .or_else(|| config.anon_role.clone())
-        .ok_or(JwtError::MissingHeader)?;
+    let role = role_of(&claims, config).ok_or(JwtError::NoIdentity)?;
 
     Ok(AuthResult { role, claims })
+}
+
+/// The role a token names, or the anonymous one where it names none.
+///
+/// A role is a name, and only a string is one. Rendering anything else --
+/// `"role": 42`, `"role": {"a": 1}` -- would make a database role nobody
+/// created out of a claim that does not name one, so a claim of the wrong
+/// shape is read as a token that named no role at all and falls back the same
+/// way an absent claim does.
+fn role_of(claims: &HashMap<String, serde_json::Value>, config: &JwtConfig) -> Option<String> {
+    claims
+        .get(&config.role_claim_key)
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .or_else(|| config.anon_role.clone())
 }
 
 /// The registered claims, checked in the order the contract checks them.
@@ -84,7 +99,7 @@ fn check_claims(
     };
 
     if let Some(exp) = number("exp")? {
-        if now - ALLOWED_SKEW > exp {
+        if now > exp {
             return Err(JwtError::Claim(ClaimFault::Expired));
         }
     }
@@ -237,22 +252,60 @@ mod tests {
         ));
     }
 
-    /// A clock a few seconds out of step is not a forgery.
+    /// A clock a few seconds ahead is not a forgery.
     #[test]
-    fn a_small_clock_difference_is_tolerated_at_both_ends() {
-        let expired_moments_ago = claims(serde_json::json!({"exp": 1_000}));
-        assert!(check_claims(&expired_moments_ago, &config(), 1_010).is_ok());
-        assert!(matches!(
-            check_claims(&expired_moments_ago, &config(), 1_100),
-            Err(JwtError::Claim(ClaimFault::Expired))
-        ));
-
+    fn a_token_that_is_not_valid_yet_is_given_the_benefit_of_the_clock() {
         let issued_moments_hence = claims(serde_json::json!({"iat": 1_000}));
         assert!(check_claims(&issued_moments_hence, &config(), 990).is_ok());
         assert!(matches!(
             check_claims(&issued_moments_hence, &config(), 900),
             Err(JwtError::Claim(ClaimFault::IssuedInFuture))
         ));
+
+        let valid_moments_hence = claims(serde_json::json!({"nbf": 1_000}));
+        assert!(check_claims(&valid_moments_hence, &config(), 990).is_ok());
+        assert!(matches!(
+            check_claims(&valid_moments_hence, &config(), 900),
+            Err(JwtError::Claim(ClaimFault::NotYetValid))
+        ));
+    }
+
+    /// The same slack the other way would keep a withdrawn token alive past
+    /// the second its issuer said it ended.
+    #[test]
+    fn an_expiry_is_honoured_to_the_second() {
+        let expires_at = claims(serde_json::json!({"exp": 1_000}));
+        assert!(check_claims(&expires_at, &config(), 1_000).is_ok());
+        assert!(matches!(
+            check_claims(&expires_at, &config(), 1_001),
+            Err(JwtError::Claim(ClaimFault::Expired))
+        ));
+    }
+
+    /// A role is a name, and a claim that is not a string does not carry one.
+    #[test]
+    fn a_role_claim_that_is_not_a_string_names_no_role() {
+        let configured = JwtConfig {
+            anon_role: Some("anon".into()),
+            ..config()
+        };
+        for value in [
+            serde_json::json!(42),
+            serde_json::json!({"a": 1}),
+            serde_json::json!(["admin"]),
+        ] {
+            let mut claims = HashMap::new();
+            claims.insert("role".to_string(), value.clone());
+            assert_eq!(
+                role_of(&claims, &configured),
+                Some("anon".to_string()),
+                "{value}"
+            );
+        }
+
+        let mut named = HashMap::new();
+        named.insert("role".to_string(), serde_json::json!("web_user"));
+        assert_eq!(role_of(&named, &configured), Some("web_user".to_string()));
     }
 
     /// The first thing wrong with the token is what the client is told.

--- a/crates/postrust-auth/src/lib.rs
+++ b/crates/postrust-auth/src/lib.rs
@@ -102,8 +102,9 @@ pub enum ClaimFault {
 /// JWT validation error.
 #[derive(Debug, thiserror::Error)]
 pub enum JwtError {
+    /// Nothing said who is asking, and there is no anonymous role to be.
     #[error("Anonymous access is disabled")]
-    MissingHeader,
+    NoIdentity,
 
     #[error("Unsupported token type")]
     InvalidHeaderFormat,
@@ -131,7 +132,7 @@ pub fn authenticate(auth_header: Option<&str>, config: &JwtConfig) -> Result<Aut
         None => {
             return match &config.anon_role {
                 Some(role) => Ok(AuthResult::anonymous(role)),
-                None => Err(JwtError::MissingHeader),
+                None => Err(JwtError::NoIdentity),
             };
         }
     };

--- a/crates/postrust-auth/src/lib.rs
+++ b/crates/postrust-auth/src/lib.rs
@@ -67,32 +67,60 @@ impl Default for JwtConfig {
     }
 }
 
+/// What was wrong with a token's claims.
+///
+/// Separate from the failures above because a token whose claims are wrong was
+/// read successfully: the signature verified, the server has the right key,
+/// and what remains is a disagreement about the claims themselves. A client
+/// that cannot tell those apart cannot tell "rotate your key" from "your clock
+/// is wrong".
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ClaimFault {
+    #[error("JWT expired")]
+    Expired,
+
+    #[error("JWT not yet valid")]
+    NotYetValid,
+
+    #[error("JWT issued at future")]
+    IssuedInFuture,
+
+    #[error("JWT not in audience")]
+    NotInAudience,
+
+    #[error("Parsing claims failed")]
+    Unparsable,
+
+    /// A timestamp claim that is present and is not a timestamp.
+    #[error("The JWT '{0}' claim must be a number")]
+    NotANumber(&'static str),
+
+    #[error("The JWT 'aud' claim must be a string or an array of strings")]
+    AudienceNotStrings,
+}
+
 /// JWT validation error.
 #[derive(Debug, thiserror::Error)]
 pub enum JwtError {
-    #[error("Missing authorization header")]
+    #[error("Anonymous access is disabled")]
     MissingHeader,
 
-    #[error("Invalid authorization header format")]
+    #[error("Unsupported token type")]
     InvalidHeaderFormat,
 
-    #[error("Token expired")]
-    Expired,
+    #[error("Server lacks JWT secret")]
+    SecretMissing,
 
-    #[error("Token not yet valid")]
-    NotYetValid,
-
-    #[error("Invalid signature")]
+    #[error("JWT cryptographic operation failed")]
     InvalidSignature,
 
-    #[error("Invalid token: {0}")]
-    InvalidToken(String),
+    /// No key this server holds could decode the token.
+    #[error("No suitable key or wrong key type")]
+    NoSuitableKey,
 
-    #[error("Missing role claim")]
-    MissingRole,
-
-    #[error("Invalid audience")]
-    InvalidAudience,
+    /// The token was read, and its claims were not acceptable.
+    #[error("{0}")]
+    Claim(#[from] ClaimFault),
 }
 
 /// Extract and validate JWT from Authorization header.

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -43,11 +43,17 @@ where
     // Parse action from method and resource
     let action = parse_action(method, &resource, &schema)?;
 
-    // Parse query parameters. On a function the unrecognized ones are
-    // arguments rather than malformed filters.
+    // Parse query parameters. On a function *called over GET* the
+    // unrecognized ones are arguments rather than malformed filters. Over
+    // POST the arguments are in the body, so the query string is filters and
+    // nothing else -- `POST /rpc/f?name=John` is a malformed filter, which is
+    // what PostgREST says about it.
     let is_rpc = matches!(
         action,
-        Action::Db(DbAction::Routine { .. }) | Action::RoutineInfo { .. }
+        Action::Db(DbAction::Routine {
+            invoke_method: InvokeMethod::InvRead { .. },
+            ..
+        }) | Action::RoutineInfo { .. }
     );
     let query_params = parse_query_params(query, is_rpc)?;
 

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -9,7 +9,7 @@ pub mod query_params;
 pub mod types;
 
 pub use preferences::parse_preferences;
-pub use query_params::parse_query_params;
+pub use query_params::{parse_query_params, value_is_filter};
 pub use types::*;
 
 use crate::error::{Error, Result};
@@ -95,20 +95,31 @@ fn parse_resource(path: &str) -> Result<Resource> {
         return Ok(Resource::Schema);
     }
 
+    // A trailing slash names the same resource: `/items/` is `/items`.
+    let path = path.trim_end_matches('/');
+    if path.is_empty() {
+        return Ok(Resource::Schema);
+    }
+
     if let Some(func_name) = path.strip_prefix("rpc/") {
         if func_name.is_empty() {
             return Err(Error::InvalidPath("Empty function name".into()));
         }
+        if func_name.contains('/') {
+            return Err(Error::InvalidResourcePath);
+        }
         return Ok(Resource::Routine(func_name.to_string()));
     }
 
-    // Table/view name is the first path segment
-    let name = path.split('/').next().unwrap_or(path);
-    if name.is_empty() {
-        return Err(Error::InvalidPath("Empty resource name".into()));
+    // A table is named by one segment. More than one names nothing at all --
+    // there is no nesting in the API -- and reading only the first would
+    // answer a request for `/first/second/third` with the contents of
+    // `first`, which is not what was asked for.
+    if path.contains('/') {
+        return Err(Error::InvalidResourcePath);
     }
 
-    Ok(Resource::Relation(name.to_string()))
+    Ok(Resource::Relation(path.to_string()))
 }
 
 /// Parse the schema from Accept-Profile or Content-Profile headers.
@@ -251,8 +262,11 @@ fn parse_media_type(s: &str) -> MediaType {
         "*/*" => MediaType::Any,
         s if s.starts_with("application/vnd.pgrst.object") => MediaType::SingularJson {
             nullable: s.contains("nulls=null"),
+            strip_nulls: s.contains("nulls=stripped"),
         },
-        s if s.starts_with("application/vnd.pgrst.array") => MediaType::ArrayJsonStrip,
+        s if s.starts_with("application/vnd.pgrst.array") => MediaType::ArrayJson {
+            strip_nulls: s.contains("nulls=stripped"),
+        },
         other => MediaType::Other(other.to_string()),
     }
 }

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -43,8 +43,13 @@ where
     // Parse action from method and resource
     let action = parse_action(method, &resource, &schema)?;
 
-    // Parse query parameters
-    let query_params = parse_query_params(query)?;
+    // Parse query parameters. On a function the unrecognized ones are
+    // arguments rather than malformed filters.
+    let is_rpc = matches!(
+        action,
+        Action::Db(DbAction::Routine { .. }) | Action::RoutineInfo { .. }
+    );
+    let query_params = parse_query_params(query, is_rpc)?;
 
     // Parse preferences from Prefer header
     let preferences = parse_preferences(req.headers())?;

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -229,6 +229,7 @@ fn parse_action(method: &Method, resource: &Resource, schema: &str) -> Result<Ac
         }),
 
         // Unsupported methods
+        (_, Resource::Routine(_)) => Err(Error::InvalidRpcMethod(method.to_string())),
         _ => Err(Error::UnsupportedMethod(method.to_string())),
     }
 }

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -371,21 +371,55 @@ fn parse_content_type(headers: &http::HeaderMap) -> Result<MediaType> {
 }
 
 /// Parse Range header for pagination.
+///
+/// `0-9`, `10-19` and `10-` are all ranges. Only the first of those was read
+/// before, by matching the literal prefix `0-`; every other range was dropped
+/// on the floor and the request answered with the whole relation. A client
+/// paging with `Range: 1000-1999` was handed all of it and a `Content-Range`
+/// saying so, which is the sort of disagreement a client discovers in
+/// production rather than in a test.
+///
+/// A range that is not a range at all is left alone, as before: hyper accepts
+/// header values this never has to make sense of, and the query parameters
+/// remain the way to page.
 fn parse_range(headers: &http::HeaderMap) -> Result<Range> {
-    if let Some(range) = headers.get(http::header::RANGE) {
-        let range_str = range.to_str().map_err(|_| Error::InvalidHeader("Range"))?;
-        // Parse "0-9" or "10-" format
-        if let Some(range_value) = range_str.strip_prefix("0-") {
-            if range_value.is_empty() {
-                return Ok(Range::new(0, None));
-            }
-            if let Ok(end) = range_value.parse::<i64>() {
-                return Ok(Range::from_bounds(0, Some(end)));
-            }
-        }
-        // More complex range parsing would go here
+    let Some(range) = headers.get(http::header::RANGE) else {
+        return Ok(Range::default());
+    };
+    let range_str = range.to_str().map_err(|_| Error::InvalidHeader("Range"))?;
+
+    // PostgREST writes the unit in `Range-Unit` and the bounds bare, but a
+    // client following RFC 9110 puts the unit here. Both name the same rows.
+    let bounds = range_str
+        .split_once('=')
+        .map_or(range_str, |(_unit, bounds)| bounds)
+        .trim();
+
+    let Some((start, end)) = bounds.split_once('-') else {
+        return Ok(Range::default());
+    };
+    let Ok(start) = start.trim().parse::<i64>() else {
+        return Ok(Range::default());
+    };
+    if start < 0 {
+        return Ok(Range::default());
     }
-    Ok(Range::default())
+
+    let end = end.trim();
+    if end.is_empty() {
+        // Open-ended: from here to the end of the relation.
+        return Ok(Range::new(start, None));
+    }
+    let Ok(end) = end.parse::<i64>() else {
+        return Ok(Range::default());
+    };
+    if end < start {
+        return Err(Error::InvalidRange(
+            "Requested range not satisfiable".into(),
+        ));
+    }
+
+    Ok(Range::from_bounds(start, Some(end)))
 }
 
 /// Extract headers for GUC passthrough.
@@ -416,6 +450,43 @@ fn extract_cookies(headers: &http::HeaderMap) -> indexmap::IndexMap<String, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn range_of(value: &str) -> Result<Range> {
+        let mut headers = http::HeaderMap::new();
+        headers.insert(http::header::RANGE, value.parse().unwrap());
+        parse_range(&headers)
+    }
+
+    /// Every range, not only the ones that begin at the first row.
+    #[test]
+    fn a_range_header_names_the_rows_it_says() {
+        assert_eq!(range_of("0-9").unwrap(), Range::from_bounds(0, Some(9)));
+        assert_eq!(range_of("5-9").unwrap(), Range::from_bounds(5, Some(9)));
+        assert_eq!(range_of("10-19").unwrap(), Range::from_bounds(10, Some(19)));
+        // Open-ended: from there to the end of the relation.
+        assert_eq!(range_of("10-").unwrap(), Range::new(10, None));
+        assert_eq!(range_of("0-").unwrap(), Range::new(0, None));
+        // A unit, for a client that follows RFC 9110 rather than PostgREST.
+        assert_eq!(
+            range_of("items=5-9").unwrap(),
+            Range::from_bounds(5, Some(9))
+        );
+    }
+
+    /// A range whose end precedes its start names no rows at all.
+    #[test]
+    fn an_inverted_range_is_refused_rather_than_widened() {
+        assert!(matches!(range_of("9-5"), Err(Error::InvalidRange(_))));
+    }
+
+    /// Anything that is not a range leaves paging to the query parameters,
+    /// rather than being guessed at.
+    #[test]
+    fn a_header_that_is_not_a_range_is_left_alone() {
+        for value in ["", "nonsense", "-5", "a-b", "5"] {
+            assert_eq!(range_of(value).unwrap(), Range::default(), "{value:?}");
+        }
+    }
 
     /// A plan is named back with everything that made it that plan.
     ///

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -123,7 +123,10 @@ fn parse_schema<B>(
             .to_str()
             .map_err(|_| Error::InvalidHeader("Accept-Profile"))?;
         if !schemas.contains(&schema.to_string()) {
-            return Err(Error::UnacceptableSchema(schema.into()));
+            return Err(Error::UnacceptableSchema {
+                requested: schema.into(),
+                exposed: schemas.to_vec(),
+            });
         }
         return Ok((schema.to_string(), true));
     }
@@ -134,7 +137,10 @@ fn parse_schema<B>(
             .to_str()
             .map_err(|_| Error::InvalidHeader("Content-Profile"))?;
         if !schemas.contains(&schema.to_string()) {
-            return Err(Error::UnacceptableSchema(schema.into()));
+            return Err(Error::UnacceptableSchema {
+                requested: schema.into(),
+                exposed: schemas.to_vec(),
+            });
         }
         return Ok((schema.to_string(), true));
     }

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -284,8 +284,28 @@ fn parse_accept(headers: &http::HeaderMap) -> Result<Vec<MediaType>> {
 fn parse_media_type(s: &str) -> MediaType {
     let mut parts = s.split(';').map(str::trim);
     let base = parts.next().unwrap_or(s);
-    let parameters: Vec<&str> = parts.collect();
-    let given = |parameter: &str| parameters.contains(&parameter);
+    // A parameter value may be quoted -- `for="application/json"` -- because
+    // it is itself a media type and carries a `/`. The quotes delimit it and
+    // are not part of it.
+    let parameters: Vec<(String, &str)> = parts
+        .filter_map(|part| part.split_once('='))
+        .map(|(key, value)| {
+            (
+                key.trim().to_ascii_lowercase(),
+                value.trim().trim_matches('"'),
+            )
+        })
+        .collect();
+    let param = |name: &str| {
+        parameters
+            .iter()
+            .find(|(key, _)| key == name)
+            .map(|(_, value)| *value)
+    };
+    let given = |parameter: &str| match parameter.split_once('=') {
+        Some((name, value)) => param(name) == Some(value),
+        None => false,
+    };
 
     match base {
         "application/json" => MediaType::ApplicationJson,
@@ -297,6 +317,37 @@ fn parse_media_type(s: &str) -> MediaType {
         "application/x-www-form-urlencoded" => MediaType::UrlEncoded,
         "application/octet-stream" => MediaType::OctetStream,
         "*/*" => MediaType::Any,
+        // A plan is a plan *for* something, and that something is a media
+        // type in its own right: read the same way, and named back the same
+        // way. `for="application/vnd.pgrst.object"` is how the client says
+        // "the plan for the query that would answer a singular request", and
+        // it comes back out as `application/vnd.pgrst.object+json` because
+        // that is the name that type has.
+        s if s.starts_with("application/vnd.pgrst.plan") => {
+            let format = match s.ends_with("+json") {
+                true => PlanFormat::Json,
+                false => PlanFormat::Text,
+            };
+            let requested = param("options").unwrap_or_default();
+            // Named in a fixed order rather than the order they were asked
+            // for, so that one set of options has one name.
+            let options = [
+                ("analyze", PlanOption::Analyze),
+                ("verbose", PlanOption::Verbose),
+                ("settings", PlanOption::Settings),
+                ("buffers", PlanOption::Buffers),
+                ("wal", PlanOption::Wal),
+            ]
+            .into_iter()
+            .filter(|(name, _)| requested.split('|').any(|asked| asked == *name))
+            .map(|(_, option)| option)
+            .collect();
+            MediaType::Plan {
+                base: Box::new(parse_media_type(param("for").unwrap_or("application/json"))),
+                format,
+                options,
+            }
+        }
         s if s.starts_with("application/vnd.pgrst.object") => MediaType::SingularJson {
             nullable: given("nulls=null"),
             strip_nulls: given("nulls=stripped"),
@@ -365,6 +416,36 @@ fn extract_cookies(headers: &http::HeaderMap) -> indexmap::IndexMap<String, Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A plan is named back with everything that made it that plan.
+    ///
+    /// The cases are PostgREST's own doctests for `decodeMediaType`, read
+    /// back out through `toMime`.
+    #[test]
+    fn a_plan_media_type_is_named_back_in_full() {
+        let named = |s: &str| parse_media_type(s).to_mime();
+
+        assert_eq!(
+            named("application/vnd.pgrst.plan+json"),
+            "application/vnd.pgrst.plan+json; for=\"application/json\""
+        );
+        // The `for` type is read as a media type, so it is named by the name
+        // that type has rather than the one the client wrote.
+        assert_eq!(
+            named("application/vnd.pgrst.plan+json; for=\"application/vnd.pgrst.object\""),
+            "application/vnd.pgrst.plan+json; for=\"application/vnd.pgrst.object+json\""
+        );
+        assert_eq!(
+            named("application/vnd.pgrst.plan; for=\"text/csv\""),
+            "application/vnd.pgrst.plan+text; for=\"text/csv\""
+        );
+        // Options come back in a fixed order, not the order they were asked
+        // for, and anything unrecognised is not an option.
+        assert_eq!(
+            named("application/vnd.pgrst.plan+json; options=verbose|analyze|nonsense"),
+            "application/vnd.pgrst.plan+json; for=\"application/json\"; options=analyze|verbose"
+        );
+    }
 
     #[test]
     fn test_parse_resource() {

--- a/crates/postrust-core/src/api_request/mod.rs
+++ b/crates/postrust-core/src/api_request/mod.rs
@@ -14,6 +14,7 @@ pub use types::*;
 
 use crate::error::{Error, Result};
 use http::{Method, Request};
+use percent_encoding::percent_decode_str;
 use std::collections::{HashMap, HashSet};
 
 /// Parse an HTTP request into an ApiRequest.
@@ -107,6 +108,17 @@ fn parse_resource(path: &str) -> Result<Resource> {
         return Ok(Resource::Schema);
     }
 
+    // A name is the name the schema gave it, not the encoding a URL had to use
+    // to carry it: `/%D9%85%D9%88%D8%A7%D8%B1%D8%AF` addresses a table called
+    // `موارد`. Looking the encoded form up finds nothing, and says so using
+    // the escape sequence rather than the name.
+    let decoded = |segment: &str| -> String {
+        percent_decode_str(segment)
+            .decode_utf8()
+            .map(|name| name.into_owned())
+            .unwrap_or_else(|_| segment.to_string())
+    };
+
     if let Some(func_name) = path.strip_prefix("rpc/") {
         if func_name.is_empty() {
             return Err(Error::InvalidPath("Empty function name".into()));
@@ -114,7 +126,7 @@ fn parse_resource(path: &str) -> Result<Resource> {
         if func_name.contains('/') {
             return Err(Error::InvalidResourcePath);
         }
-        return Ok(Resource::Routine(func_name.to_string()));
+        return Ok(Resource::Routine(decoded(func_name)));
     }
 
     // A table is named by one segment. More than one names nothing at all --
@@ -125,7 +137,7 @@ fn parse_resource(path: &str) -> Result<Resource> {
         return Err(Error::InvalidResourcePath);
     }
 
-    Ok(Resource::Relation(path.to_string()))
+    Ok(Resource::Relation(decoded(path)))
 }
 
 /// Parse the schema from Accept-Profile or Content-Profile headers.
@@ -240,12 +252,22 @@ fn parse_accept(headers: &http::HeaderMap) -> Result<Vec<MediaType>> {
         let accept_str = accept
             .to_str()
             .map_err(|_| Error::InvalidHeader("Accept"))?;
-        // Simple parsing - full implementation would handle quality factors
+        // A quality factor orders the list and says nothing about the type,
+        // so it is dropped. The other parameters are not decoration: `;nulls=
+        // stripped` is part of what `application/vnd.pgrst.array+json` *is*,
+        // and cutting the entry at the semicolon threw it away along with the
+        // `q=`.
         let types: Vec<MediaType> = accept_str
             .split(',')
-            .map(|s| s.trim())
-            .map(|s| s.split(';').next().unwrap_or(s).trim())
-            .map(parse_media_type)
+            .map(str::trim)
+            .map(|entry| {
+                let kept: Vec<&str> = entry
+                    .split(';')
+                    .map(str::trim)
+                    .filter(|part| !part.starts_with("q="))
+                    .collect();
+                parse_media_type(&kept.join(";"))
+            })
             .collect();
         if types.is_empty() {
             return Ok(vec![MediaType::ApplicationJson]);
@@ -255,9 +277,17 @@ fn parse_accept(headers: &http::HeaderMap) -> Result<Vec<MediaType>> {
     Ok(vec![MediaType::ApplicationJson])
 }
 
-/// Parse a single media type string.
+/// Parse a single media type, parameters included.
+///
+/// Only the vendored types read their parameters; for everything else the
+/// name alone is the type, so `application/json;charset=utf-8` is still JSON.
 fn parse_media_type(s: &str) -> MediaType {
-    match s {
+    let mut parts = s.split(';').map(str::trim);
+    let base = parts.next().unwrap_or(s);
+    let parameters: Vec<&str> = parts.collect();
+    let given = |parameter: &str| parameters.contains(&parameter);
+
+    match base {
         "application/json" => MediaType::ApplicationJson,
         "application/geo+json" => MediaType::GeoJson,
         "text/csv" => MediaType::TextCsv,
@@ -268,11 +298,11 @@ fn parse_media_type(s: &str) -> MediaType {
         "application/octet-stream" => MediaType::OctetStream,
         "*/*" => MediaType::Any,
         s if s.starts_with("application/vnd.pgrst.object") => MediaType::SingularJson {
-            nullable: s.contains("nulls=null"),
-            strip_nulls: s.contains("nulls=stripped"),
+            nullable: given("nulls=null"),
+            strip_nulls: given("nulls=stripped"),
         },
         s if s.starts_with("application/vnd.pgrst.array") => MediaType::ArrayJson {
-            strip_nulls: s.contains("nulls=stripped"),
+            strip_nulls: given("nulls=stripped"),
         },
         other => MediaType::Other(other.to_string()),
     }
@@ -284,8 +314,7 @@ fn parse_content_type(headers: &http::HeaderMap) -> Result<MediaType> {
         let ct_str = ct
             .to_str()
             .map_err(|_| Error::InvalidHeader("Content-Type"))?;
-        let media_type = ct_str.split(';').next().unwrap_or(ct_str).trim();
-        return Ok(parse_media_type(media_type));
+        return Ok(parse_media_type(ct_str.trim()));
     }
     Ok(MediaType::ApplicationJson)
 }

--- a/crates/postrust-core/src/api_request/payload.rs
+++ b/crates/postrust-core/src/api_request/payload.rs
@@ -67,7 +67,10 @@ fn parse_csv_payload(body: Bytes) -> Result<Option<Payload>> {
         }
         let mut row = serde_json::Map::with_capacity(headers.len());
         for (name, (value, quoted)) in headers.iter().zip(record) {
-            let value = match value.is_empty() && !quoted {
+            // CSV has no null of its own, so the two spellings it is given are
+            // an unquoted empty field and the unquoted word NULL. Quoting
+            // either makes it the text it looks like.
+            let value = match !quoted && (value.is_empty() || value == "NULL") {
                 true => serde_json::Value::Null,
                 false => serde_json::Value::String(value),
             };

--- a/crates/postrust-core/src/api_request/payload.rs
+++ b/crates/postrust-core/src/api_request/payload.rs
@@ -16,10 +16,7 @@ pub fn parse_payload(body: Bytes, content_type: &MediaType) -> Result<Option<Pay
     match content_type {
         MediaType::ApplicationJson => parse_json_payload(body),
         MediaType::UrlEncoded => parse_urlencoded_payload(body),
-        MediaType::TextCsv => {
-            // CSV is handled as raw JSON for processing
-            Ok(Some(Payload::RawJson(body)))
-        }
+        MediaType::TextCsv => parse_csv_payload(body),
         MediaType::OctetStream | MediaType::TextPlain | MediaType::TextXml => {
             Ok(Some(Payload::RawPayload(body)))
         }
@@ -30,12 +27,149 @@ pub fn parse_payload(body: Bytes, content_type: &MediaType) -> Result<Option<Pay
 /// Parse JSON body and extract keys.
 fn parse_json_payload(body: Bytes) -> Result<Option<Payload>> {
     // Parse to extract keys
-    let value: serde_json::Value =
-        serde_json::from_slice(&body).map_err(|e| Error::InvalidBody(e.to_string()))?;
+    // What went wrong with the JSON is not the client's to act on -- the
+    // parser's offset says nothing it can use -- so this is the one message,
+    // and it is the one PostgREST gives.
+    let value: serde_json::Value = serde_json::from_slice(&body)
+        .map_err(|_| Error::InvalidBody("Empty or invalid json".into()))?;
 
     let keys = extract_json_keys(&value);
 
     Ok(Some(Payload::ProcessedJson { raw: body, keys }))
+}
+
+/// Parse a CSV body into the same shape a JSON array body would have taken.
+///
+/// The header row names the columns. Everything after it is a row of text,
+/// except an unquoted empty field, which is null -- that is the only way CSV
+/// can express one, and it is what PostgREST reads it as.
+fn parse_csv_payload(body: Bytes) -> Result<Option<Payload>> {
+    let text = std::str::from_utf8(&body)
+        .map_err(|_| Error::InvalidBody("Empty or invalid json".into()))?;
+
+    let mut records = read_csv(text);
+    if records.is_empty() {
+        return Ok(None);
+    }
+
+    let headers: Vec<String> = records
+        .remove(0)
+        .into_iter()
+        .map(|(value, _)| value)
+        .collect();
+
+    let mut rows = Vec::with_capacity(records.len());
+    for record in records {
+        if record.len() != headers.len() {
+            return Err(Error::InvalidBody(
+                "All lines must have same number of fields".into(),
+            ));
+        }
+        let mut row = serde_json::Map::with_capacity(headers.len());
+        for (name, (value, quoted)) in headers.iter().zip(record) {
+            let value = match value.is_empty() && !quoted {
+                true => serde_json::Value::Null,
+                false => serde_json::Value::String(value),
+            };
+            row.insert(name.clone(), value);
+        }
+        rows.push(serde_json::Value::Object(row));
+    }
+
+    let raw = serde_json::to_vec(&serde_json::Value::Array(rows))
+        .map_err(|e| Error::Internal(e.to_string()))?;
+
+    Ok(Some(Payload::ProcessedJson {
+        raw: Bytes::from(raw),
+        keys: headers.into_iter().collect(),
+    }))
+}
+
+/// Split CSV text into records of `(field, was quoted)`.
+///
+/// A quoted field may contain commas and newlines, and `""` inside one is a
+/// literal quote. Whether a field was quoted is carried out because it is the
+/// only thing separating an empty string from a null.
+fn read_csv(text: &str) -> Vec<Vec<(String, bool)>> {
+    let mut records = Vec::new();
+    let mut record = Vec::new();
+    let mut field = String::new();
+    let mut quoted = false;
+    let mut in_quotes = false;
+    let mut chars = text.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if in_quotes {
+            match ch {
+                '"' if chars.peek() == Some(&'"') => {
+                    chars.next();
+                    field.push('"');
+                }
+                '"' => in_quotes = false,
+                other => field.push(other),
+            }
+            continue;
+        }
+        match ch {
+            '"' => {
+                in_quotes = true;
+                quoted = true;
+            }
+            ',' => record.push((std::mem::take(&mut field), std::mem::take(&mut quoted))),
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                record.push((std::mem::take(&mut field), std::mem::take(&mut quoted)));
+                records.push(std::mem::take(&mut record));
+            }
+            '\n' => {
+                record.push((std::mem::take(&mut field), std::mem::take(&mut quoted)));
+                records.push(std::mem::take(&mut record));
+            }
+            other => field.push(other),
+        }
+    }
+
+    if !field.is_empty() || quoted || !record.is_empty() {
+        record.push((field, quoted));
+        records.push(record);
+    }
+
+    records
+}
+
+/// Check that every row of a bulk insert names the same columns.
+///
+/// The insert is one statement with one column list, so a row naming fewer
+/// columns would silently take defaults for the rest. `?columns=` is how a
+/// client says which columns to write when the rows genuinely differ, and this
+/// check is skipped when it does.
+pub fn validate_uniform_keys(payload: &Payload) -> Result<()> {
+    let Payload::ProcessedJson { raw, .. } = payload else {
+        return Ok(());
+    };
+    let Ok(serde_json::Value::Array(rows)) = serde_json::from_slice::<serde_json::Value>(raw)
+    else {
+        return Ok(());
+    };
+
+    let mut expected: Option<HashSet<&String>> = None;
+    for row in &rows {
+        let Some(object) = row.as_object() else {
+            return Err(Error::InvalidBody("All object keys must match".into()));
+        };
+        let keys: HashSet<&String> = object.keys().collect();
+        match &expected {
+            None => expected = Some(keys),
+            Some(first) if *first != keys => {
+                return Err(Error::InvalidBody("All object keys must match".into()))
+            }
+            Some(_) => {}
+        }
+    }
+
+    Ok(())
 }
 
 /// Extract top-level keys from JSON value.
@@ -77,7 +211,10 @@ pub fn validate_payload_columns(payload: &Payload, expected: &HashSet<String>) -
 
     for key in keys {
         if !expected.contains(key) {
-            return Err(Error::UnknownColumn(key.clone()));
+            return Err(Error::UnknownColumn {
+                column: key.clone(),
+                relation: String::new(),
+            });
         }
     }
 

--- a/crates/postrust-core/src/api_request/preferences.rs
+++ b/crates/postrust-core/src/api_request/preferences.rs
@@ -168,7 +168,13 @@ pub fn preference_applied(prefs: &Preferences, relevance: PreferenceScope) -> Op
         values.extend(asked("return="));
     }
     values.extend(asked("count="));
-    values.extend(asked("tx="));
+    // `tx=` is deliberately absent. Ending the transaction the client's way
+    // is something PostgREST does only where `db-tx-end` is configured to let
+    // the request decide; by default the preference is not honoured, and so
+    // is not reported. There is no such setting here and nothing reads
+    // `Preferences::transaction`, which makes the answer the same one for a
+    // stronger reason: a rollback that was asked for and never happened must
+    // not come back described as applied.
     values.extend(asked("handling="));
     values.extend(asked("timezone="));
     // `max-affected` only has an effect under strict handling, so leniently
@@ -285,6 +291,33 @@ mod tests {
         assert_eq!(
             preference_applied(&prefs, PreferenceScope::read()).as_deref(),
             Some("count=exact")
+        );
+    }
+
+    /// A preference nothing here acts on is not reported as applied, however
+    /// plainly it was asked for. `tx=rollback` is parsed and then ignored --
+    /// the transaction commits either way -- so a client told the preference
+    /// was applied would believe its write had been undone.
+    #[test]
+    fn preference_applied_leaves_out_a_transaction_end_nothing_honours() {
+        let headers = headers_with_prefer("tx=rollback");
+        let prefs = parse_preferences(&headers).unwrap();
+
+        assert_eq!(
+            preference_applied(&prefs, PreferenceScope::read()),
+            None,
+            "tx= must not be reported while the transaction always commits"
+        );
+
+        let headers = headers_with_prefer("return=representation, tx=commit");
+        let prefs = parse_preferences(&headers).unwrap();
+        let writing = PreferenceScope {
+            representation: true,
+            ..PreferenceScope::read()
+        };
+        assert_eq!(
+            preference_applied(&prefs, writing).as_deref(),
+            Some("return=representation")
         );
     }
 

--- a/crates/postrust-core/src/api_request/preferences.rs
+++ b/crates/postrust-core/src/api_request/preferences.rs
@@ -10,13 +10,20 @@ use http::HeaderMap;
 pub fn parse_preferences(headers: &HeaderMap) -> Result<Preferences> {
     let mut prefs = Preferences::default();
 
-    let prefer = match headers.get("prefer") {
-        Some(v) => v.to_str().map_err(|_| Error::InvalidHeader("Prefer"))?,
-        None => return Ok(prefs),
-    };
+    // A client may send one `Prefer` header with a comma-separated list, or
+    // several headers, or both -- RFC 7240 allows all three and PostgREST's
+    // own suite uses more than one. Reading only the first drops the rest.
+    let mut seen_any = false;
+    for value in headers.get_all("prefer") {
+        let value = value.to_str().map_err(|_| Error::InvalidHeader("Prefer"))?;
+        seen_any = true;
+        for pref in value.split(',').map(|s| s.trim()) {
+            parse_preference(&mut prefs, pref);
+        }
+    }
 
-    for pref in prefer.split(',').map(|s| s.trim()) {
-        parse_preference(&mut prefs, pref);
+    if !seen_any {
+        return Ok(prefs);
     }
 
     // `handling=strict` asks to be told about preferences the server does not

--- a/crates/postrust-core/src/api_request/preferences.rs
+++ b/crates/postrust-core/src/api_request/preferences.rs
@@ -43,6 +43,9 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "ignore-duplicates" => Some(PreferResolution::IgnoreDuplicates),
                     _ => None,
                 };
+                if prefs.resolution.is_some() {
+                    prefs.applied.push(format!("resolution={}", value));
+                }
             }
             "return" => {
                 prefs.representation = match value {
@@ -51,6 +54,7 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "minimal" => PreferRepresentation::None,
                     _ => PreferRepresentation::None,
                 };
+                prefs.applied.push(format!("return={}", value));
             }
             "count" => {
                 prefs.count = match value {
@@ -59,6 +63,9 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "estimated" => Some(PreferCount::Estimated),
                     _ => None,
                 };
+                if prefs.count.is_some() {
+                    prefs.applied.push(format!("count={}", value));
+                }
             }
             "tx" => {
                 prefs.transaction = match value {
@@ -66,6 +73,7 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "rollback" => PreferTransaction::Rollback,
                     _ => PreferTransaction::Commit,
                 };
+                prefs.applied.push(format!("tx={}", value));
             }
             "missing" => {
                 prefs.missing = match value {
@@ -73,6 +81,7 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "null" => PreferMissing::ApplyNulls,
                     _ => PreferMissing::ApplyDefaults,
                 };
+                prefs.applied.push(format!("missing={}", value));
             }
             "handling" => {
                 prefs.handling = match value {
@@ -80,15 +89,18 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
                     "lenient" => PreferHandling::Lenient,
                     _ => PreferHandling::Strict,
                 };
+                prefs.applied.push(format!("handling={}", value));
             }
             "timezone" => {
                 prefs.timezone = Some(value.to_string());
+                prefs.applied.push(format!("timezone={}", value));
             }
             // Understood, and applied where the RPC path reads the body.
             "params" => {}
             "max-affected" => {
                 if let Ok(n) = value.parse::<i64>() {
                     prefs.max_affected = Some(n);
+                    prefs.applied.push(format!("max-affected={}", n));
                 }
             }
             _ => {
@@ -120,58 +132,15 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
     }
 }
 
-/// Build Preference-Applied header from applied preferences.
+/// Build the `Preference-Applied` header.
+///
+/// Every preference the server understood, in the order it was sent. A client
+/// reads it to find out which of what it asked for was honoured, so a
+/// preference the server merely defaulted to has no business appearing.
 pub fn preference_applied(prefs: &Preferences) -> Option<String> {
-    let mut applied = Vec::new();
-
-    if prefs.resolution.is_some() {
-        let val = match prefs.resolution {
-            Some(PreferResolution::MergeDuplicates) => "resolution=merge-duplicates",
-            Some(PreferResolution::IgnoreDuplicates) => "resolution=ignore-duplicates",
-            None => "",
-        };
-        if !val.is_empty() {
-            applied.push(val);
-        }
-    }
-
-    match prefs.representation {
-        PreferRepresentation::Full => applied.push("return=representation"),
-        PreferRepresentation::HeadersOnly => applied.push("return=headers-only"),
-        PreferRepresentation::None => {}
-    }
-
-    if let Some(count) = &prefs.count {
-        let val = match count {
-            PreferCount::Exact => "count=exact",
-            PreferCount::Planned => "count=planned",
-            PreferCount::Estimated => "count=estimated",
-        };
-        applied.push(val);
-    }
-
-    match prefs.transaction {
-        PreferTransaction::Rollback => applied.push("tx=rollback"),
-        PreferTransaction::Commit => {}
-    }
-
-    // Strict handling and a timezone are both applied rather than merely
-    // understood, so both are reported back. The timezone is owned rather than
-    // borrowed, which is why the list is built as strings from here on.
-    let mut applied: Vec<String> = applied.into_iter().map(String::from).collect();
-
-    if prefs.handling == PreferHandling::Strict {
-        applied.insert(0, "handling=strict".to_string());
-    }
-
-    if let Some(timezone) = &prefs.timezone {
-        applied.push(format!("timezone={}", timezone));
-    }
-
-    if applied.is_empty() {
-        None
-    } else {
-        Some(applied.join(", "))
+    match prefs.applied.is_empty() {
+        true => None,
+        false => Some(prefs.applied.join(", ")),
     }
 }
 
@@ -232,14 +201,24 @@ mod tests {
 
     #[test]
     fn test_preference_applied() {
-        let prefs = Preferences {
-            representation: PreferRepresentation::Full,
-            count: Some(PreferCount::Exact),
-            ..Default::default()
-        };
+        let headers = headers_with_prefer("return=representation, count=exact");
+        let prefs = parse_preferences(&headers).unwrap();
 
         let applied = preference_applied(&prefs).unwrap();
         assert!(applied.contains("return=representation"));
         assert!(applied.contains("count=exact"));
+    }
+
+    /// A preference the server merely defaulted to is not one it applied.
+    #[test]
+    fn preference_applied_reports_only_what_was_asked_for() {
+        let headers = headers_with_prefer("handling=lenient");
+        let prefs = parse_preferences(&headers).unwrap();
+
+        assert_eq!(
+            preference_applied(&prefs).as_deref(),
+            Some("handling=lenient")
+        );
+        assert_eq!(preference_applied(&Preferences::default()), None);
     }
 }

--- a/crates/postrust-core/src/api_request/preferences.rs
+++ b/crates/postrust-core/src/api_request/preferences.rs
@@ -134,13 +134,69 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
 
 /// Build the `Preference-Applied` header.
 ///
-/// Every preference the server understood, in the order it was sent. A client
-/// reads it to find out which of what it asked for was honoured, so a
-/// preference the server merely defaulted to has no business appearing.
-pub fn preference_applied(prefs: &Preferences) -> Option<String> {
-    match prefs.applied.is_empty() {
+/// Only preferences that were asked for, and only those the request could
+/// honour: `return=representation` says nothing on a read, and `missing`
+/// nothing on a delete. PostgREST filters the same way and in this order,
+/// and a client comparing the header against what it sent will notice.
+///
+/// `applied` records what was asked for, since a parsed field cannot say
+/// whether its value was requested or is merely its default.
+pub fn preference_applied(prefs: &Preferences, relevance: PreferenceScope) -> Option<String> {
+    let asked = |name: &str| {
+        prefs
+            .applied
+            .iter()
+            .find(|pref| pref.starts_with(name))
+            .cloned()
+    };
+
+    let mut values = Vec::new();
+    if relevance.resolution {
+        values.extend(asked("resolution="));
+    }
+    if relevance.missing {
+        values.extend(asked("missing="));
+    }
+    if relevance.representation {
+        values.extend(asked("return="));
+    }
+    values.extend(asked("count="));
+    values.extend(asked("tx="));
+    values.extend(asked("handling="));
+    values.extend(asked("timezone="));
+    // `max-affected` only has an effect under strict handling, so leniently
+    // it was not applied.
+    if relevance.max_affected && prefs.handling == PreferHandling::Strict {
+        values.extend(asked("max-affected="));
+    }
+
+    match values.is_empty() {
         true => None,
-        false => Some(prefs.applied.join(", ")),
+        false => Some(values.join(", ")),
+    }
+}
+
+/// Which preferences a given request could honour.
+///
+/// A preference that cannot apply to the request is not reported back, however
+/// plainly it was asked for -- saying it was applied when it was ignored is
+/// worse than saying nothing.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PreferenceScope {
+    /// Insert, where duplicates can be resolved.
+    pub resolution: bool,
+    /// Insert or update, where a missing column can take a default.
+    pub representation: bool,
+    /// Insert or update.
+    pub missing: bool,
+    /// Update, delete or a function call.
+    pub max_affected: bool,
+}
+
+impl PreferenceScope {
+    /// What a read can honour: none of the write-only preferences.
+    pub fn read() -> Self {
+        Self::default()
     }
 }
 
@@ -203,10 +259,26 @@ mod tests {
     fn test_preference_applied() {
         let headers = headers_with_prefer("return=representation, count=exact");
         let prefs = parse_preferences(&headers).unwrap();
+        let writing = PreferenceScope {
+            representation: true,
+            ..PreferenceScope::read()
+        };
 
-        let applied = preference_applied(&prefs).unwrap();
+        let applied = preference_applied(&prefs, writing).unwrap();
         assert!(applied.contains("return=representation"));
         assert!(applied.contains("count=exact"));
+    }
+
+    /// A preference the request could not act on is not reported as applied.
+    #[test]
+    fn preference_applied_leaves_out_what_a_read_cannot_honour() {
+        let headers = headers_with_prefer("return=representation, count=exact");
+        let prefs = parse_preferences(&headers).unwrap();
+
+        assert_eq!(
+            preference_applied(&prefs, PreferenceScope::read()).as_deref(),
+            Some("count=exact")
+        );
     }
 
     /// A preference the server merely defaulted to is not one it applied.
@@ -216,9 +288,12 @@ mod tests {
         let prefs = parse_preferences(&headers).unwrap();
 
         assert_eq!(
-            preference_applied(&prefs).as_deref(),
+            preference_applied(&prefs, PreferenceScope::read()).as_deref(),
             Some("handling=lenient")
         );
-        assert_eq!(preference_applied(&Preferences::default()), None);
+        assert_eq!(
+            preference_applied(&Preferences::default(), PreferenceScope::read()),
+            None
+        );
     }
 }

--- a/crates/postrust-core/src/api_request/preferences.rs
+++ b/crates/postrust-core/src/api_request/preferences.rs
@@ -19,6 +19,12 @@ pub fn parse_preferences(headers: &HeaderMap) -> Result<Preferences> {
         parse_preference(&mut prefs, pref);
     }
 
+    // `handling=strict` asks to be told about preferences the server does not
+    // implement rather than have them quietly dropped.
+    if prefs.handling == PreferHandling::Strict && !prefs.invalid.is_empty() {
+        return Err(Error::InvalidPreferences(prefs.invalid));
+    }
+
     Ok(prefs)
 }
 
@@ -78,6 +84,8 @@ fn parse_preference(prefs: &mut Preferences, pref: &str) {
             "timezone" => {
                 prefs.timezone = Some(value.to_string());
             }
+            // Understood, and applied where the RPC path reads the body.
+            "params" => {}
             "max-affected" => {
                 if let Ok(n) = value.parse::<i64>() {
                     prefs.max_affected = Some(n);
@@ -145,6 +153,19 @@ pub fn preference_applied(prefs: &Preferences) -> Option<String> {
     match prefs.transaction {
         PreferTransaction::Rollback => applied.push("tx=rollback"),
         PreferTransaction::Commit => {}
+    }
+
+    // Strict handling and a timezone are both applied rather than merely
+    // understood, so both are reported back. The timezone is owned rather than
+    // borrowed, which is why the list is built as strings from here on.
+    let mut applied: Vec<String> = applied.into_iter().map(String::from).collect();
+
+    if prefs.handling == PreferHandling::Strict {
+        applied.insert(0, "handling=strict".to_string());
+    }
+
+    if let Some(timezone) = &prefs.timezone {
+        applied.push(format!("timezone={}", timezone));
     }
 
     if applied.is_empty() {

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -680,6 +680,36 @@ fn parse_operation(value: &str) -> Result<Operation> {
     Err(Error::InvalidQueryParam(value.into()))
 }
 
+/// The four modifiers an order term accepts, and where reading one stopped.
+///
+/// Reading gets as far as the word still could be one of them and reports the
+/// character that ruled the last one out, so `nullslasttt` fails on the tenth
+/// character rather than on the word.
+fn unreadable_order(term: &str, at: usize, part: &str) -> Error {
+    const MODIFIERS: [&str; 4] = ["asc", "desc", "nullsfirst", "nullslast"];
+
+    let read = MODIFIERS
+        .iter()
+        .map(|modifier| {
+            part.chars()
+                .zip(modifier.chars())
+                .take_while(|(a, b)| a == b)
+                .count()
+        })
+        .max()
+        .unwrap_or(0);
+
+    Error::UnparsableQuery {
+        kind: "order",
+        text: term.to_string(),
+        column: at + read + 1,
+        expected: format!(
+            "unexpected {:?} expecting \",\" or end of input",
+            part.chars().nth(read).unwrap_or_default()
+        ),
+    }
+}
+
 /// The five things `is.` accepts, and where reading one stopped.
 ///
 /// Reading gets as far as the operand still could be one of them and reports
@@ -846,14 +876,22 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
     let mut direction = None;
     let mut nulls = None;
 
+    // Where each modifier starts within the term, so a word that is not one
+    // can be reported at the character that made it not one.
+    let mut at = field_name.len() + 1;
     for part in &parts[1..] {
         match *part {
             "asc" => direction = Some(OrderDirection::Asc),
             "desc" => direction = Some(OrderDirection::Desc),
             "nullsfirst" => nulls = Some(OrderNulls::First),
             "nullslast" => nulls = Some(OrderNulls::Last),
-            _ => {}
+            // Not one of the four. Ignoring it answered a request nobody made:
+            // `order=id.asc.nullslasttt` was read as `id.asc` and the typo
+            // silently changed nothing, so a client asking for nulls last got
+            // whatever the table happened to give it.
+            other => return Err(unreadable_order(value, at, other)),
         }
+        at += part.len() + 1;
     }
 
     // `clients(name)` orders by a column of an embedded resource rather than

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -88,7 +88,9 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
                     let offset: i64 = decoded_value
                         .parse()
                         .map_err(|_| Error::InvalidQueryParam("offset".into()))?;
-                    params.ranges.entry(path.join(".")).or_default().offset = offset;
+                    let range = params.ranges.entry(path.join(".")).or_default();
+                    range.offset = offset;
+                    range.offset_explicit = true;
                 }
                 Modifier::Logic(op, negated) => {
                     params
@@ -1689,5 +1691,4 @@ mod tests {
             "\"failed to parse logic tree ((,))\" (line 1, column 4)"
         );
     }
-
 }

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -8,8 +8,8 @@ use crate::error::{Error, Result};
 use nom::{
     branch::alt,
     bytes::complete::{tag, take_while1},
-    character::complete::{char, digit1},
-    combinator::{map, opt, value},
+    character::complete::char,
+    combinator::{opt, value},
     multi::{many0, separated_list0},
     sequence::preceded,
     IResult,
@@ -833,24 +833,57 @@ fn parse_identifier(input: &str) -> IResult<&str, &str> {
 }
 
 fn parse_json_path(input: &str) -> IResult<&str, JsonPath> {
-    many0(alt((parse_arrow, parse_double_arrow)))(input)
+    // `->>` first: it starts with `->`, so trying the shorter one first would
+    // match it and leave the second `>` at the head of the key.
+    many0(alt((parse_double_arrow, parse_arrow)))(input)
+}
+
+/// Parse one step of a JSON path.
+///
+/// A JSON object key can be very nearly anything, and PostgREST's grammar says
+/// so: everything up to the next thing the select grammar itself reserves is
+/// the key. `data->>!@#$%^&*_e` and `data->23-xy-45` are ordinary keys, not
+/// syntax errors, and reading a key as alphanumeric-only silently truncated
+/// the path and returned the whole column instead.
+///
+/// A key made entirely of digits is an array index, which is why this decides
+/// between the two only once the whole key has been read: `data->0xy1` steps
+/// into the key `0xy1`, not into element 0 of an array.
+fn parse_json_operand(input: &str) -> IResult<&str, JsonOperand> {
+    let mut end = input.len();
+    for (idx, ch) in input.char_indices() {
+        // `,` ends the select item, `(` and `)` bound an embedding, `:` starts
+        // a cast or an alias, and `->` starts the next step.
+        if matches!(ch, ',' | '(' | ')' | ':') || input[idx..].starts_with("->") {
+            end = idx;
+            break;
+        }
+    }
+
+    let (key, rest) = input.split_at(end);
+    if key.is_empty() {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::TakeWhile1,
+        )));
+    }
+
+    let operand = match key.parse::<i32>() {
+        Ok(index) => JsonOperand::Idx(index),
+        Err(_) => JsonOperand::Key(key.to_string()),
+    };
+    Ok((rest, operand))
 }
 
 fn parse_arrow(input: &str) -> IResult<&str, JsonOperation> {
     let (input, _) = tag("->")(input)?;
-    let (input, operand) = alt((
-        map(digit1, |s: &str| JsonOperand::Idx(s.parse().unwrap_or(0))),
-        map(parse_identifier, |s| JsonOperand::Key(s.to_string())),
-    ))(input)?;
+    let (input, operand) = parse_json_operand(input)?;
     Ok((input, JsonOperation::Arrow(operand)))
 }
 
 fn parse_double_arrow(input: &str) -> IResult<&str, JsonOperation> {
     let (input, _) = tag("->>")(input)?;
-    let (input, operand) = alt((
-        map(digit1, |s: &str| JsonOperand::Idx(s.parse().unwrap_or(0))),
-        map(parse_identifier, |s| JsonOperand::Key(s.to_string())),
-    ))(input)?;
+    let (input, operand) = parse_json_operand(input)?;
     Ok((input, JsonOperation::DoubleArrow(operand)))
 }
 
@@ -879,6 +912,74 @@ mod tests {
                 assert_eq!(values, &vec!["1", "2", "3"]);
             }
             _ => panic!("Expected In operation"),
+        }
+    }
+
+    #[test]
+    fn test_json_path_double_arrow_wins_over_single() {
+        let items = parse_select("settings->foo->>bar").unwrap();
+        match &items[0] {
+            SelectItem::Field { field, .. } => {
+                assert_eq!(
+                    field.json_path,
+                    vec![
+                        JsonOperation::Arrow(JsonOperand::Key("foo".into())),
+                        JsonOperation::DoubleArrow(JsonOperand::Key("bar".into())),
+                    ]
+                );
+            }
+            other => panic!("expected a field, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_json_path_accepts_awkward_keys() {
+        // PostgREST reserves only what its own grammar needs, so a key may
+        // hold punctuation and hyphens.
+        let items = parse_select("data->23-xy-45->>!@#$%^&*_e").unwrap();
+        match &items[0] {
+            SelectItem::Field { field, .. } => {
+                assert_eq!(
+                    field.json_path,
+                    vec![
+                        JsonOperation::Arrow(JsonOperand::Key("23-xy-45".into())),
+                        JsonOperation::DoubleArrow(JsonOperand::Key("!@#$%^&*_e".into())),
+                    ]
+                );
+            }
+            other => panic!("expected a field, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_json_path_digits_are_an_index_but_only_when_whole() {
+        let items = parse_select("data->0,other->0xy1").unwrap();
+        let paths: Vec<_> = items
+            .iter()
+            .map(|i| match i {
+                SelectItem::Field { field, .. } => field.json_path.clone(),
+                other => panic!("expected a field, got {:?}", other),
+            })
+            .collect();
+        assert_eq!(paths[0], vec![JsonOperation::Arrow(JsonOperand::Idx(0))]);
+        assert_eq!(
+            paths[1],
+            vec![JsonOperation::Arrow(JsonOperand::Key("0xy1".into()))]
+        );
+    }
+
+    #[test]
+    fn test_json_path_stops_at_a_cast() {
+        let items = parse_select("settings->>foo::json").unwrap();
+        match &items[0] {
+            SelectItem::Field { field, cast, .. } => {
+                assert_eq!(
+                    field.json_path,
+                    vec![JsonOperation::DoubleArrow(JsonOperand::Key("foo".into()))]
+                );
+                assert_eq!(cast.as_deref(), Some("json"));
+            }
+            other => panic!("expected a field, got {:?}", other),
         }
     }
 

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -153,9 +153,12 @@ pub fn parse_select(input: &str) -> Result<Vec<SelectItem>> {
         return Ok(vec![]);
     }
 
+    // Anything left over is a parse failure, not something to ignore. Left
+    // ignored, one unparsable item silently discarded every item after it --
+    // `select=id, name, billing(address)` returned the id alone.
     match parse_select_items(input) {
-        Ok((_, items)) => Ok(items),
-        Err(_) => Err(Error::InvalidQueryParam("select".into())),
+        Ok(("", items)) => Ok(items),
+        _ => Err(Error::InvalidQueryParam(format!("select={}", input))),
     }
 }
 
@@ -164,6 +167,9 @@ fn parse_select_items(input: &str) -> IResult<&str, Vec<SelectItem>> {
 }
 
 fn parse_select_item(input: &str) -> IResult<&str, SelectItem> {
+    // A space after a comma is ordinary in a hand-written URL, and PostgREST
+    // accepts it.
+    let (input, _) = nom::character::complete::space0(input)?;
     alt((
         parse_star,
         // Before relations: `count()` is spelled exactly like an embed of a

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -691,6 +691,19 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
         }
     }
 
+    // `clients(name)` orders by a column of an embedded resource rather than
+    // by one of this table's own.
+    if let Some((relation, rest)) = field_name.split_once('(') {
+        if let Some(column) = rest.strip_suffix(')') {
+            return Ok(OrderTerm::Relation {
+                relation: relation.to_string(),
+                field: split_json_path(column),
+                direction,
+                nulls,
+            });
+        }
+    }
+
     Ok(OrderTerm::Field {
         field,
         direction,

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -496,13 +496,29 @@ pub fn value_is_filter(value: &str) -> bool {
 
 /// Parse filter value: `operator.value` or `not.operator.value`
 fn parse_filter_value(value: &str) -> Result<OpExpr> {
+    let whole = value;
     let (value, negated) = if let Some(rest) = value.strip_prefix("not.") {
         (rest, true)
     } else {
         (value, false)
     };
 
-    let operation = parse_operation(value)?;
+    let operation = parse_operation(value).map_err(|error| match error {
+        // Nothing in the value named an operator, so reading stopped at its
+        // first character -- and what a filter may begin with is a short,
+        // published list. Any other failure got further in and has more to say
+        // about where.
+        Error::InvalidQueryParam(_) => Error::UnparsableQuery {
+            kind: "filter",
+            text: whole.to_string(),
+            column: 1,
+            expected: format!(
+                "unexpected \"{}\" expecting \"not\" or operator (eq, gt, ...)",
+                whole.chars().next().unwrap_or_default()
+            ),
+        },
+        other => other,
+    })?;
     Ok(OpExpr { negated, operation })
 }
 
@@ -637,7 +653,7 @@ fn parse_operation(value: &str) -> Result<Operation> {
             "true" => IsValue::True,
             "false" => IsValue::False,
             "unknown" => IsValue::Unknown,
-            _ => return Err(Error::InvalidQueryParam(format!("is.{}", rest))),
+            _ => return Err(unreadable_is_value(rest)),
         };
         return Ok(Operation::Is(is_val));
     }
@@ -662,6 +678,42 @@ fn parse_operation(value: &str) -> Result<Operation> {
     }
 
     Err(Error::InvalidQueryParam(value.into()))
+}
+
+/// The five things `is.` accepts, and where reading one stopped.
+///
+/// Reading gets as far as the operand still could be one of them and reports
+/// the character that ruled the last one out -- `is.nil` fails on the `i`,
+/// having read `n` as the start of `null`, while `is.ok` fails on the `o`.
+/// That is where a client has to look, and it is the difference between a
+/// message about a typo and one about the whole request.
+fn unreadable_is_value(rest: &str) -> Error {
+    const VALUES: [&str; 5] = ["null", "not_null", "true", "false", "unknown"];
+
+    let lowered = rest.to_ascii_lowercase();
+    let read = VALUES
+        .iter()
+        .map(|value| {
+            lowered
+                .chars()
+                .zip(value.chars())
+                .take_while(|(a, b)| a == b)
+                .count()
+        })
+        .max()
+        .unwrap_or(0);
+
+    Error::UnparsableQuery {
+        kind: "filter",
+        text: format!("is.{}", rest),
+        // Counting from one, past the `is.` that was read before this.
+        column: 4 + read,
+        expected: format!(
+            "unexpected \"{}\" expecting isVal: ({})",
+            rest.chars().nth(read).unwrap_or_default(),
+            VALUES.join(", ")
+        ),
+    }
 }
 
 /// Parse IN list: `(a,b,c)` -> vec!["a", "b", "c"]

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -165,6 +165,7 @@ fn parse_select_items(input: &str) -> IResult<&str, Vec<SelectItem>> {
 
 fn parse_select_item(input: &str) -> IResult<&str, SelectItem> {
     alt((
+        parse_star,
         // Before relations: `count()` is spelled exactly like an embed of a
         // relation named `count` with an empty selection.
         parse_bare_aggregate,
@@ -172,6 +173,16 @@ fn parse_select_item(input: &str) -> IResult<&str, SelectItem> {
         parse_relation_select,
         parse_field_select,
     ))(input)
+}
+
+/// Parse `*`, which names every column.
+///
+/// It is a select item like any other, so it composes: `*,clients(id)` asks
+/// for every column of this table and an embed besides, and `clients(*)` asks
+/// for every column of the embedded one.
+fn parse_star(input: &str) -> IResult<&str, SelectItem> {
+    let (input, _) = char('*')(input)?;
+    Ok((input, SelectItem::field("*")))
 }
 
 /// Parse a field-less aggregate: `count()`, `cnt:count()`, `count()::text`.

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -17,7 +17,15 @@ use nom::{
 use percent_encoding::percent_decode_str;
 
 /// Parse a query string into QueryParams.
-pub fn parse_query_params(query: &str) -> Result<QueryParams> {
+///
+/// `is_rpc` changes what an unrecognized key means. On a table, `a=2` is a
+/// malformed filter and an error, because a filter value must carry an
+/// operator. On a function, it is an argument -- so every such key is also
+/// recorded as a candidate argument, and one that fails to parse as a filter
+/// is no longer fatal. Which candidates are really arguments is settled at
+/// plan time, against the parameters the routine actually declares; a
+/// well-formed filter such as `id=eq.1` stays available to filter the result.
+pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
     let mut params = QueryParams::default();
 
     if query.is_empty() {
@@ -44,6 +52,15 @@ pub fn parse_query_params(query: &str) -> Result<QueryParams> {
             .decode_utf8()
             .map_err(|_| Error::InvalidQueryParam(key.into()))?
             .to_string();
+
+        // The key is decoded as well as the value. A filter on a JSON path
+        // arrives as `data-%3E%3Eb` from any client that escapes `>`, and
+        // would otherwise be looked up as a column of that literal name.
+        let decoded_key = percent_decode_str(key)
+            .decode_utf8()
+            .map_err(|_| Error::InvalidQueryParam(key.into()))?
+            .to_string();
+        let key: &str = &decoded_key;
 
         match key {
             "select" => {
@@ -86,8 +103,20 @@ pub fn parse_query_params(query: &str) -> Result<QueryParams> {
                 params.logic.push((vec![], logic));
             }
             key if !key.starts_with('_') => {
+                if is_rpc {
+                    params.params.push((key.to_string(), decoded_value.clone()));
+                }
+
                 // Filter parameter
-                let (path, filter) = parse_filter_param(key, &decoded_value)?;
+                let parsed = parse_filter_param(key, &decoded_value);
+                let (path, filter) = match parsed {
+                    Ok(parsed) => parsed,
+                    // On a function, a key that isn't a filter is just an
+                    // argument, which was recorded above.
+                    Err(_) if is_rpc => continue,
+                    Err(e) => return Err(e),
+                };
+
                 if path.is_empty() {
                     params.filter_fields.insert(filter.field.name.clone());
                     params.filters_root.push(filter);
@@ -127,24 +156,63 @@ fn parse_select_items(input: &str) -> IResult<&str, Vec<SelectItem>> {
 
 fn parse_select_item(input: &str) -> IResult<&str, SelectItem> {
     alt((
+        // Before relations: `count()` is spelled exactly like an embed of a
+        // relation named `count` with an empty selection.
+        parse_bare_aggregate,
         parse_spread_relation,
         parse_relation_select,
         parse_field_select,
     ))(input)
 }
 
+/// Parse a field-less aggregate: `count()`, `cnt:count()`, `count()::text`.
+///
+/// Only `count` is meaningful without a field -- the others have nothing to
+/// sum -- which is also what keeps this from swallowing embeds.
+fn parse_bare_aggregate(input: &str) -> IResult<&str, SelectItem> {
+    let (input, alias) = opt(parse_alias_prefix)(input)?;
+    let (input, _) = tag("count()")(input)?;
+    let (input, cast) = opt(preceded(tag("::"), parse_identifier))(input)?;
+
+    Ok((
+        input,
+        SelectItem::Field {
+            // An empty name marks the `COUNT(*)` form: there is no column to
+            // resolve, and nothing to group by.
+            field: Field::simple(""),
+            aggregate: Some(AggregateFunction::Count),
+            aggregate_cast: cast.map(|s| s.to_string()),
+            cast: None,
+            alias: alias.map(|s| s.to_string()),
+        },
+    ))
+}
+
+/// Parse an aggregate applied to a field: the `.sum()` of `amount.sum()`.
+fn parse_aggregate_suffix(input: &str) -> IResult<&str, AggregateFunction> {
+    let (input, _) = char('.')(input)?;
+    let (input, function) = alt((
+        value(AggregateFunction::Sum, tag("sum")),
+        value(AggregateFunction::Avg, tag("avg")),
+        value(AggregateFunction::Max, tag("max")),
+        value(AggregateFunction::Min, tag("min")),
+        value(AggregateFunction::Count, tag("count")),
+    ))(input)?;
+    let (input, _) = tag("()")(input)?;
+    Ok((input, function))
+}
+
 /// Parse spread relation: `...relation`
 fn parse_spread_relation(input: &str) -> IResult<&str, SelectItem> {
     let (input, _) = tag("...")(input)?;
     let (input, relation) = parse_identifier(input)?;
-    let (input, hint) = opt(preceded(char('!'), parse_identifier))(input)?;
-    let (input, join_type) = opt(preceded(char('!'), parse_join_type))(input)?;
+    let (input, (hint, join_type)) = parse_relation_modifiers(input)?;
 
     Ok((
         input,
         SelectItem::SpreadRelation {
             relation: relation.to_string(),
-            hint: hint.map(|s| s.to_string()),
+            hint,
             join_type,
         },
     ))
@@ -190,10 +258,10 @@ fn parse_nested_select(input: &str) -> IResult<&str, Vec<SelectItem>> {
 
 /// Parse relation with embedded select: `relation(select_items)`
 fn parse_relation_select(input: &str) -> IResult<&str, SelectItem> {
+    // As with fields, the alias precedes what it names: `c:clients(*)`.
+    let (input, alias) = opt(parse_alias_prefix)(input)?;
     let (input, name) = parse_identifier(input)?;
-    let (input, alias) = opt(preceded(char(':'), parse_identifier))(input)?;
-    let (input, hint) = opt(preceded(char('!'), parse_identifier))(input)?;
-    let (input, join_type) = opt(preceded(char('!'), parse_join_type))(input)?;
+    let (input, (hint, join_type)) = parse_relation_modifiers(input)?;
     // The nested selection is parsed rather than skipped: it says which
     // columns of the related resource to return, and may embed further
     // relations of its own.
@@ -206,7 +274,7 @@ fn parse_relation_select(input: &str) -> IResult<&str, SelectItem> {
         SelectItem::Relation {
             relation: name.to_string(),
             alias: alias.map(|s| s.to_string()),
-            hint: hint.map(|s| s.to_string()),
+            hint,
             join_type,
             select: nested,
         },
@@ -215,28 +283,24 @@ fn parse_relation_select(input: &str) -> IResult<&str, SelectItem> {
 
 /// Parse field select: `field`, `field::cast`, `field:alias`, `agg(field)`
 fn parse_field_select(input: &str) -> IResult<&str, SelectItem> {
-    // Check for aggregate function
-    let (input, aggregate) = opt(parse_aggregate_prefix)(input)?;
+    // `alias:expression` -- the alias comes first, as in `myId:id` or
+    // `total:sum(amount)`. Only a name immediately followed by `:` is one;
+    // anything else backtracks and is read as the expression itself.
+    let (input, alias) = opt(parse_alias_prefix)(input)?;
 
     let (input, name) = parse_identifier(input)?;
     let (input, json_path) = parse_json_path(input)?;
 
-    // Close aggregate if present
+    // A cast on the column binds before the aggregate: `key::integer.sum()`
+    // sums integers, where `.sum()::text` renders the sum as text.
+    let (input, cast) = opt(preceded(tag("::"), parse_identifier))(input)?;
+    let (input, aggregate) = opt(parse_aggregate_suffix)(input)?;
     let (input, aggregate_cast) = if aggregate.is_some() {
-        let (input, _) = char(')')(input)?;
         let (input, cast) = opt(preceded(tag("::"), parse_identifier))(input)?;
         (input, cast.map(|s| s.to_string()))
     } else {
         (input, None)
     };
-
-    let (input, cast) = if aggregate.is_none() {
-        opt(preceded(tag("::"), parse_identifier))(input)?
-    } else {
-        (input, None)
-    };
-
-    let (input, alias) = opt(preceded(char(':'), parse_identifier))(input)?;
 
     Ok((
         input,
@@ -253,21 +317,47 @@ fn parse_field_select(input: &str) -> IResult<&str, SelectItem> {
     ))
 }
 
-fn parse_aggregate_prefix(input: &str) -> IResult<&str, AggregateFunction> {
-    alt((
-        value(AggregateFunction::Sum, tag("sum(")),
-        value(AggregateFunction::Avg, tag("avg(")),
-        value(AggregateFunction::Max, tag("max(")),
-        value(AggregateFunction::Min, tag("min(")),
-        value(AggregateFunction::Count, tag("count(")),
-    ))(input)
+/// Parse the `!`-prefixed modifiers on an embedded relation.
+///
+/// A relation may carry a disambiguating hint, a join type, or both, in either
+/// order: `books!author(*)`, `books!inner(*)`, `books!author!inner(*)`. They
+/// cannot be told apart by position, only by spelling -- `inner` and `left`
+/// are join types and anything else names a foreign key or table -- so each
+/// modifier is read in turn and classified.
+/// An `alias:` prefix, distinguished from the `::` of a cast.
+///
+/// `myId:id` names the column; `id::text` casts it. Both start with an
+/// identifier followed by a colon, so the second colon is what tells them
+/// apart -- without this check `id::text` would be read as an alias `id`
+/// applied to nothing.
+fn parse_alias_prefix(input: &str) -> IResult<&str, &str> {
+    let (rest, name) = parse_identifier(input)?;
+    let (rest, _) = char(':')(rest)?;
+
+    if rest.starts_with(':') {
+        return Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Verify,
+        )));
+    }
+
+    Ok((rest, name))
 }
 
-fn parse_join_type(input: &str) -> IResult<&str, JoinType> {
-    alt((
-        value(JoinType::Inner, tag("inner")),
-        value(JoinType::Left, tag("left")),
-    ))(input)
+fn parse_relation_modifiers(input: &str) -> IResult<&str, (Option<String>, Option<JoinType>)> {
+    let (input, modifiers) = many0(preceded(char('!'), parse_identifier))(input)?;
+
+    let mut hint = None;
+    let mut join_type = None;
+    for modifier in modifiers {
+        match modifier {
+            "inner" => join_type = Some(JoinType::Inner),
+            "left" => join_type = Some(JoinType::Left),
+            other => hint = Some(other.to_string()),
+        }
+    }
+
+    Ok((input, (hint, join_type)))
 }
 
 // ============================================================================
@@ -282,8 +372,26 @@ fn parse_filter_param(key: &str, value: &str) -> Result<(EmbedPath, Filter)> {
     // Parse the value for operator and operand
     let op_expr = parse_filter_value(value)?;
 
-    let filter = Filter::new(Field::simple(field_name), op_expr);
+    let filter = Filter::new(split_json_path(&field_name), op_expr);
     Ok((path, filter))
+}
+
+/// Split a reference like `data->a->>b` into its column and JSON path.
+///
+/// A name with no arrows is returned unchanged, so this is safe to apply to
+/// every field reference. A trailing fragment that does not parse as a path is
+/// left attached to the column name rather than silently dropped -- the column
+/// then fails to resolve, which is the honest outcome.
+fn split_json_path(reference: &str) -> Field {
+    let Some(arrow) = reference.find("->") else {
+        return Field::simple(reference);
+    };
+
+    let (column, rest) = reference.split_at(arrow);
+    match parse_json_path(rest) {
+        Ok(("", json_path)) if !json_path.is_empty() => Field::with_json_path(column, json_path),
+        _ => Field::simple(reference),
+    }
 }
 
 /// Parse a filter key into path and field name.
@@ -534,6 +642,7 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
     }
 
     let field_name = parts[0];
+    let field = split_json_path(field_name);
     let mut direction = None;
     let mut nulls = None;
 
@@ -548,7 +657,7 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
     }
 
     Ok(OrderTerm::Field {
-        field: Field::simple(field_name),
+        field,
         direction,
         nulls,
     })
@@ -626,20 +735,20 @@ mod tests {
 
     #[test]
     fn test_parse_simple_filter() {
-        let params = parse_query_params("name=eq.John").unwrap();
+        let params = parse_query_params("name=eq.John", false).unwrap();
         assert_eq!(params.filters_root.len(), 1);
         assert_eq!(params.filters_root[0].field.name, "name");
     }
 
     #[test]
     fn test_parse_negated_filter() {
-        let params = parse_query_params("status=not.eq.active").unwrap();
+        let params = parse_query_params("status=not.eq.active", false).unwrap();
         assert!(params.filters_root[0].op_expr.negated);
     }
 
     #[test]
     fn test_parse_in_filter() {
-        let params = parse_query_params("id=in.(1,2,3)").unwrap();
+        let params = parse_query_params("id=in.(1,2,3)", false).unwrap();
         match &params.filters_root[0].op_expr.operation {
             Operation::In(values) => {
                 assert_eq!(values, &vec!["1", "2", "3"]);
@@ -650,7 +759,7 @@ mod tests {
 
     #[test]
     fn test_parse_is_null() {
-        let params = parse_query_params("deleted_at=is.null").unwrap();
+        let params = parse_query_params("deleted_at=is.null", false).unwrap();
         match &params.filters_root[0].op_expr.operation {
             Operation::Is(IsValue::Null) => {}
             _ => panic!("Expected Is Null"),
@@ -659,7 +768,7 @@ mod tests {
 
     #[test]
     fn test_parse_order() {
-        let params = parse_query_params("order=name.asc,age.desc.nullslast").unwrap();
+        let params = parse_query_params("order=name.asc,age.desc.nullslast", false).unwrap();
         assert_eq!(params.order.len(), 1);
         let (_, terms) = &params.order[0];
         assert_eq!(terms.len(), 2);
@@ -667,7 +776,7 @@ mod tests {
 
     #[test]
     fn test_parse_limit_offset() {
-        let params = parse_query_params("limit=10&offset=20").unwrap();
+        let params = parse_query_params("limit=10&offset=20", false).unwrap();
         let range = params.ranges.get("").unwrap();
         assert_eq!(range.limit, Some(10));
         assert_eq!(range.offset, 20);
@@ -681,7 +790,7 @@ mod tests {
 
     #[test]
     fn test_parse_fts() {
-        let params = parse_query_params("content=fts(english).search+term").unwrap();
+        let params = parse_query_params("content=fts(english).search+term", false).unwrap();
         match &params.filters_root[0].op_expr.operation {
             Operation::Fts {
                 op,

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -965,17 +965,56 @@ fn parse_logic_param(op: LogicOperator, negated: bool, value: &str) -> Result<Lo
     // The group ends at the parenthesis that closes it, not at the last one in
     // the string: `and=(a.eq.1,b.eq.2))` is a well-formed group with a stray
     // character after it, and PostgREST reads it as one.
-    let inner =
-        balanced_group(value.trim()).ok_or_else(|| Error::InvalidQueryParam(value.into()))?;
+    let trimmed = value.trim();
+    let inner = balanced_group(trimmed).ok_or_else(|| Error::InvalidQueryParam(value.into()))?;
+
+    // Where a member is empty there is nothing to hand the filter parser, and
+    // "Invalid request" says only that something in a URL the client wrote is
+    // wrong. PostgREST names the character and what would have been accepted
+    // there, counting from the start of the tree as it spells it -- `or=(...)`
+    // is read as `or(...)`, so the `=` is not a column and the operator's own
+    // name is.
+    let members = split_top_level(inner);
+    for member in &members {
+        if !member.trim().is_empty() {
+            continue;
+        }
+        let at = offset_within(trimmed, member);
+        return Err(Error::UnparsableQuery {
+            kind: "logic tree",
+            text: trimmed.to_string(),
+            column: negated as usize * "not.".len()
+                + match op {
+                    LogicOperator::And => 3,
+                    LogicOperator::Or => 2,
+                }
+                + at
+                + 1,
+            expected: format!(
+                "unexpected \"{}\" expecting field name (* or [a..z0..9_$]), \
+                 negation operator (not) or logic operator (and, or)",
+                trimmed[at..].chars().next().unwrap_or_default()
+            ),
+        });
+    }
 
     Ok(LogicTree::Expr {
         negated,
         op,
-        children: split_top_level(inner)
+        children: members
             .into_iter()
             .map(parse_logic_child)
             .collect::<Result<Vec<_>>>()?,
     })
+}
+
+/// Where `part` begins inside `whole`, which it is a subslice of.
+///
+/// The split loses the positions and the message needs them; taking them from
+/// the pointers is exact where searching for the text would find the wrong
+/// occurrence of a repeated member.
+fn offset_within(whole: &str, part: &str) -> usize {
+    (part.as_ptr() as usize).saturating_sub(whole.as_ptr() as usize)
 }
 
 /// The contents of a parenthesised group at the head of `input`.
@@ -1616,6 +1655,39 @@ mod tests {
         assert!(parse_select("data->>-34").is_ok());
         assert!(parse_select("data->>34").is_ok());
         assert!(parse_select("data->>key").is_ok());
+    }
+    /// An empty member of a logic tree is reported the way PostgREST reports
+    /// it, which counts from the tree as it spells it: `or=(...)` is read as
+    /// `or(...)`, so the `=` is not a column and the operator's name is.
+    #[test]
+    fn an_empty_logic_tree_member_names_the_character_and_the_column() {
+        let error = parse_logic_param(LogicOperator::Or, false, "()").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"failed to parse logic tree (())\" (line 1, column 4)"
+        );
+        match &error {
+            Error::UnparsableQuery { expected, .. } => assert_eq!(
+                expected,
+                "unexpected \")\" expecting field name (* or [a..z0..9_$]), \
+                 negation operator (not) or logic operator (and, or)"
+            ),
+            other => panic!("wrong variant: {:?}", other),
+        }
+
+        // `and` is a longer name, so the same shape reports one column later.
+        let error = parse_logic_param(LogicOperator::And, false, "()").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"failed to parse logic tree (())\" (line 1, column 5)"
+        );
+
+        // A gap between two members is reported where the gap is.
+        let error = parse_logic_param(LogicOperator::Or, false, "(,)").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"failed to parse logic tree ((,))\" (line 1, column 4)"
+        );
     }
 
 }

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -425,75 +425,66 @@ fn parse_filter_value(value: &str) -> Result<OpExpr> {
     Ok(OpExpr { negated, operation })
 }
 
+/// Map an operator name to its comparison operator, if it is one.
+///
+/// These are exactly the operators that accept an `any`/`all` quantifier.
+fn quant_operator(name: &str) -> Option<QuantOperator> {
+    Some(match name {
+        "eq" => QuantOperator::Equal,
+        "gt" => QuantOperator::GreaterThan,
+        "gte" => QuantOperator::GreaterThanEqual,
+        "lt" => QuantOperator::LessThan,
+        "lte" => QuantOperator::LessThanEqual,
+        "like" => QuantOperator::Like,
+        "ilike" => QuantOperator::ILike,
+        "match" => QuantOperator::Match,
+        "imatch" => QuantOperator::IMatch,
+        _ => return None,
+    })
+}
+
+/// Parse the parenthesised modifier of a quantified comparison.
+fn parse_quantifier(modifier: &str) -> Option<OpQuantifier> {
+    match modifier {
+        "any" => Some(OpQuantifier::Any),
+        "all" => Some(OpQuantifier::All),
+        _ => None,
+    }
+}
+
 /// Parse an operation: `eq.value`, `in.(a,b,c)`, `is.null`, etc.
 fn parse_operation(value: &str) -> Result<Operation> {
-    // Try each operator pattern
-    if let Some(rest) = value.strip_prefix("eq.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::Equal,
-            quantifier: None,
-            value: rest.to_string(),
-        });
+    // A quantified comparison spells the quantifier in parentheses after the
+    // operator name: `col=like(any).{foo,bar}`. Full-text search borrows the
+    // same shape for its language, so the operator name decides the reading.
+    if let Some((name, rest)) = value.split_once('(') {
+        if let Some((modifier, operand)) = rest.split_once(").") {
+            if let (Some(op), Some(quantifier)) = (quant_operator(name), parse_quantifier(modifier))
+            {
+                return Ok(Operation::Quant {
+                    op,
+                    quantifier: Some(quantifier),
+                    value: operand.to_string(),
+                });
+            }
+        }
     }
+
+    // Comparison operators. Every one of these accepts a quantifier, so they
+    // share the lookup above rather than repeating the name-to-operator map.
+    if let Some((name, rest)) = value.split_once('.') {
+        if let Some(op) = quant_operator(name) {
+            return Ok(Operation::Quant {
+                op,
+                quantifier: None,
+                value: rest.to_string(),
+            });
+        }
+    }
+
     if let Some(rest) = value.strip_prefix("neq.") {
         return Ok(Operation::Simple {
             op: SimpleOperator::NotEqual,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("gt.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::GreaterThan,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("gte.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::GreaterThanEqual,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("lt.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::LessThan,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("lte.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::LessThanEqual,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("like.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::Like,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("ilike.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::ILike,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("match.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::Match,
-            quantifier: None,
-            value: rest.to_string(),
-        });
-    }
-    if let Some(rest) = value.strip_prefix("imatch.") {
-        return Ok(Operation::Quant {
-            op: QuantOperator::IMatch,
-            quantifier: None,
             value: rest.to_string(),
         });
     }
@@ -590,12 +581,36 @@ fn parse_operation(value: &str) -> Result<Operation> {
 
 /// Parse IN list: `(a,b,c)` -> vec!["a", "b", "c"]
 fn parse_in_list(value: &str) -> Result<Vec<String>> {
-    let value = value
+    let inner = value
         .strip_prefix('(')
         .and_then(|s| s.strip_suffix(')'))
         .ok_or_else(|| Error::InvalidQueryParam(format!("in.{}", value)))?;
 
-    Ok(value.split(',').map(|s| s.trim().to_string()).collect())
+    let mut values = Vec::new();
+    let mut current = String::new();
+    let mut quoted = false;
+    let mut chars = inner.chars();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // A value may be double-quoted so that it can contain a comma.
+            // Inside the quotes a backslash escapes the next character, which
+            // is the only way to write a literal `"` or `\`.
+            '"' => quoted = !quoted,
+            '\\' if quoted => {
+                if let Some(escaped) = chars.next() {
+                    current.push(escaped);
+                }
+            }
+            ',' if !quoted => {
+                values.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    values.push(current);
+
+    Ok(values)
 }
 
 /// Parse FTS operation: `(language).query` or `.query`
@@ -754,6 +769,95 @@ mod tests {
                 assert_eq!(values, &vec!["1", "2", "3"]);
             }
             _ => panic!("Expected In operation"),
+        }
+    }
+
+    #[test]
+    fn test_parse_in_filter_with_quoted_commas() {
+        let params = parse_query_params(r#"name=in.("hi,there","yes,you")"#, false).unwrap();
+        match &params.filters_root[0].op_expr.operation {
+            Operation::In(values) => {
+                assert_eq!(values, &vec!["hi,there".to_string(), "yes,you".to_string()]);
+            }
+            other => panic!("expected an In operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_in_filter_with_escapes() {
+        let params = parse_query_params(r#"name=in.("a\"b","c\\d")"#, false).unwrap();
+        match &params.filters_root[0].op_expr.operation {
+            Operation::In(values) => {
+                assert_eq!(values, &vec![r#"a"b"#.to_string(), r#"c\d"#.to_string()]);
+            }
+            other => panic!("expected an In operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_quantified_filter() {
+        for (query, expected) in [
+            ("id=eq(any).{1,2,3}", OpQuantifier::Any),
+            ("id=eq(all).{1,2,3}", OpQuantifier::All),
+        ] {
+            let params = parse_query_params(query, false).unwrap();
+            match &params.filters_root[0].op_expr.operation {
+                Operation::Quant {
+                    op,
+                    quantifier,
+                    value,
+                } => {
+                    assert_eq!(op, &QuantOperator::Equal);
+                    assert_eq!(quantifier.as_ref(), Some(&expected));
+                    assert_eq!(value, "{1,2,3}");
+                }
+                other => panic!("expected a quantified operation, got {:?}", other),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_quantified_like_keeps_array_literal() {
+        let params = parse_query_params("name=like(any).{foo*,bar*}", false).unwrap();
+        match &params.filters_root[0].op_expr.operation {
+            Operation::Quant {
+                op,
+                quantifier,
+                value,
+            } => {
+                assert_eq!(op, &QuantOperator::Like);
+                assert_eq!(quantifier.as_ref(), Some(&OpQuantifier::Any));
+                // The `*`-to-`%` mapping belongs to SQL generation, so the
+                // parsed operand is still the literal the client sent.
+                assert_eq!(value, "{foo*,bar*}");
+            }
+            other => panic!("expected a quantified operation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_negated_quantified_filter() {
+        let params = parse_query_params("id=not.eq(any).{1,2}", false).unwrap();
+        assert!(params.filters_root[0].op_expr.negated);
+        assert!(matches!(
+            params.filters_root[0].op_expr.operation,
+            Operation::Quant {
+                quantifier: Some(OpQuantifier::Any),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_quantifier_form_does_not_capture_fts_language() {
+        // `fts(english).x` has the same shape but is not a quantified
+        // comparison; the operator name is what tells the two apart.
+        let params = parse_query_params("body=fts(english).cat", false).unwrap();
+        match &params.filters_root[0].op_expr.operation {
+            Operation::Fts { language, .. } => {
+                assert_eq!(language.as_deref(), Some("english"));
+            }
+            other => panic!("expected an fts operation, got {:?}", other),
         }
     }
 

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -62,25 +62,38 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
             .to_string();
         let key: &str = &decoded_key;
 
+        // Modifiers come before filters, since both are dotted: `clients.order`
+        // orders an embedded resource while `clients.name` filters one.
+        if let Some((path, modifier)) = parse_modifier_key(key) {
+            match modifier {
+                Modifier::Order => {
+                    let (_, terms) = parse_order_param(&decoded_value)?;
+                    params.order.push((path, terms));
+                }
+                Modifier::Limit => {
+                    let limit: i64 = decoded_value
+                        .parse()
+                        .map_err(|_| Error::InvalidQueryParam("limit".into()))?;
+                    params.ranges.entry(path.join(".")).or_default().limit = Some(limit);
+                }
+                Modifier::Offset => {
+                    let offset: i64 = decoded_value
+                        .parse()
+                        .map_err(|_| Error::InvalidQueryParam("offset".into()))?;
+                    params.ranges.entry(path.join(".")).or_default().offset = offset;
+                }
+                Modifier::Logic(op, negated) => {
+                    params
+                        .logic
+                        .push((path, parse_logic_param(op, negated, &decoded_value)?));
+                }
+            }
+            continue;
+        }
+
         match key {
             "select" => {
                 params.select = parse_select(&decoded_value)?;
-            }
-            "order" => {
-                let (path, terms) = parse_order_param(&decoded_value)?;
-                params.order.push((path, terms));
-            }
-            "limit" => {
-                let limit: i64 = decoded_value
-                    .parse()
-                    .map_err(|_| Error::InvalidQueryParam("limit".into()))?;
-                params.ranges.entry(String::new()).or_default().limit = Some(limit);
-            }
-            "offset" => {
-                let offset: i64 = decoded_value
-                    .parse()
-                    .map_err(|_| Error::InvalidQueryParam("offset".into()))?;
-                params.ranges.entry(String::new()).or_default().offset = offset;
             }
             "columns" => {
                 params.columns = Some(
@@ -97,10 +110,6 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
                         .map(|s| s.trim().to_string())
                         .collect(),
                 );
-            }
-            "and" | "or" => {
-                let logic = parse_logic_param(key, &decoded_value)?;
-                params.logic.push((vec![], logic));
             }
             key if !key.starts_with('_') => {
                 if is_rpc {
@@ -554,8 +563,12 @@ fn parse_operation(value: &str) -> Result<Operation> {
 
     // IS operator
     if let Some(rest) = value.strip_prefix("is.") {
-        let is_val = match rest {
+        // These are the only case-insensitive operands in the grammar, and
+        // `not_null` has no operator of its own -- `is.not_null` is the only
+        // spelling of `IS NOT NULL`.
+        let is_val = match rest.to_ascii_lowercase().as_str() {
             "null" => IsValue::Null,
+            "not_null" => IsValue::NotNull,
             "true" => IsValue::True,
             "false" => IsValue::False,
             "unknown" => IsValue::Unknown,
@@ -690,35 +703,125 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
 // ============================================================================
 
 /// Parse `and` or `or` parameter: `(filter1,filter2)`
-fn parse_logic_param(op: &str, value: &str) -> Result<LogicTree> {
-    let logic_op = match op {
-        "and" => LogicOperator::And,
-        "or" => LogicOperator::Or,
-        _ => return Err(Error::InvalidQueryParam(op.into())),
-    };
-
-    // Parse nested filters: (field.op.value,field2.op.value)
-    let value = value
+fn parse_logic_param(op: LogicOperator, negated: bool, value: &str) -> Result<LogicTree> {
+    let inner = value
         .strip_prefix('(')
         .and_then(|s| s.strip_suffix(')'))
-        .ok_or_else(|| Error::InvalidQueryParam(format!("{}={}", op, value)))?;
-
-    let children: Vec<LogicTree> = value
-        .split(',')
-        .map(|s| {
-            let (key, val) = s
-                .split_once('.')
-                .ok_or_else(|| Error::InvalidQueryParam(s.into()))?;
-            let (_, filter) = parse_filter_param(key, val)?;
-            Ok(LogicTree::Stmt(filter))
-        })
-        .collect::<Result<Vec<_>>>()?;
+        .ok_or_else(|| Error::InvalidQueryParam(value.into()))?;
 
     Ok(LogicTree::Expr {
-        negated: false,
-        op: logic_op,
-        children,
+        negated,
+        op,
+        children: split_top_level(inner)
+            .into_iter()
+            .map(parse_logic_child)
+            .collect::<Result<Vec<_>>>()?,
     })
+}
+
+/// Split a comma-separated list on its top-level commas only.
+///
+/// A logic list holds whole conditions, and a condition may contain commas of
+/// its own -- `id.in.(1,2)`, `arr.cs.{1,2}`, a nested `and(...)`, or a quoted
+/// value. Splitting on every comma tears those apart.
+fn split_top_level(input: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut start = 0usize;
+
+    for (idx, ch) in input.char_indices() {
+        if quoted {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                '"' => quoted = false,
+                _ => {}
+            }
+            continue;
+        }
+        match ch {
+            '"' => quoted = true,
+            '(' | '{' | '[' => depth += 1,
+            ')' | '}' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(&input[start..idx]);
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    parts.push(&input[start..]);
+    parts
+}
+
+/// Parse one member of a logic list: either a nested group or a condition.
+fn parse_logic_child(item: &str) -> Result<LogicTree> {
+    let item = item.trim();
+
+    // `not.and(...)` negates the group. A leading `not.` on anything else
+    // belongs to the condition's operator (`arr.not.cs.{1,2}`), so it is left
+    // in place for the filter parser to deal with.
+    let (body, negated) = match item.strip_prefix("not.") {
+        Some(rest) if rest.starts_with("and(") || rest.starts_with("or(") => (rest, true),
+        _ => (item, false),
+    };
+
+    for (name, op) in [("and", LogicOperator::And), ("or", LogicOperator::Or)] {
+        if let Some(rest) = body.strip_prefix(name) {
+            if rest.starts_with('(') && rest.ends_with(')') {
+                return parse_logic_param(op, negated, rest);
+            }
+        }
+    }
+
+    let (key, val) = body
+        .split_once('.')
+        .ok_or_else(|| Error::InvalidQueryParam(item.into()))?;
+    let (_, filter) = parse_filter_param(key, val)?;
+    Ok(LogicTree::Stmt(filter))
+}
+
+/// A query parameter that modifies a resource rather than filtering it.
+enum Modifier {
+    Order,
+    Limit,
+    Offset,
+    Logic(LogicOperator, bool),
+}
+
+/// Recognise a modifier key and the embedded resource it addresses.
+///
+/// Every modifier may be aimed at an embedded resource by prefixing it with
+/// the path to that resource: `clients.order=name` orders the embedded
+/// clients, `clients.limit=1` pages them, `clients.or=(...)` filters them. The
+/// bare forms are the same thing with an empty path.
+fn parse_modifier_key(key: &str) -> Option<(EmbedPath, Modifier)> {
+    let mut parts: Vec<&str> = key.split('.').collect();
+    let last = parts.pop()?;
+
+    let modifier = match last {
+        "order" => Modifier::Order,
+        "limit" => Modifier::Limit,
+        "offset" => Modifier::Offset,
+        "and" | "or" => {
+            let op = if last == "and" {
+                LogicOperator::And
+            } else {
+                LogicOperator::Or
+            };
+            // `not.or=(...)` negates the whole group.
+            let negated = parts.last() == Some(&"not");
+            if negated {
+                parts.pop();
+            }
+            Modifier::Logic(op, negated)
+        }
+        _ => return None,
+    };
+
+    Some((parts.into_iter().map(String::from).collect(), modifier))
 }
 
 // ============================================================================

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -104,12 +104,7 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
                 params.select = parse_select(&decoded_value)?;
             }
             "columns" => {
-                params.columns = Some(
-                    decoded_value
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .collect(),
-                );
+                params.columns = Some(parse_columns(&decoded_value)?.into_iter().collect());
             }
             "on_conflict" => {
                 params.on_conflict = Some(
@@ -154,6 +149,50 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
 // ============================================================================
 // Select Parsing
 // ============================================================================
+
+/// Parse the `columns` parameter value.
+///
+/// A list of field names and nothing else, so the only thing that can go wrong
+/// is a name that is not there -- `?columns=` names none, and `?columns=a,,b`
+/// leaves a gap in the middle. Both were read as a field whose name is the
+/// empty string, which got as far as the schema cache and came back as
+/// "Could not find the '' column", describing a lookup the client never asked
+/// for rather than the parameter it actually wrote.
+fn parse_columns(input: &str) -> Result<Vec<String>> {
+    const EXPECTED: &str = "expecting field name (* or [a..z0..9_$])";
+
+    let mut columns = Vec::new();
+    let mut at = 0usize;
+
+    for (index, field) in input.split(',').enumerate() {
+        if index > 0 {
+            // The comma that separated this field from the last one.
+            at += 1;
+        }
+        let trimmed = field.trim();
+        if trimmed.is_empty() {
+            return Err(Error::UnparsableQuery {
+                kind: "columns parameter",
+                text: input.to_string(),
+                // Counting from one, at the character that should have begun
+                // the name -- the end of the input where there is none left.
+                column: at + 1,
+                expected: match at >= input.len() {
+                    true => format!("unexpected end of input {}", EXPECTED),
+                    false => format!(
+                        "unexpected {:?} {}",
+                        input[at..].chars().next().unwrap_or_default(),
+                        EXPECTED
+                    ),
+                },
+            });
+        }
+        columns.push(trimmed.to_string());
+        at += field.len();
+    }
+
+    Ok(columns)
+}
 
 /// Parse the `select` parameter value.
 pub fn parse_select(input: &str) -> Result<Vec<SelectItem>> {
@@ -1223,6 +1262,21 @@ fn parse_json_operand(input: &str) -> IResult<&str, JsonOperand> {
 
     let operand = match key.parse::<i32>() {
         Ok(index) => JsonOperand::Idx(index),
+        // A leading `-` begins an array index counted from the end, so what
+        // follows it has to be a number. `data->>--34` was read as a key
+        // literally named `--34` and answered 200 with nulls, where the
+        // grammar has no such key in it and PostgREST says so.
+        // A `Failure` rather than an `Error`: the arrow has already been read,
+        // so this is not a step that some other rule might match instead.
+        // Reported as a recoverable error, `alt` backtracked from `->>` to
+        // `->` and read the rest as a key beginning with `>`, which turned a
+        // malformed index into an ordinary lookup that answered 200.
+        Err(_) if key.starts_with('-') => {
+            return Err(nom::Err::Failure(nom::error::Error::new(
+                &input[1..],
+                nom::error::ErrorKind::Digit,
+            )))
+        }
         Err(_) => JsonOperand::Key(key.to_string()),
     };
     Ok((rest, operand))
@@ -1519,4 +1573,49 @@ mod tests {
             _ => panic!("Expected FTS operation"),
         }
     }
+    /// `?columns=` names no field, and is reported as the parameter it is.
+    #[test]
+    fn an_empty_columns_parameter_is_a_parse_error() {
+        let error = parse_columns("").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"failed to parse columns parameter ()\" (line 1, column 1)"
+        );
+        match error {
+            Error::UnparsableQuery { expected, .. } => assert_eq!(
+                expected,
+                "unexpected end of input expecting field name (* or [a..z0..9_$])"
+            ),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    /// A gap in the middle is reported where the gap is, not at the end.
+    #[test]
+    fn a_missing_field_in_columns_is_reported_where_it_is() {
+        let error = parse_columns("a,,b").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "\"failed to parse columns parameter (a,,b)\" (line 1, column 3)"
+        );
+    }
+
+    #[test]
+    fn columns_parses_a_plain_list() {
+        assert_eq!(
+            parse_columns("a, b ,c").unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    /// A `-` inside a JSON path begins an index, so a non-number after it is
+    /// not a key by another name.
+    #[test]
+    fn a_json_path_index_that_is_not_a_number_is_refused() {
+        assert!(parse_select("data->>--34").is_err());
+        assert!(parse_select("data->>-34").is_ok());
+        assert!(parse_select("data->>34").is_ok());
+        assert!(parse_select("data->>key").is_ok());
+    }
+
 }

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -202,11 +202,17 @@ fn parse_aggregate_suffix(input: &str) -> IResult<&str, AggregateFunction> {
     Ok((input, function))
 }
 
-/// Parse spread relation: `...relation`
+/// Parse spread relation: `...relation(cols)`
 fn parse_spread_relation(input: &str) -> IResult<&str, SelectItem> {
     let (input, _) = tag("...")(input)?;
     let (input, relation) = parse_identifier(input)?;
     let (input, (hint, join_type)) = parse_relation_modifiers(input)?;
+    // The parentheses are as much a part of the syntax here as they are for a
+    // plain embed. Leaving them for the caller to trip over meant the column
+    // list was silently discarded along with the rest of the select.
+    let (input, _) = char('(')(input)?;
+    let (input, nested) = parse_nested_select(input)?;
+    let (input, _) = char(')')(input)?;
 
     Ok((
         input,
@@ -214,6 +220,7 @@ fn parse_spread_relation(input: &str) -> IResult<&str, SelectItem> {
             relation: relation.to_string(),
             hint,
             join_type,
+            select: nested,
         },
     ))
 }
@@ -769,6 +776,53 @@ mod tests {
                 assert_eq!(values, &vec!["1", "2", "3"]);
             }
             _ => panic!("Expected In operation"),
+        }
+    }
+
+    #[test]
+    fn test_parse_spread_relation_keeps_its_columns() {
+        let items = parse_select("title,...directors(first_name,last_name)").unwrap();
+        assert_eq!(items.len(), 2);
+        match &items[1] {
+            SelectItem::SpreadRelation {
+                relation, select, ..
+            } => {
+                assert_eq!(relation, "directors");
+                let names: Vec<_> = select
+                    .iter()
+                    .map(|item| match item {
+                        SelectItem::Field { field, .. } => field.name.clone(),
+                        other => panic!("expected a field, got {:?}", other),
+                    })
+                    .collect();
+                assert_eq!(names, vec!["first_name", "last_name"]);
+            }
+            other => panic!("expected a spread relation, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_spread_relation_does_not_swallow_later_items() {
+        // The column list used to be left unconsumed, which silently truncated
+        // everything after it.
+        let items = parse_select("...directors(name),year").unwrap();
+        assert_eq!(items.len(), 2);
+        assert!(matches!(items[0], SelectItem::SpreadRelation { .. }));
+        match &items[1] {
+            SelectItem::Field { field, .. } => assert_eq!(field.name, "year"),
+            other => panic!("expected a field, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_nested_spread_relation() {
+        let items = parse_select("id,films(title,...directors(name))").unwrap();
+        match &items[1] {
+            SelectItem::Relation { select, .. } => {
+                assert_eq!(select.len(), 2);
+                assert!(matches!(select[1], SelectItem::SpreadRelation { .. }));
+            }
+            other => panic!("expected a relation, got {:?}", other),
         }
     }
 

--- a/crates/postrust-core/src/api_request/query_params.rs
+++ b/crates/postrust-core/src/api_request/query_params.rs
@@ -74,6 +74,14 @@ pub fn parse_query_params(query: &str, is_rpc: bool) -> Result<QueryParams> {
                     let limit: i64 = decoded_value
                         .parse()
                         .map_err(|_| Error::InvalidQueryParam("limit".into()))?;
+                    // Caught here rather than left to `LIMIT -1`, which
+                    // PostgreSQL rejects with a message about SQL syntax for
+                    // what is a plainly out-of-range request.
+                    if limit < 0 {
+                        return Err(Error::InvalidRange(
+                            "Limit should be greater than or equal to zero.".into(),
+                        ));
+                    }
                     params.ranges.entry(path.join(".")).or_default().limit = Some(limit);
                 }
                 Modifier::Offset => {
@@ -231,7 +239,7 @@ fn parse_aggregate_suffix(input: &str) -> IResult<&str, AggregateFunction> {
 /// Parse spread relation: `...relation(cols)`
 fn parse_spread_relation(input: &str) -> IResult<&str, SelectItem> {
     let (input, _) = tag("...")(input)?;
-    let (input, relation) = parse_identifier(input)?;
+    let (input, relation) = parse_field_name(input)?;
     let (input, (hint, join_type)) = parse_relation_modifiers(input)?;
     // The parentheses are as much a part of the syntax here as they are for a
     // plain embed. Leaving them for the caller to trip over meant the column
@@ -243,7 +251,7 @@ fn parse_spread_relation(input: &str) -> IResult<&str, SelectItem> {
     Ok((
         input,
         SelectItem::SpreadRelation {
-            relation: relation.to_string(),
+            relation,
             hint,
             join_type,
             select: nested,
@@ -293,7 +301,7 @@ fn parse_nested_select(input: &str) -> IResult<&str, Vec<SelectItem>> {
 fn parse_relation_select(input: &str) -> IResult<&str, SelectItem> {
     // As with fields, the alias precedes what it names: `c:clients(*)`.
     let (input, alias) = opt(parse_alias_prefix)(input)?;
-    let (input, name) = parse_identifier(input)?;
+    let (input, name) = parse_field_name(input)?;
     let (input, (hint, join_type)) = parse_relation_modifiers(input)?;
     // The nested selection is parsed rather than skipped: it says which
     // columns of the related resource to return, and may embed further
@@ -305,8 +313,8 @@ fn parse_relation_select(input: &str) -> IResult<&str, SelectItem> {
     Ok((
         input,
         SelectItem::Relation {
-            relation: name.to_string(),
-            alias: alias.map(|s| s.to_string()),
+            relation: name,
+            alias,
             hint,
             join_type,
             select: nested,
@@ -321,7 +329,7 @@ fn parse_field_select(input: &str) -> IResult<&str, SelectItem> {
     // anything else backtracks and is read as the expression itself.
     let (input, alias) = opt(parse_alias_prefix)(input)?;
 
-    let (input, name) = parse_identifier(input)?;
+    let (input, name) = parse_field_name(input)?;
     let (input, json_path) = parse_json_path(input)?;
 
     // A cast on the column binds before the aggregate: `key::integer.sum()`
@@ -338,10 +346,7 @@ fn parse_field_select(input: &str) -> IResult<&str, SelectItem> {
     Ok((
         input,
         SelectItem::Field {
-            field: Field {
-                name: name.to_string(),
-                json_path,
-            },
+            field: Field { name, json_path },
             aggregate,
             aggregate_cast,
             cast: cast.map(|s| s.to_string()),
@@ -363,8 +368,8 @@ fn parse_field_select(input: &str) -> IResult<&str, SelectItem> {
 /// identifier followed by a colon, so the second colon is what tells them
 /// apart -- without this check `id::text` would be read as an alias `id`
 /// applied to nothing.
-fn parse_alias_prefix(input: &str) -> IResult<&str, &str> {
-    let (rest, name) = parse_identifier(input)?;
+fn parse_alias_prefix(input: &str) -> IResult<&str, String> {
+    let (rest, name) = parse_field_name(input)?;
     let (rest, _) = char(':')(rest)?;
 
     if rest.starts_with(':') {
@@ -400,13 +405,12 @@ fn parse_relation_modifiers(input: &str) -> IResult<&str, (Option<String>, Optio
 /// Parse a filter parameter (key=value where key is a field name).
 fn parse_filter_param(key: &str, value: &str) -> Result<(EmbedPath, Filter)> {
     // Parse the key for embedded path: rel.field or field
-    let (path, field_name) = parse_filter_key(key)?;
+    let (path, field) = parse_filter_key(key)?;
 
     // Parse the value for operator and operand
     let op_expr = parse_filter_value(value)?;
 
-    let filter = Filter::new(split_json_path(&field_name), op_expr);
-    Ok((path, filter))
+    Ok((path, Filter::new(field, op_expr)))
 }
 
 /// Split a reference like `data->a->>b` into its column and JSON path.
@@ -427,23 +431,67 @@ fn split_json_path(reference: &str) -> Field {
     }
 }
 
-/// Parse a filter key into path and field name.
-fn parse_filter_key(key: &str) -> Result<(EmbedPath, String)> {
-    let parts: Vec<&str> = key.split('.').collect();
-    if parts.is_empty() {
-        return Err(Error::InvalidQueryParam(key.into()));
+/// Parse a filter key into the embedded path and the field it names.
+///
+/// The key is a run of field names separated by `.`, optionally followed by a
+/// JSON path: `clients.id`, `data->>a`, `"a.dotted.column"`. Splitting on `.`
+/// alone would cut a quoted name in half, and would take the dot of
+/// `id.something` for a path separator, so the names are parsed rather than
+/// split.
+///
+/// A key the grammar cannot account for falls back to the plain split, which
+/// leaves whatever it produced to fail at column resolution -- an honest
+/// outcome, and the one this had before.
+fn parse_filter_key(key: &str) -> Result<(EmbedPath, Field)> {
+    if let Some(parsed) = parse_field_reference(key) {
+        return Ok(parsed);
     }
 
-    if parts.len() == 1 {
-        return Ok((vec![], parts[0].to_string()));
+    let mut parts: Vec<&str> = key.split('.').collect();
+    let field = parts
+        .pop()
+        .ok_or_else(|| Error::InvalidQueryParam(key.into()))?;
+    let path = parts.into_iter().map(String::from).collect();
+    Ok((path, split_json_path(field)))
+}
+
+/// A dotted path of field names followed by an optional JSON path.
+///
+/// `None` when the whole key was not consumed, which is the caller's signal
+/// that this grammar does not describe it.
+fn parse_field_reference(key: &str) -> Option<(EmbedPath, Field)> {
+    let mut names = Vec::new();
+    let mut rest = key;
+
+    loop {
+        let (remainder, name) = parse_field_name(rest).ok()?;
+        names.push(name);
+        match remainder.strip_prefix('.') {
+            Some(after) => rest = after,
+            None => {
+                rest = remainder;
+                break;
+            }
+        }
     }
 
-    let path: Vec<String> = parts[..parts.len() - 1]
-        .iter()
-        .map(|s| s.to_string())
-        .collect();
-    let field = parts.last().unwrap().to_string();
-    Ok((path, field))
+    let (rest, json_path) = parse_json_path(rest).ok()?;
+    if !rest.is_empty() {
+        return None;
+    }
+
+    let field = names.pop()?;
+    Some((names, Field::with_json_path(field, json_path)))
+}
+
+/// Whether a query parameter reads as a filter rather than a function argument.
+///
+/// On `/rpc/f?id=5&id=gt.2` the same name is both: `5` is the argument the
+/// function takes and `gt.2` filters what it returned. What tells them apart
+/// is the value -- an operator prefix means a filter -- so the classification
+/// has to look at the value rather than the name.
+pub fn value_is_filter(value: &str) -> bool {
+    parse_filter_value(value).is_ok()
 }
 
 /// Parse filter value: `operator.value` or `not.operator.value`
@@ -618,36 +666,84 @@ fn parse_operation(value: &str) -> Result<Operation> {
 
 /// Parse IN list: `(a,b,c)` -> vec!["a", "b", "c"]
 fn parse_in_list(value: &str) -> Result<Vec<String>> {
+    // Whitespace immediately inside the parentheses is not part of the first
+    // or last element: `in.(    )` is the empty list, while `in.( ,3,4)` has
+    // an empty first element and is a type error the database reports.
     let inner = value
+        .trim()
         .strip_prefix('(')
         .and_then(|s| s.strip_suffix(')'))
+        .map(|inner| {
+            inner
+                .trim_start_matches([' ', '\t'])
+                .trim_end_matches([' ', '\t'])
+        })
         .ok_or_else(|| Error::InvalidQueryParam(format!("in.{}", value)))?;
 
-    let mut values = Vec::new();
-    let mut current = String::new();
-    let mut quoted = false;
-    let mut chars = inner.chars();
+    // `in.()` names no values at all, which is not the same as naming one
+    // empty value -- and is what `?id=in.()` returning nothing means.
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
 
-    while let Some(c) = chars.next() {
-        match c {
-            // A value may be double-quoted so that it can contain a comma.
-            // Inside the quotes a backslash escapes the next character, which
-            // is the only way to write a literal `"` or `\`.
-            '"' => quoted = !quoted,
-            '\\' if quoted => {
-                if let Some(escaped) = chars.next() {
-                    current.push(escaped);
-                }
+    let mut values = Vec::new();
+    let mut rest = inner;
+
+    loop {
+        // Quoting is what lets a value contain the comma that would otherwise
+        // end it, so it counts only when it spans the whole element: in
+        // `Double"Quote"McGraw"` the quotes are part of the name, and taking
+        // them for syntax would silently change what was asked for.
+        let element = match quoted_element(rest) {
+            Some((unquoted, remainder)) => {
+                rest = remainder;
+                unquoted
             }
-            ',' if !quoted => {
-                values.push(std::mem::take(&mut current));
+            None => {
+                let end = rest.find(',').unwrap_or(rest.len());
+                let (element, remainder) = rest.split_at(end);
+                rest = remainder;
+                element.to_string()
             }
-            _ => current.push(c),
+        };
+        values.push(element);
+
+        match rest.strip_prefix(',') {
+            Some(remainder) => rest = remainder,
+            None => break,
         }
     }
-    values.push(current);
 
     Ok(values)
+}
+
+/// A complete double-quoted element at the head of `input`.
+///
+/// `None` unless the closing quote ends the element -- what follows it has to
+/// be the comma that separates elements, or nothing at all.
+fn quoted_element(input: &str) -> Option<(String, &str)> {
+    let body = input.strip_prefix('"')?;
+
+    let mut value = String::new();
+    let mut chars = body.char_indices();
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '\\' => {
+                let (_, escaped) = chars.next()?;
+                value.push(escaped);
+            }
+            '"' => {
+                let rest = &body[index + 1..];
+                return match rest.is_empty() || rest.starts_with(',') {
+                    true => Some((value, rest)),
+                    false => None,
+                };
+            }
+            other => value.push(other),
+        }
+    }
+
+    None
 }
 
 /// Parse FTS operation: `(language).query` or `.query`
@@ -734,10 +830,14 @@ fn parse_order_term(value: &str) -> Result<OrderTerm> {
 
 /// Parse `and` or `or` parameter: `(filter1,filter2)`
 fn parse_logic_param(op: LogicOperator, negated: bool, value: &str) -> Result<LogicTree> {
-    let inner = value
-        .strip_prefix('(')
-        .and_then(|s| s.strip_suffix(')'))
-        .ok_or_else(|| Error::InvalidQueryParam(value.into()))?;
+    // Whitespace around the group and around each member is insignificant, as
+    // it is in PostgREST: `and=( a.eq.1 , b.eq.2 )` is the same request as
+    // `and=(a.eq.1,b.eq.2)`.
+    // The group ends at the parenthesis that closes it, not at the last one in
+    // the string: `and=(a.eq.1,b.eq.2))` is a well-formed group with a stray
+    // character after it, and PostgREST reads it as one.
+    let inner =
+        balanced_group(value.trim()).ok_or_else(|| Error::InvalidQueryParam(value.into()))?;
 
     Ok(LogicTree::Expr {
         negated,
@@ -747,6 +847,39 @@ fn parse_logic_param(op: LogicOperator, negated: bool, value: &str) -> Result<Lo
             .map(parse_logic_child)
             .collect::<Result<Vec<_>>>()?,
     })
+}
+
+/// The contents of a parenthesised group at the head of `input`.
+///
+/// Anything after the closing parenthesis is not part of the group and is
+/// discarded, which is what a parser that does not demand end-of-input does.
+fn balanced_group(input: &str) -> Option<&str> {
+    let body = input.strip_prefix('(')?;
+
+    let mut depth = 0usize;
+    let mut quoted = false;
+    let mut escaped = false;
+
+    for (idx, ch) in body.char_indices() {
+        if quoted {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                '"' => quoted = false,
+                _ => {}
+            }
+            continue;
+        }
+        match ch {
+            '"' => quoted = true,
+            '(' => depth += 1,
+            ')' if depth == 0 => return Some(&body[..idx]),
+            ')' => depth -= 1,
+            _ => {}
+        }
+    }
+
+    None
 }
 
 /// Split a comma-separated list on its top-level commas only.
@@ -800,6 +933,7 @@ fn parse_logic_child(item: &str) -> Result<LogicTree> {
 
     for (name, op) in [("and", LogicOperator::And), ("or", LogicOperator::Or)] {
         if let Some(rest) = body.strip_prefix(name) {
+            let rest = rest.trim_start();
             if rest.starts_with('(') && rest.ends_with(')') {
                 return parse_logic_param(op, negated, rest);
             }
@@ -809,8 +943,43 @@ fn parse_logic_child(item: &str) -> Result<LogicTree> {
     let (key, val) = body
         .split_once('.')
         .ok_or_else(|| Error::InvalidQueryParam(item.into()))?;
-    let (_, filter) = parse_filter_param(key, val)?;
+    let (_, filter) = parse_filter_param(key, &unquote_logic_operand(val))?;
     Ok(LogicTree::Stmt(filter))
+}
+
+/// Strip the quotes from a logic-tree operand.
+///
+/// Inside `or=(...)` a value may be quoted so that it can contain the comma
+/// that would otherwise end it -- `name.eq."(grandchild,entity,4)"` -- and the
+/// quotes are then syntax rather than part of the value. Outside a logic tree
+/// there is nothing to protect the value from, so a quote there is a
+/// character like any other and is left alone.
+fn unquote_logic_operand(value: &str) -> String {
+    let Some(open) = value.find('"') else {
+        return value.to_string();
+    };
+    // The quote has to open the operand rather than sit inside one: `id.in.(
+    // "a","b")` is a list, which does its own unquoting element by element.
+    if open != 0 && !value[..open].ends_with('.') {
+        return value.to_string();
+    }
+    if !value.ends_with('"') || value.len() < open + 2 {
+        return value.to_string();
+    }
+
+    let mut unquoted = String::from(&value[..open]);
+    let mut chars = value[open + 1..value.len() - 1].chars();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\\' => {
+                if let Some(escaped) = chars.next() {
+                    unquoted.push(escaped);
+                }
+            }
+            other => unquoted.push(other),
+        }
+    }
+    unquoted
 }
 
 /// A query parameter that modifies a resource rather than filtering it.
@@ -858,8 +1027,72 @@ fn parse_modifier_key(key: &str) -> Option<(EmbedPath, Modifier)> {
 // Helper Parsers
 // ============================================================================
 
+/// The characters a bare identifier is made of.
+///
+/// PostgREST's set exactly: letters, digits, `_`, `$` and the space, with the
+/// result trimmed. A space is allowed because a column may genuinely have one
+/// -- `?select=Just A Server Model` -- and trimming is what keeps
+/// `?select=id, name` from asking for a column called `name ` .
 fn parse_identifier(input: &str) -> IResult<&str, &str> {
-    take_while1(|c: char| c.is_alphanumeric() || c == '_')(input)
+    let (rest, matched) =
+        take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '$' || c == ' ')(input)?;
+    Ok((rest, matched.trim()))
+}
+
+/// Parse a field name: a quoted name, or dash-joined identifiers.
+///
+/// Quoting is how a client names a column the bare grammar cannot spell --
+/// `"a.dotted.column"`, `"(inside,parens)"` -- and a backslash escapes the
+/// next character inside it.
+///
+/// Unquoted, a `-` joins identifiers into one name, so `field-with_sep` is a
+/// single column. A `-` that starts `->` is not a join: that is a JSON path,
+/// and it belongs to whatever comes after the name.
+fn parse_field_name(input: &str) -> IResult<&str, String> {
+    if let Ok(quoted) = parse_quoted_name(input) {
+        return Ok(quoted);
+    }
+
+    let (mut rest, first) = parse_identifier(input)?;
+    let mut name = first.to_string();
+
+    while let Some(after_dash) = rest.strip_prefix('-') {
+        if after_dash.starts_with('>') {
+            break;
+        }
+        let Ok((next, segment)) = parse_identifier(after_dash) else {
+            break;
+        };
+        name.push('-');
+        name.push_str(segment);
+        rest = next;
+    }
+
+    Ok((rest, name))
+}
+
+/// Parse a double-quoted name, honouring backslash escapes.
+fn parse_quoted_name(input: &str) -> IResult<&str, String> {
+    let (rest, _) = char('"')(input)?;
+
+    let mut name = String::new();
+    let mut chars = rest.char_indices();
+    while let Some((index, ch)) = chars.next() {
+        match ch {
+            '\\' => {
+                if let Some((_, escaped)) = chars.next() {
+                    name.push(escaped);
+                }
+            }
+            '"' => return Ok((&rest[index + 1..], name)),
+            other => name.push(other),
+        }
+    }
+
+    Err(nom::Err::Error(nom::error::Error::new(
+        input,
+        nom::error::ErrorKind::Verify,
+    )))
 }
 
 fn parse_json_path(input: &str) -> IResult<&str, JsonPath> {

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -713,6 +713,57 @@ impl MediaType {
             Self::Plan { .. } => "application/vnd.pgrst.plan+json",
         }
     }
+
+    /// The type's full name, parameters included.
+    ///
+    /// [`Self::content_type`] answers what a response body *is*, which never
+    /// needs the parameters. Naming a type back to a client does: a plan is
+    /// not the same request as a plan for CSV with `analyze` on, and a client
+    /// told only `application/vnd.pgrst.plan+json` has not been told which of
+    /// its requests was refused.
+    pub fn to_mime(&self) -> String {
+        match self {
+            Self::SingularJson {
+                strip_nulls: true, ..
+            } => "application/vnd.pgrst.object+json;nulls=stripped".to_string(),
+            Self::ArrayJson { strip_nulls: true } => {
+                "application/vnd.pgrst.array+json;nulls=stripped".to_string()
+            }
+            // Without the parameter there is nothing to distinguish it from
+            // plain JSON, which is the name it is known by.
+            Self::ArrayJson { strip_nulls: false } => "application/json".to_string(),
+            Self::Plan {
+                base,
+                format,
+                options,
+            } => {
+                let mut mime = format!(
+                    "application/vnd.pgrst.plan+{}; for=\"{}\"",
+                    match format {
+                        PlanFormat::Json => "json",
+                        PlanFormat::Text => "text",
+                    },
+                    base.to_mime()
+                );
+                if !options.is_empty() {
+                    let named: Vec<&str> = options
+                        .iter()
+                        .map(|option| match option {
+                            PlanOption::Analyze => "analyze",
+                            PlanOption::Verbose => "verbose",
+                            PlanOption::Settings => "settings",
+                            PlanOption::Buffers => "buffers",
+                            PlanOption::Wal => "wal",
+                        })
+                        .collect();
+                    mime.push_str("; options=");
+                    mime.push_str(&named.join("|"));
+                }
+                mime
+            }
+            other => other.content_type().to_string(),
+        }
+    }
 }
 
 /// EXPLAIN plan format.

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -677,9 +677,16 @@ pub enum MediaType {
     /// Custom media type
     Other(String),
     /// Singular JSON object (vnd.pgrst.object)
-    SingularJson { nullable: bool },
-    /// Array JSON with nulls stripped
-    ArrayJsonStrip,
+    SingularJson {
+        nullable: bool,
+        /// `;nulls=stripped`: omit keys whose value is null.
+        strip_nulls: bool,
+    },
+    /// Array JSON (vnd.pgrst.array)
+    ArrayJson {
+        /// `;nulls=stripped`: omit keys whose value is null.
+        strip_nulls: bool,
+    },
     /// EXPLAIN plan output
     Plan {
         base: Box<MediaType>,
@@ -702,7 +709,7 @@ impl MediaType {
             Self::Any => "*/*",
             Self::Other(s) => s,
             Self::SingularJson { .. } => "application/vnd.pgrst.object+json",
-            Self::ArrayJsonStrip => "application/vnd.pgrst.array+json",
+            Self::ArrayJson { .. } => "application/vnd.pgrst.array+json",
             Self::Plan { .. } => "application/vnd.pgrst.plan+json",
         }
     }
@@ -781,9 +788,12 @@ pub enum PreferMissing {
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PreferHandling {
     /// Strict - fail on unknown parameters
-    #[default]
     Strict,
-    /// Lenient - ignore unknown parameters
+    /// Lenient - ignore unknown parameters.
+    ///
+    /// The default, as in PostgREST: a `Prefer` the server does not recognise
+    /// is a preference, and RFC 7240 says a preference may be ignored.
+    #[default]
     Lenient,
 }
 

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -809,6 +809,14 @@ pub struct Preferences {
     pub timezone: Option<String>,
     pub max_affected: Option<i64>,
     pub invalid: Vec<String>,
+    /// Every preference the server understood, in the order it was sent.
+    ///
+    /// Reported back as `Preference-Applied`. Kept as written rather than
+    /// rebuilt from the fields above, because a field cannot say whether its
+    /// value was asked for or is merely its default -- and `handling=lenient`
+    /// is worth echoing exactly when it was asked for.
+    #[serde(default)]
+    pub applied: Vec<String>,
 }
 
 // ============================================================================

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -297,6 +297,7 @@ impl FtsOperator {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IsValue {
     Null,
+    NotNull,
     True,
     False,
     Unknown,
@@ -306,6 +307,7 @@ impl IsValue {
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::Null => "NULL",
+            Self::NotNull => "NOT NULL",
             Self::True => "TRUE",
             Self::False => "FALSE",
             Self::Unknown => "UNKNOWN",

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -481,10 +481,18 @@ pub enum SelectItem {
         select: Vec<SelectItem>,
     },
     /// Spread a related resource's columns (horizontal embedding)
+    ///
+    /// The related resource's columns land in the parent object itself rather
+    /// than under a key of their own, so unlike [`Self::Relation`] there is no
+    /// alias: nothing is being named.
     SpreadRelation {
         relation: FieldName,
         hint: Option<Hint>,
         join_type: Option<JoinType>,
+        /// Columns and further embeds selected on the related resource.
+        ///
+        /// Empty means every column, matching a bare `...relation()`.
+        select: Vec<SelectItem>,
     },
 }
 

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -402,7 +402,42 @@ pub enum LogicTree {
     Stmt(Filter),
 }
 
+/// The names embedded resources answer to in a selection.
+///
+/// The name a filter would use is the one the response uses: the alias where
+/// there is one, the relation's own name otherwise. A spread has neither --
+/// its columns land in the parent and nothing is named -- so there is nothing
+/// to filter by.
+pub fn embedded_names(select: &[SelectItem]) -> Vec<String> {
+    select
+        .iter()
+        .filter_map(|item| match item {
+            SelectItem::Relation {
+                relation, alias, ..
+            } => Some(alias.clone().unwrap_or_else(|| relation.clone())),
+            _ => None,
+        })
+        .collect()
+}
+
 impl LogicTree {
+    /// Whether every leaf of this tree names one of `embeds`.
+    ///
+    /// `or=(clientinfo.not.is.null,contact.not.is.null)` asks about embedded
+    /// resources rather than about columns: whether the related row was
+    /// there. Those are not names the table has, so a tree made only of them
+    /// cannot be evaluated where the table's own filters are -- it has to
+    /// wait until the embeds themselves are in scope. Answering this decides
+    /// which of the two places the tree belongs to.
+    pub fn names_only(&self, embeds: &[String]) -> bool {
+        match self {
+            Self::Expr { children, .. } => {
+                !children.is_empty() && children.iter().all(|child| child.names_only(embeds))
+            }
+            Self::Stmt(filter) => embeds.contains(&filter.field.name),
+        }
+    }
+
     pub fn and(children: Vec<LogicTree>) -> Self {
         Self::Expr {
             negated: false,

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -639,11 +639,24 @@ impl OrderTerm {
 pub struct Range {
     pub offset: i64,
     pub limit: Option<i64>,
+    /// Whether `offset` was asked for rather than defaulted to.
+    ///
+    /// A query parameter takes precedence over the `Range` header, and
+    /// `?offset=0` is a request to start at the first row -- not the absence
+    /// of one. Without this the two are the same value and `?limit=10` with a
+    /// `Range: 5-9` header starts at the header's row, which is neither what
+    /// was asked for nor where the reported `Content-Range` says it began.
+    #[serde(default)]
+    pub offset_explicit: bool,
 }
 
 impl Range {
     pub fn new(offset: i64, limit: Option<i64>) -> Self {
-        Self { offset, limit }
+        Self {
+            offset,
+            limit,
+            offset_explicit: false,
+        }
     }
 
     /// Create a range from HTTP Range header format (0-9 means rows 0-9 inclusive).
@@ -651,6 +664,7 @@ impl Range {
         Self {
             offset: start,
             limit: end.map(|e| e - start + 1),
+            offset_explicit: false,
         }
     }
 

--- a/crates/postrust-core/src/config.rs
+++ b/crates/postrust-core/src/config.rs
@@ -34,8 +34,14 @@ pub struct AppConfig {
     #[serde(default = "default_true")]
     pub db_prepared_statements: bool,
 
-    /// Extra search path schemas
-    #[serde(default)]
+    /// Schemas added to the `search_path` of every request, after the
+    /// request's own schema.
+    ///
+    /// These are not exposed as API endpoints; they are where a function an
+    /// exposed one calls, or a type it references, is allowed to live. An
+    /// aggregate returning a domain declared elsewhere cannot resolve that
+    /// domain without this. `public` by default, as in PostgREST.
+    #[serde(default = "default_extra_search_path")]
     pub db_extra_search_path: Vec<String>,
 
     /// LISTEN/NOTIFY channel for schema reload
@@ -153,7 +159,7 @@ impl Default for AppConfig {
             db_pool_size: default_pool_size(),
             db_pool_timeout: default_pool_timeout(),
             db_prepared_statements: true,
-            db_extra_search_path: vec![],
+            db_extra_search_path: default_extra_search_path(),
             db_channel: default_db_channel(),
             db_channel_enabled: false,
             db_pre_request: None,
@@ -202,6 +208,14 @@ impl AppConfig {
             }
         }
         // `PGRST_MAX_ROWS` is the name used in our own documentation;
+        if let Ok(v) = std::env::var("PGRST_DB_EXTRA_SEARCH_PATH") {
+            config.db_extra_search_path = v
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+
         if let Ok(v) = std::env::var("PGRST_DB_AGGREGATES_ENABLED") {
             config.db_aggregates_enabled = matches!(v.to_ascii_lowercase().as_str(), "1" | "true");
         }
@@ -335,6 +349,10 @@ fn default_pool_size() -> u32 {
 
 fn default_pool_timeout() -> u64 {
     10
+}
+
+fn default_extra_search_path() -> Vec<String> {
+    vec!["public".to_string()]
 }
 
 fn default_db_channel() -> String {

--- a/crates/postrust-core/src/config.rs
+++ b/crates/postrust-core/src/config.rs
@@ -52,8 +52,11 @@ pub struct AppConfig {
     /// Maximum rows allowed in a response
     pub db_max_rows: Option<i64>,
 
-    /// Enable aggregate functions
-    #[serde(default = "default_true")]
+    /// Enable aggregate functions in `select`.
+    ///
+    /// Off by default, as in PostgREST: an aggregate over a large table costs
+    /// far more than the request looks like it asks for.
+    #[serde(default)]
     pub db_aggregates_enabled: bool,
 
     // ========================================================================
@@ -155,7 +158,7 @@ impl Default for AppConfig {
             db_channel_enabled: false,
             db_pre_request: None,
             db_max_rows: None,
-            db_aggregates_enabled: true,
+            db_aggregates_enabled: false,
             server_host: default_host(),
             server_port: default_port(),
             server_unix_socket: None,
@@ -199,6 +202,10 @@ impl AppConfig {
             }
         }
         // `PGRST_MAX_ROWS` is the name used in our own documentation;
+        if let Ok(v) = std::env::var("PGRST_DB_AGGREGATES_ENABLED") {
+            config.db_aggregates_enabled = matches!(v.to_ascii_lowercase().as_str(), "1" | "true");
+        }
+
         // `PGRST_DB_MAX_ROWS` mirrors PostgREST's `db-max-rows`. Accept both.
         for var in ["PGRST_DB_MAX_ROWS", "PGRST_MAX_ROWS"] {
             if let Ok(max_rows) = std::env::var(var) {

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -304,6 +304,7 @@ impl EmbedPlan {
     /// request, so embedding does not change how a NUMERIC or a timestamp is
     /// rendered. Only the relationship column arrives as JSON, which is what
     /// the separate child query already returned.
+    #[allow(clippy::too_many_arguments)] // one parameter per SQL clause
     pub fn embed_expression(
         &self,
         parent_alias: &str,
@@ -312,6 +313,10 @@ impl EmbedPlan {
         inner_select: &str,
         limit: Option<i64>,
         child_where: Option<&str>,
+        // `clients.order=name.desc` orders the rows inside the embed, which
+        // belongs to the child's own subselect -- and has to be applied before
+        // the child's own limit, or the limit takes an unsorted window.
+        order_by: Option<&str>,
     ) -> Result<String> {
         // The child table is aliased rather than referred to by name. A
         // self-referential relationship would otherwise make the correlation
@@ -371,6 +376,11 @@ impl EmbedPlan {
         if let Some(child_where) = child_where {
             inner.push_str(" AND ");
             inner.push_str(child_where);
+        }
+
+        if let Some(order_by) = order_by {
+            inner.push_str(" ORDER BY ");
+            inner.push_str(order_by);
         }
 
         // A to-one relationship takes the first row; a to-many takes them all.
@@ -754,7 +764,7 @@ mod tests {
     #[test]
     fn embed_expression_aggregates_a_to_many_relation() {
         let sql = plan(true)
-            .embed_expression("p", "\"p\"", "posts", r#""id", "title""#, None, None)
+            .embed_expression("p", "\"p\"", "posts", r#""id", "title""#, None, None, None)
             .unwrap();
 
         assert!(sql.starts_with("COALESCE((SELECT json_agg("), "{}", sql);
@@ -774,7 +784,7 @@ mod tests {
     #[test]
     fn embed_expression_takes_one_row_for_a_to_one_relation() {
         let sql = plan(false)
-            .embed_expression("p", "\"p\"", "author", r#""id""#, None, None)
+            .embed_expression("p", "\"p\"", "author", r#""id""#, None, None, None)
             .unwrap();
 
         assert!(sql.contains("row_to_json"), "{}", sql);
@@ -789,7 +799,7 @@ mod tests {
     #[test]
     fn embed_expression_limits_rows_per_parent() {
         let sql = plan(true)
-            .embed_expression("p", "\"p\"", "posts", r#""id""#, Some(25), None)
+            .embed_expression("p", "\"p\"", "posts", r#""id""#, Some(25), None, None)
             .unwrap();
         assert!(sql.contains("LIMIT 25"), "{}", sql);
     }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -312,6 +312,10 @@ impl EmbedPlan {
         child_alias: &str,
         inner_select: &str,
         limit: Option<i64>,
+        // `clients.offset=1` skips rows inside the embed. A to-one embed that
+        // is skipped past yields no row at all, which is null -- the same
+        // answer as no match, and the one PostgREST gives.
+        offset: i64,
         child_where: Option<&str>,
         // `clients.order=name.desc` orders the rows inside the embed, which
         // belongs to the child's own subselect -- and has to be applied before
@@ -391,6 +395,10 @@ impl EmbedPlan {
             inner.push_str(&format!(" LIMIT {}", limit));
         } else if !self.is_list {
             inner.push_str(" LIMIT 1");
+        }
+
+        if offset > 0 {
+            inner.push_str(&format!(" OFFSET {}", offset));
         }
 
         let alias = postrust_sql::escape_ident(&format!("{}_j", child_alias));
@@ -764,7 +772,16 @@ mod tests {
     #[test]
     fn embed_expression_aggregates_a_to_many_relation() {
         let sql = plan(true)
-            .embed_expression("p", "\"p\"", "posts", r#""id", "title""#, None, None, None)
+            .embed_expression(
+                "p",
+                "\"p\"",
+                "posts",
+                r#""id", "title""#,
+                None,
+                0,
+                None,
+                None,
+            )
             .unwrap();
 
         assert!(sql.starts_with("COALESCE((SELECT json_agg("), "{}", sql);
@@ -784,7 +801,7 @@ mod tests {
     #[test]
     fn embed_expression_takes_one_row_for_a_to_one_relation() {
         let sql = plan(false)
-            .embed_expression("p", "\"p\"", "author", r#""id""#, None, None, None)
+            .embed_expression("p", "\"p\"", "author", r#""id""#, None, 0, None, None)
             .unwrap();
 
         assert!(sql.contains("row_to_json"), "{}", sql);
@@ -799,7 +816,7 @@ mod tests {
     #[test]
     fn embed_expression_limits_rows_per_parent() {
         let sql = plan(true)
-            .embed_expression("p", "\"p\"", "posts", r#""id""#, Some(25), None, None)
+            .embed_expression("p", "\"p\"", "posts", r#""id""#, Some(25), 0, None, None)
             .unwrap();
         assert!(sql.contains("LIMIT 25"), "{}", sql);
     }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -34,6 +34,11 @@ pub struct EmbedPlan {
     pub foreign_table: String,
     /// Whether the relationship yields many rows per parent.
     pub is_list: bool,
+    /// The junction of a many-to-many relationship, if that is what this is.
+    ///
+    /// The parent and the child share no key; each points at a table that
+    /// exists to join them, so reaching the child means going through it.
+    pub junction: Option<EmbedJunction>,
     /// The function behind a computed relationship, if that is what this is.
     ///
     /// A computed relationship is a function taking the parent row and
@@ -41,6 +46,17 @@ pub struct EmbedPlan {
     /// parent row is the argument -- so the columns above are empty and the
     /// relationship can only be expressed as a call correlated to the parent.
     pub function: Option<crate::api_request::QualifiedIdentifier>,
+}
+
+/// The table a many-to-many relationship is joined through.
+#[derive(Clone, Debug)]
+pub struct EmbedJunction {
+    pub schema: String,
+    pub table: String,
+    /// Column on the junction matching the parent's own key.
+    pub parent_column: String,
+    /// Column on the junction matching the child's key.
+    pub child_column: String,
 }
 
 impl EmbedPlan {
@@ -67,7 +83,40 @@ impl EmbedPlan {
                 foreign_schema: foreign_table.schema.clone(),
                 foreign_table: foreign_table.name.clone(),
                 is_list: !to_one,
+                junction: None,
                 function: Some(function.clone()),
+            });
+        }
+
+        if let Relationship::ForeignKey {
+            cardinality: crate::schema_cache::Cardinality::M2M(junction),
+            ..
+        } = relationship
+        {
+            let (local_column, parent_column) =
+                junction.source_columns.first().cloned().ok_or_else(|| {
+                    Error::EmbeddingError("junction has no source columns".into())
+                })?;
+            let (child_column, foreign_column) =
+                junction.target_columns.first().cloned().ok_or_else(|| {
+                    Error::EmbeddingError("junction has no target columns".into())
+                })?;
+
+            return Ok(Self {
+                local_column,
+                foreign_column,
+                foreign_column_type: String::new(),
+                foreign_schema: foreign_table_qi.schema.clone(),
+                foreign_table: foreign_table_qi.name.clone(),
+                // A junction always yields a set: that is what it is for.
+                is_list: true,
+                junction: Some(EmbedJunction {
+                    schema: junction.table.schema.clone(),
+                    table: junction.table.name.clone(),
+                    parent_column,
+                    child_column,
+                }),
+                function: None,
             });
         }
 
@@ -111,6 +160,7 @@ impl EmbedPlan {
             foreign_schema: foreign_table_qi.schema.clone(),
             foreign_table: foreign_table_qi.name.clone(),
             is_list: !relationship.is_to_one(),
+            junction: None,
             function: None,
         })
     }
@@ -241,17 +291,43 @@ impl EmbedPlan {
                 parent_row,
                 postrust_sql::escape_ident(child_alias),
             ),
-            None => format!(
-                "SELECT {} FROM {}.{} AS {} WHERE {}.{} = {}.{}",
-                inner_select,
-                postrust_sql::escape_ident(&self.foreign_schema),
-                postrust_sql::escape_ident(&self.foreign_table),
-                postrust_sql::escape_ident(child_alias),
-                postrust_sql::escape_ident(child_alias),
-                postrust_sql::escape_ident(&self.foreign_column),
-                postrust_sql::escape_ident(parent_alias),
-                postrust_sql::escape_ident(&self.local_column),
-            ),
+            None => match &self.junction {
+                // Two hops: the child is reached through the table that joins
+                // it to the parent, so the correlation lands on the junction.
+                Some(junction) => {
+                    let junction_alias = format!("{}_j", child_alias);
+                    format!(
+                        "SELECT {} FROM {}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} \
+                         WHERE {}.{} = {}.{}",
+                        inner_select,
+                        postrust_sql::escape_ident(&self.foreign_schema),
+                        postrust_sql::escape_ident(&self.foreign_table),
+                        postrust_sql::escape_ident(child_alias),
+                        postrust_sql::escape_ident(&junction.schema),
+                        postrust_sql::escape_ident(&junction.table),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction.child_column),
+                        postrust_sql::escape_ident(child_alias),
+                        postrust_sql::escape_ident(&self.foreign_column),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction.parent_column),
+                        postrust_sql::escape_ident(parent_alias),
+                        postrust_sql::escape_ident(&self.local_column),
+                    )
+                }
+                None => format!(
+                    "SELECT {} FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                    inner_select,
+                    postrust_sql::escape_ident(&self.foreign_schema),
+                    postrust_sql::escape_ident(&self.foreign_table),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(&self.foreign_column),
+                    postrust_sql::escape_ident(parent_alias),
+                    postrust_sql::escape_ident(&self.local_column),
+                ),
+            },
         };
 
         // Filters written against the embedded resource (`clients.id=eq.1`)
@@ -314,16 +390,39 @@ impl EmbedPlan {
                 parent_row,
                 postrust_sql::escape_ident(child_alias),
             ),
-            None => format!(
-                "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
-                postrust_sql::escape_ident(&self.foreign_schema),
-                postrust_sql::escape_ident(&self.foreign_table),
-                postrust_sql::escape_ident(child_alias),
-                postrust_sql::escape_ident(child_alias),
-                postrust_sql::escape_ident(&self.foreign_column),
-                postrust_sql::escape_ident(parent_alias),
-                postrust_sql::escape_ident(&self.local_column),
-            ),
+            None => match &self.junction {
+                Some(junction) => {
+                    let junction_alias = format!("{}_j", child_alias);
+                    format!(
+                        "EXISTS (SELECT 1 FROM {}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} \
+                         WHERE {}.{} = {}.{}",
+                        postrust_sql::escape_ident(&self.foreign_schema),
+                        postrust_sql::escape_ident(&self.foreign_table),
+                        postrust_sql::escape_ident(child_alias),
+                        postrust_sql::escape_ident(&junction.schema),
+                        postrust_sql::escape_ident(&junction.table),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction.child_column),
+                        postrust_sql::escape_ident(child_alias),
+                        postrust_sql::escape_ident(&self.foreign_column),
+                        postrust_sql::escape_ident(&junction_alias),
+                        postrust_sql::escape_ident(&junction.parent_column),
+                        postrust_sql::escape_ident(parent_alias),
+                        postrust_sql::escape_ident(&self.local_column),
+                    )
+                }
+                None => format!(
+                    "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                    postrust_sql::escape_ident(&self.foreign_schema),
+                    postrust_sql::escape_ident(&self.foreign_table),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(&self.foreign_column),
+                    postrust_sql::escape_ident(parent_alias),
+                    postrust_sql::escape_ident(&self.local_column),
+                ),
+            },
         };
 
         if let Some(child_where) = child_where {
@@ -550,6 +649,7 @@ mod tests {
             foreign_schema: "public".into(),
             foreign_table: "posts".into(),
             is_list,
+            junction: None,
             function: None,
         }
     }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -402,6 +402,60 @@ impl EmbedPlan {
         })
     }
 
+    /// A scalar subselect yielding one column of the related row.
+    ///
+    /// This is what `order=clients(name)` orders by: the parent has no such
+    /// column, so the value is fetched per parent row exactly as the embed
+    /// itself is. A to-many relationship has no single value to order by, so
+    /// the first row wins -- which is what `LIMIT 1` says and what PostgREST
+    /// does.
+    pub fn order_expression(
+        &self,
+        parent_alias: &str,
+        parent_row: &str,
+        child_alias: &str,
+        column_sql: &str,
+    ) -> String {
+        let source = match (&self.function, &self.junction) {
+            (Some(function), _) => format!(
+                "{}.{}({}) AS {} WHERE true",
+                postrust_sql::escape_ident(&function.schema),
+                postrust_sql::escape_ident(&function.name),
+                parent_row,
+                postrust_sql::escape_ident(child_alias),
+            ),
+            (None, Some(junction)) => {
+                let junction_alias = format!("{}_j", child_alias);
+                format!(
+                    "{}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} WHERE {}.{} = {}.{}",
+                    postrust_sql::escape_ident(&self.foreign_schema),
+                    postrust_sql::escape_ident(&self.foreign_table),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(&junction.schema),
+                    postrust_sql::escape_ident(&junction.table),
+                    postrust_sql::escape_ident(&junction_alias),
+                    postrust_sql::escape_ident(&junction_alias),
+                    postrust_sql::escape_ident(&junction.child_column),
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(&self.foreign_column),
+                    postrust_sql::escape_ident(&junction_alias),
+                    postrust_sql::escape_ident(&junction.parent_column),
+                    postrust_sql::escape_ident(parent_alias),
+                    postrust_sql::escape_ident(&self.local_column),
+                )
+            }
+            (None, None) => format!(
+                "{}.{} AS {} WHERE {}",
+                postrust_sql::escape_ident(&self.foreign_schema),
+                postrust_sql::escape_ident(&self.foreign_table),
+                postrust_sql::escape_ident(child_alias),
+                self.correlation(parent_alias, child_alias),
+            ),
+        };
+
+        format!("(SELECT {} FROM {} LIMIT 1)", column_sql, source)
+    }
+
     /// An `EXISTS` predicate restricting parents to those with a matching child.
     ///
     /// This is what `!inner` means. The embed expression on its own only

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -34,6 +34,13 @@ pub struct EmbedPlan {
     pub foreign_table: String,
     /// Whether the relationship yields many rows per parent.
     pub is_list: bool,
+    /// The function behind a computed relationship, if that is what this is.
+    ///
+    /// A computed relationship is a function taking the parent row and
+    /// returning rows of the related table. There is no key to join on -- the
+    /// parent row is the argument -- so the columns above are empty and the
+    /// relationship can only be expressed as a call correlated to the parent.
+    pub function: Option<crate::api_request::QualifiedIdentifier>,
 }
 
 impl EmbedPlan {
@@ -44,13 +51,29 @@ impl EmbedPlan {
     pub fn resolve(relationship: &Relationship, schema_cache: &SchemaCache) -> Result<Self> {
         let foreign_table_qi = relationship.foreign_table().clone();
 
+        // A computed relationship takes the parent row as its argument, so
+        // there is nothing to look up and nothing to join on.
+        if let Relationship::Computed {
+            function,
+            foreign_table,
+            to_one,
+            ..
+        } = relationship
+        {
+            return Ok(Self {
+                local_column: String::new(),
+                foreign_column: String::new(),
+                foreign_column_type: String::new(),
+                foreign_schema: foreign_table.schema.clone(),
+                foreign_table: foreign_table.name.clone(),
+                is_list: !to_one,
+                function: Some(function.clone()),
+            });
+        }
+
         let columns = match relationship {
             Relationship::ForeignKey { cardinality, .. } => cardinality.columns(),
-            Relationship::Computed { .. } => {
-                return Err(Error::EmbeddingError(
-                    "embedding a computed relationship is not supported yet".into(),
-                ))
-            }
+            Relationship::Computed { .. } => unreachable!("handled above"),
         };
 
         if columns.len() != 1 {
@@ -88,6 +111,7 @@ impl EmbedPlan {
             foreign_schema: foreign_table_qi.schema.clone(),
             foreign_table: foreign_table_qi.name.clone(),
             is_list: !relationship.is_to_one(),
+            function: None,
         })
     }
 
@@ -195,6 +219,7 @@ impl EmbedPlan {
     pub fn embed_expression(
         &self,
         parent_alias: &str,
+        parent_row: &str,
         child_alias: &str,
         inner_select: &str,
         limit: Option<i64>,
@@ -203,17 +228,31 @@ impl EmbedPlan {
         // The child table is aliased rather than referred to by name. A
         // self-referential relationship would otherwise make the correlation
         // ambiguous, since the parent and the child are the same table.
-        let mut inner = format!(
-            "SELECT {} FROM {}.{} AS {} WHERE {}.{} = {}.{}",
-            inner_select,
-            postrust_sql::escape_ident(&self.foreign_schema),
-            postrust_sql::escape_ident(&self.foreign_table),
-            postrust_sql::escape_ident(child_alias),
-            postrust_sql::escape_ident(child_alias),
-            postrust_sql::escape_ident(&self.foreign_column),
-            postrust_sql::escape_ident(parent_alias),
-            postrust_sql::escape_ident(&self.local_column),
-        );
+        //
+        // A computed relationship is correlated by argument rather than by a
+        // key: the function takes the parent row, so the parent alias is
+        // passed to it and there is no predicate to write.
+        let mut inner = match &self.function {
+            Some(function) => format!(
+                "SELECT {} FROM {}.{}({}) AS {} WHERE true",
+                inner_select,
+                postrust_sql::escape_ident(&function.schema),
+                postrust_sql::escape_ident(&function.name),
+                parent_row,
+                postrust_sql::escape_ident(child_alias),
+            ),
+            None => format!(
+                "SELECT {} FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                inner_select,
+                postrust_sql::escape_ident(&self.foreign_schema),
+                postrust_sql::escape_ident(&self.foreign_table),
+                postrust_sql::escape_ident(child_alias),
+                postrust_sql::escape_ident(child_alias),
+                postrust_sql::escape_ident(&self.foreign_column),
+                postrust_sql::escape_ident(parent_alias),
+                postrust_sql::escape_ident(&self.local_column),
+            ),
+        };
 
         // Filters written against the embedded resource (`clients.id=eq.1`)
         // narrow the children, exactly as they would if the child had been
@@ -263,19 +302,29 @@ impl EmbedPlan {
     pub fn inner_join_predicate(
         &self,
         parent_alias: &str,
+        parent_row: &str,
         child_alias: &str,
         child_where: Option<&str>,
     ) -> String {
-        let mut predicate = format!(
-            "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
-            postrust_sql::escape_ident(&self.foreign_schema),
-            postrust_sql::escape_ident(&self.foreign_table),
-            postrust_sql::escape_ident(child_alias),
-            postrust_sql::escape_ident(child_alias),
-            postrust_sql::escape_ident(&self.foreign_column),
-            postrust_sql::escape_ident(parent_alias),
-            postrust_sql::escape_ident(&self.local_column),
-        );
+        let mut predicate = match &self.function {
+            Some(function) => format!(
+                "EXISTS (SELECT 1 FROM {}.{}({}) AS {} WHERE true",
+                postrust_sql::escape_ident(&function.schema),
+                postrust_sql::escape_ident(&function.name),
+                parent_row,
+                postrust_sql::escape_ident(child_alias),
+            ),
+            None => format!(
+                "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                postrust_sql::escape_ident(&self.foreign_schema),
+                postrust_sql::escape_ident(&self.foreign_table),
+                postrust_sql::escape_ident(child_alias),
+                postrust_sql::escape_ident(child_alias),
+                postrust_sql::escape_ident(&self.foreign_column),
+                postrust_sql::escape_ident(parent_alias),
+                postrust_sql::escape_ident(&self.local_column),
+            ),
+        };
 
         if let Some(child_where) = child_where {
             predicate.push_str(" AND ");
@@ -501,6 +550,7 @@ mod tests {
             foreign_schema: "public".into(),
             foreign_table: "posts".into(),
             is_list,
+            function: None,
         }
     }
 
@@ -517,7 +567,7 @@ mod tests {
     #[test]
     fn embed_expression_aggregates_a_to_many_relation() {
         let sql = plan(true)
-            .embed_expression("p", "posts", r#""id", "title""#, None, None)
+            .embed_expression("p", "\"p\"", "posts", r#""id", "title""#, None, None)
             .unwrap();
 
         assert!(sql.starts_with("COALESCE((SELECT json_agg("), "{}", sql);
@@ -537,7 +587,7 @@ mod tests {
     #[test]
     fn embed_expression_takes_one_row_for_a_to_one_relation() {
         let sql = plan(false)
-            .embed_expression("p", "author", r#""id""#, None, None)
+            .embed_expression("p", "\"p\"", "author", r#""id""#, None, None)
             .unwrap();
 
         assert!(sql.contains("row_to_json"), "{}", sql);
@@ -552,7 +602,7 @@ mod tests {
     #[test]
     fn embed_expression_limits_rows_per_parent() {
         let sql = plan(true)
-            .embed_expression("p", "posts", r#""id""#, Some(25), None)
+            .embed_expression("p", "\"p\"", "posts", r#""id""#, Some(25), None)
             .unwrap();
         assert!(sql.contains("LIMIT 25"), "{}", sql);
     }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -403,17 +403,22 @@ impl EmbedPlan {
 
         let alias = postrust_sql::escape_ident(&format!("{}_j", child_alias));
 
+        // Cast to `jsonb`, as PostgREST does -- `COALESCE(json_agg(..),'[]')::jsonb`.
+        // Only visible where an embedded row is rendered as text rather than
+        // as part of a JSON body: `jsonb` normalises what `json` keeps
+        // verbatim, so a schema-declared handler that stringifies the whole
+        // row wrote `{"id":1}` where PostgREST wrote `{"id": 1}`.
         Ok(if self.is_list {
             // An empty array rather than null, so the shape does not depend on
             // whether the parent happens to have children.
             format!(
-                "COALESCE((SELECT json_agg(row_to_json({alias})) FROM ({inner}) {alias}), '[]'::json)",
+                "COALESCE((SELECT json_agg(row_to_json({alias})) FROM ({inner}) {alias}), '[]'::json)::jsonb",
                 alias = alias,
                 inner = inner
             )
         } else {
             format!(
-                "(SELECT row_to_json({alias}) FROM ({inner}) {alias})",
+                "(SELECT row_to_json({alias}) FROM ({inner}) {alias})::jsonb",
                 alias = alias,
                 inner = inner
             )

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -415,6 +415,71 @@ pub fn attach_to_parent(
     }
 }
 
+/// Merge a related resource's columns into the parent row itself.
+///
+/// This is what the `...` of `select=title,...directors(name)` means. Where
+/// [`attach_to_parent`] puts the related rows under a key of their own, a
+/// spread lifts their columns into the parent object, so the result stays flat.
+///
+/// Spreading a to-many relationship gives each column an array of that
+/// column's value across the matched rows, rather than an array of objects.
+///
+/// `columns` names the columns the client asked for, in order. It is what lets
+/// a parent with no matching child still carry the right keys with null
+/// values, since there is no child row to read the names off. A spread with no
+/// explicit column list has no such list to fall back on, so in that case a
+/// parent with no match gains nothing.
+pub fn spread_into_parent(
+    parent: &mut serde_json::Value,
+    plan: &EmbedPlan,
+    grouped: &HashMap<String, Vec<serde_json::Value>>,
+    columns: &[String],
+) {
+    let key = parent.get(&plan.local_column).and_then(key_to_text);
+    let matches = key
+        .as_ref()
+        .and_then(|k| grouped.get(k))
+        .cloned()
+        .unwrap_or_default();
+
+    // Which keys to write, and in which order. An explicit column list wins,
+    // so the shape does not depend on which rows happened to match; otherwise
+    // take the union of the keys the matched rows carry, first seen first.
+    let mut names: Vec<String> = columns.to_vec();
+    if names.is_empty() {
+        for child in &matches {
+            if let Some(object) = child.as_object() {
+                for name in object.keys() {
+                    if !names.iter().any(|existing| existing == name) {
+                        names.push(name.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    let Some(object) = parent.as_object_mut() else {
+        return;
+    };
+
+    for name in names {
+        let value = if plan.is_list {
+            serde_json::Value::Array(
+                matches
+                    .iter()
+                    .map(|child| child.get(&name).cloned().unwrap_or(serde_json::Value::Null))
+                    .collect(),
+            )
+        } else {
+            matches
+                .first()
+                .and_then(|child| child.get(&name).cloned())
+                .unwrap_or(serde_json::Value::Null)
+        };
+        object.insert(name, value);
+    }
+}
+
 /// Collect the distinct, non-null join keys of a set of parent rows.
 pub fn parent_keys(parents: &[serde_json::Value], local_column: &str) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
@@ -617,5 +682,69 @@ mod tests {
         let mut unmatched = serde_json::json!({"id": 2});
         attach_to_parent(&mut unmatched, "author", &plan(false), &grouped);
         assert_eq!(unmatched["author"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn spread_lifts_a_to_one_relation_into_the_parent() {
+        let mut grouped = HashMap::new();
+        grouped.insert(
+            "1".to_string(),
+            vec![serde_json::json!({"first_name": "Ada", "last_name": "L"})],
+        );
+
+        let mut parent = serde_json::json!({"id": 1, "title": "Notes"});
+        spread_into_parent(
+            &mut parent,
+            &plan(false),
+            &grouped,
+            &["first_name".to_string(), "last_name".to_string()],
+        );
+
+        // Flat, not nested under a key of its own.
+        assert_eq!(parent["first_name"], "Ada");
+        assert_eq!(parent["last_name"], "L");
+        assert_eq!(parent["title"], "Notes");
+        assert!(parent.get("posts").is_none());
+    }
+
+    #[test]
+    fn spread_without_a_match_still_carries_the_requested_keys() {
+        let mut parent = serde_json::json!({"id": 9});
+        spread_into_parent(
+            &mut parent,
+            &plan(false),
+            &HashMap::new(),
+            &["first_name".to_string()],
+        );
+        assert_eq!(parent["first_name"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn spread_of_a_to_many_relation_gives_a_column_per_array() {
+        let mut grouped = HashMap::new();
+        grouped.insert(
+            "1".to_string(),
+            vec![
+                serde_json::json!({"title": "a"}),
+                serde_json::json!({"title": "b"}),
+            ],
+        );
+
+        let mut parent = serde_json::json!({"id": 1});
+        spread_into_parent(&mut parent, &plan(true), &grouped, &["title".to_string()]);
+
+        assert_eq!(parent["title"], serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn spread_without_a_column_list_takes_the_child_keys() {
+        let mut grouped = HashMap::new();
+        grouped.insert("1".to_string(), vec![serde_json::json!({"a": 1, "b": 2})]);
+
+        let mut parent = serde_json::json!({"id": 1});
+        spread_into_parent(&mut parent, &plan(false), &grouped, &[]);
+
+        assert_eq!(parent["a"], 1);
+        assert_eq!(parent["b"], 2);
     }
 }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -59,10 +59,57 @@ pub struct EmbedPlan {
 pub struct EmbedJunction {
     pub schema: String,
     pub table: String,
-    /// Column on the junction matching the parent's own key.
-    pub parent_column: String,
-    /// Column on the junction matching the child's key.
-    pub child_column: String,
+    /// `(parent column, junction column)` for each column the parent joins on.
+    ///
+    /// Usually one. A junction may be keyed over several columns on each side
+    /// -- `touched_files` joins `files(project_id, filename)` to
+    /// `users_tasks(user_id, task_id)` -- and joining on the first of them
+    /// alone would relate rows that are not related.
+    pub parent_columns: Vec<(String, String)>,
+    /// `(junction column, child column)` for each column the child joins on.
+    pub child_columns: Vec<(String, String)>,
+}
+
+impl EmbedJunction {
+    /// The junction's join to the child, one equality per column pair.
+    fn child_join(&self, junction_alias: &str, child_alias: &str) -> String {
+        Self::equalities(&self.child_columns, junction_alias, child_alias, true)
+    }
+
+    /// The junction's correlation to one parent row, one equality per pair.
+    fn parent_correlation(&self, junction_alias: &str, parent_alias: &str) -> String {
+        Self::equalities(&self.parent_columns, junction_alias, parent_alias, false)
+    }
+
+    /// `junction.column = other.column` for each pair, joined with `AND`.
+    ///
+    /// `junction_first` says which half of the pair is the junction's, the two
+    /// lists running in opposite directions: the parent's own column comes
+    /// first on the way in, and the child's second on the way out.
+    fn equalities(
+        pairs: &[(String, String)],
+        junction_alias: &str,
+        other_alias: &str,
+        junction_first: bool,
+    ) -> String {
+        pairs
+            .iter()
+            .map(|(left, right)| {
+                let (junction_column, other_column) = match junction_first {
+                    true => (left, right),
+                    false => (right, left),
+                };
+                format!(
+                    "{}.{} = {}.{}",
+                    postrust_sql::escape_ident(junction_alias),
+                    postrust_sql::escape_ident(junction_column),
+                    postrust_sql::escape_ident(other_alias),
+                    postrust_sql::escape_ident(other_column),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" AND ")
+    }
 }
 
 impl EmbedPlan {
@@ -100,11 +147,15 @@ impl EmbedPlan {
             ..
         } = relationship
         {
-            let (local_column, parent_column) =
+            // The join itself is written from every column pair below. These
+            // two are the parent's and the child's first key column, which is
+            // what the batched path groups by -- and it refuses a junction
+            // keyed on more than one, rather than grouping by half a key.
+            let (local_column, _) =
                 junction.source_columns.first().cloned().ok_or_else(|| {
                     Error::EmbeddingError("junction has no source columns".into())
                 })?;
-            let (child_column, foreign_column) =
+            let (_, foreign_column) =
                 junction.target_columns.first().cloned().ok_or_else(|| {
                     Error::EmbeddingError("junction has no target columns".into())
                 })?;
@@ -121,8 +172,8 @@ impl EmbedPlan {
                 junction: Some(EmbedJunction {
                     schema: junction.table.schema.clone(),
                     table: junction.table.name.clone(),
-                    parent_column,
-                    child_column,
+                    parent_columns: junction.source_columns.clone(),
+                    child_columns: junction.target_columns.clone(),
                 }),
                 function: None,
             });
@@ -248,6 +299,18 @@ impl EmbedPlan {
     /// `limit` still bounds the rows scanned, not the rows per parent, so it is
     /// applied to the inner select exactly as the ungrouped form does.
     pub fn children_grouped_sql(&self, limit: Option<i64>, columns: &[String]) -> Result<String> {
+        if self
+            .junction
+            .as_ref()
+            .is_some_and(|j| j.parent_columns.len() > 1)
+        {
+            return Err(Error::EmbeddingError(format!(
+                "embedding \"{}\" this way is not supported: it joins through a junction \
+                 keyed on several columns, and grouping children by key needs a single one",
+                self.foreign_table,
+            )));
+        }
+
         if self.columns.len() > 1 {
             return Err(Error::EmbeddingError(format!(
                 "embedding \"{}\" this way is not supported: it joins on {} columns, and \
@@ -344,8 +407,7 @@ impl EmbedPlan {
                 Some(junction) => {
                     let junction_alias = format!("{}_j", child_alias);
                     format!(
-                        "SELECT {} FROM {}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} \
-                         WHERE {}.{} = {}.{}",
+                        "SELECT {} FROM {}.{} AS {} JOIN {}.{} AS {} ON {} WHERE {}",
                         inner_select,
                         postrust_sql::escape_ident(&self.foreign_schema),
                         postrust_sql::escape_ident(&self.foreign_table),
@@ -353,14 +415,8 @@ impl EmbedPlan {
                         postrust_sql::escape_ident(&junction.schema),
                         postrust_sql::escape_ident(&junction.table),
                         postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction.child_column),
-                        postrust_sql::escape_ident(child_alias),
-                        postrust_sql::escape_ident(&self.foreign_column),
-                        postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction.parent_column),
-                        postrust_sql::escape_ident(parent_alias),
-                        postrust_sql::escape_ident(&self.local_column),
+                        junction.child_join(&junction_alias, child_alias),
+                        junction.parent_correlation(&junction_alias, parent_alias),
                     )
                 }
                 None => format!(
@@ -450,21 +506,15 @@ impl EmbedPlan {
             (None, Some(junction)) => {
                 let junction_alias = format!("{}_j", child_alias);
                 format!(
-                    "{}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} WHERE {}.{} = {}.{}",
+                    "{}.{} AS {} JOIN {}.{} AS {} ON {} WHERE {}",
                     postrust_sql::escape_ident(&self.foreign_schema),
                     postrust_sql::escape_ident(&self.foreign_table),
                     postrust_sql::escape_ident(child_alias),
                     postrust_sql::escape_ident(&junction.schema),
                     postrust_sql::escape_ident(&junction.table),
                     postrust_sql::escape_ident(&junction_alias),
-                    postrust_sql::escape_ident(&junction_alias),
-                    postrust_sql::escape_ident(&junction.child_column),
-                    postrust_sql::escape_ident(child_alias),
-                    postrust_sql::escape_ident(&self.foreign_column),
-                    postrust_sql::escape_ident(&junction_alias),
-                    postrust_sql::escape_ident(&junction.parent_column),
-                    postrust_sql::escape_ident(parent_alias),
-                    postrust_sql::escape_ident(&self.local_column),
+                    junction.child_join(&junction_alias, child_alias),
+                    junction.parent_correlation(&junction_alias, parent_alias),
                 )
             }
             (None, None) => format!(
@@ -506,22 +556,15 @@ impl EmbedPlan {
                 Some(junction) => {
                     let junction_alias = format!("{}_j", child_alias);
                     format!(
-                        "EXISTS (SELECT 1 FROM {}.{} AS {} JOIN {}.{} AS {} ON {}.{} = {}.{} \
-                         WHERE {}.{} = {}.{}",
+                        "EXISTS (SELECT 1 FROM {}.{} AS {} JOIN {}.{} AS {} ON {} WHERE {}",
                         postrust_sql::escape_ident(&self.foreign_schema),
                         postrust_sql::escape_ident(&self.foreign_table),
                         postrust_sql::escape_ident(child_alias),
                         postrust_sql::escape_ident(&junction.schema),
                         postrust_sql::escape_ident(&junction.table),
                         postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction.child_column),
-                        postrust_sql::escape_ident(child_alias),
-                        postrust_sql::escape_ident(&self.foreign_column),
-                        postrust_sql::escape_ident(&junction_alias),
-                        postrust_sql::escape_ident(&junction.parent_column),
-                        postrust_sql::escape_ident(parent_alias),
-                        postrust_sql::escape_ident(&self.local_column),
+                        junction.child_join(&junction_alias, child_alias),
+                        junction.parent_correlation(&junction_alias, parent_alias),
                     )
                 }
                 None => format!(

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -198,6 +198,7 @@ impl EmbedPlan {
         child_alias: &str,
         inner_select: &str,
         limit: Option<i64>,
+        child_where: Option<&str>,
     ) -> Result<String> {
         // The child table is aliased rather than referred to by name. A
         // self-referential relationship would otherwise make the correlation
@@ -213,6 +214,14 @@ impl EmbedPlan {
             postrust_sql::escape_ident(parent_alias),
             postrust_sql::escape_ident(&self.local_column),
         );
+
+        // Filters written against the embedded resource (`clients.id=eq.1`)
+        // narrow the children, exactly as they would if the child had been
+        // requested on its own.
+        if let Some(child_where) = child_where {
+            inner.push_str(" AND ");
+            inner.push_str(child_where);
+        }
 
         // A to-one relationship takes the first row; a to-many takes them all.
         // The limit bounds rows per parent here, which is what a client asking
@@ -241,6 +250,40 @@ impl EmbedPlan {
                 inner = inner
             )
         })
+    }
+
+    /// An `EXISTS` predicate restricting parents to those with a matching child.
+    ///
+    /// This is what `!inner` means. The embed expression on its own only
+    /// decides what the relationship column contains; without this the parent
+    /// row survives even when the relationship matched nothing, which is a
+    /// left join. `child_where` should be the same predicate given to
+    /// [`Self::embed_expression`] -- placeholders may be referenced from both
+    /// places, so no parameter needs binding twice.
+    pub fn inner_join_predicate(
+        &self,
+        parent_alias: &str,
+        child_alias: &str,
+        child_where: Option<&str>,
+    ) -> String {
+        let mut predicate = format!(
+            "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+            postrust_sql::escape_ident(&self.foreign_schema),
+            postrust_sql::escape_ident(&self.foreign_table),
+            postrust_sql::escape_ident(child_alias),
+            postrust_sql::escape_ident(child_alias),
+            postrust_sql::escape_ident(&self.foreign_column),
+            postrust_sql::escape_ident(parent_alias),
+            postrust_sql::escape_ident(&self.local_column),
+        );
+
+        if let Some(child_where) = child_where {
+            predicate.push_str(" AND ");
+            predicate.push_str(child_where);
+        }
+
+        predicate.push(')');
+        predicate
     }
 
     /// The child projection list: the requested columns plus the join column.
@@ -416,7 +459,7 @@ mod tests {
     #[test]
     fn embed_expression_aggregates_a_to_many_relation() {
         let sql = plan(true)
-            .embed_expression("p", "posts", r#""id", "title""#, None)
+            .embed_expression("p", "posts", r#""id", "title""#, None, None)
             .unwrap();
 
         assert!(sql.starts_with("COALESCE((SELECT json_agg("), "{}", sql);
@@ -436,7 +479,7 @@ mod tests {
     #[test]
     fn embed_expression_takes_one_row_for_a_to_one_relation() {
         let sql = plan(false)
-            .embed_expression("p", "author", r#""id""#, None)
+            .embed_expression("p", "author", r#""id""#, None, None)
             .unwrap();
 
         assert!(sql.contains("row_to_json"), "{}", sql);
@@ -451,7 +494,7 @@ mod tests {
     #[test]
     fn embed_expression_limits_rows_per_parent() {
         let sql = plan(true)
-            .embed_expression("p", "posts", r#""id""#, Some(25))
+            .embed_expression("p", "posts", r#""id""#, Some(25), None)
             .unwrap();
         assert!(sql.contains("LIMIT 25"), "{}", sql);
     }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -34,6 +34,12 @@ pub struct EmbedPlan {
     pub foreign_table: String,
     /// Whether the relationship yields many rows per parent.
     pub is_list: bool,
+    /// Every column pair the join is on, parent side first.
+    ///
+    /// Usually one. A foreign key over several columns joins on all of them,
+    /// and the pairs are ordered so each parent column sits with the child
+    /// column it actually references.
+    pub columns: Vec<(String, String)>,
     /// The junction of a many-to-many relationship, if that is what this is.
     ///
     /// The parent and the child share no key; each points at a table that
@@ -83,6 +89,7 @@ impl EmbedPlan {
                 foreign_schema: foreign_table.schema.clone(),
                 foreign_table: foreign_table.name.clone(),
                 is_list: !to_one,
+                columns: Vec::new(),
                 junction: None,
                 function: Some(function.clone()),
             });
@@ -110,6 +117,7 @@ impl EmbedPlan {
                 foreign_table: foreign_table_qi.name.clone(),
                 // A junction always yields a set: that is what it is for.
                 is_list: true,
+                columns: Vec::new(),
                 junction: Some(EmbedJunction {
                     schema: junction.table.schema.clone(),
                     table: junction.table.name.clone(),
@@ -125,16 +133,10 @@ impl EmbedPlan {
             Relationship::Computed { .. } => unreachable!("handled above"),
         };
 
-        if columns.len() != 1 {
-            return Err(Error::EmbeddingError(format!(
-                "embedding \"{}\" is not supported yet: it joins on {} columns and \
-                 only single-column joins are implemented",
-                foreign_table_qi.name,
-                columns.len()
-            )));
-        }
-
-        let (local_column, foreign_column) = columns[0].clone();
+        let (local_column, foreign_column) = columns
+            .first()
+            .cloned()
+            .ok_or_else(|| Error::EmbeddingError("relationship joins on no columns".into()))?;
 
         let foreign_table: &Table = schema_cache.get_table(&foreign_table_qi).ok_or_else(|| {
             Error::EmbeddingError(format!(
@@ -160,9 +162,36 @@ impl EmbedPlan {
             foreign_schema: foreign_table_qi.schema.clone(),
             foreign_table: foreign_table_qi.name.clone(),
             is_list: !relationship.is_to_one(),
+            columns,
             junction: None,
             function: None,
         })
+    }
+
+    /// The predicate correlating child rows to one parent row.
+    ///
+    /// A foreign key over several columns joins on all of them, so this is one
+    /// equality per pair rather than a single one.
+    fn correlation(&self, parent_alias: &str, child_alias: &str) -> String {
+        let pairs = if self.columns.is_empty() {
+            vec![(self.local_column.clone(), self.foreign_column.clone())]
+        } else {
+            self.columns.clone()
+        };
+
+        pairs
+            .iter()
+            .map(|(local, foreign)| {
+                format!(
+                    "{}.{} = {}.{}",
+                    postrust_sql::escape_ident(child_alias),
+                    postrust_sql::escape_ident(foreign),
+                    postrust_sql::escape_ident(parent_alias),
+                    postrust_sql::escape_ident(local),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" AND ")
     }
 
     /// SQL that fetches every related row for the given parent key values.
@@ -219,6 +248,15 @@ impl EmbedPlan {
     /// `limit` still bounds the rows scanned, not the rows per parent, so it is
     /// applied to the inner select exactly as the ungrouped form does.
     pub fn children_grouped_sql(&self, limit: Option<i64>, columns: &[String]) -> Result<String> {
+        if self.columns.len() > 1 {
+            return Err(Error::EmbeddingError(format!(
+                "embedding \"{}\" this way is not supported: it joins on {} columns, and \
+                 grouping children by key needs a single one",
+                self.foreign_table,
+                self.columns.len()
+            )));
+        }
+
         let type_name = castable_type_name(&self.foreign_column_type).ok_or_else(|| {
             Error::EmbeddingError(format!(
                 "cannot embed \"{}\": join column type \"{}\" is not a plain type name",
@@ -317,15 +355,12 @@ impl EmbedPlan {
                     )
                 }
                 None => format!(
-                    "SELECT {} FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                    "SELECT {} FROM {}.{} AS {} WHERE {}",
                     inner_select,
                     postrust_sql::escape_ident(&self.foreign_schema),
                     postrust_sql::escape_ident(&self.foreign_table),
                     postrust_sql::escape_ident(child_alias),
-                    postrust_sql::escape_ident(child_alias),
-                    postrust_sql::escape_ident(&self.foreign_column),
-                    postrust_sql::escape_ident(parent_alias),
-                    postrust_sql::escape_ident(&self.local_column),
+                    self.correlation(parent_alias, child_alias),
                 ),
             },
         };
@@ -413,14 +448,11 @@ impl EmbedPlan {
                     )
                 }
                 None => format!(
-                    "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}.{} = {}.{}",
+                    "EXISTS (SELECT 1 FROM {}.{} AS {} WHERE {}",
                     postrust_sql::escape_ident(&self.foreign_schema),
                     postrust_sql::escape_ident(&self.foreign_table),
                     postrust_sql::escape_ident(child_alias),
-                    postrust_sql::escape_ident(child_alias),
-                    postrust_sql::escape_ident(&self.foreign_column),
-                    postrust_sql::escape_ident(parent_alias),
-                    postrust_sql::escape_ident(&self.local_column),
+                    self.correlation(parent_alias, child_alias),
                 ),
             },
         };
@@ -649,6 +681,7 @@ mod tests {
             foreign_schema: "public".into(),
             foreign_table: "posts".into(),
             is_list,
+            columns: vec![("id".into(), "user_id".into())],
             junction: None,
             function: None,
         }

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -424,16 +424,20 @@ pub fn attach_to_parent(
 /// Spreading a to-many relationship gives each column an array of that
 /// column's value across the matched rows, rather than an array of objects.
 ///
-/// `columns` names the columns the client asked for, in order. It is what lets
-/// a parent with no matching child still carry the right keys with null
-/// values, since there is no child row to read the names off. A spread with no
-/// explicit column list has no such list to fall back on, so in that case a
-/// parent with no match gains nothing.
+/// `columns` pairs each requested column with the key it should appear under,
+/// which differ when the client aliased it: `...clients(client_name:name)`
+/// reads `name` and writes `client_name`. Listing them explicitly is also what
+/// lets a parent with no matching child still carry the right keys with null
+/// values, since there is no child row to read the names off.
+///
+/// An empty list spreads nothing, which is what `...clients()` means. Falling
+/// back to every column the child happens to have would be actively wrong: the
+/// related table's own `id` would land on top of the parent's.
 pub fn spread_into_parent(
     parent: &mut serde_json::Value,
     plan: &EmbedPlan,
     grouped: &HashMap<String, Vec<serde_json::Value>>,
-    columns: &[String],
+    columns: &[(String, String)],
 ) {
     let key = parent.get(&plan.local_column).and_then(key_to_text);
     let matches = key
@@ -442,41 +446,30 @@ pub fn spread_into_parent(
         .cloned()
         .unwrap_or_default();
 
-    // Which keys to write, and in which order. An explicit column list wins,
-    // so the shape does not depend on which rows happened to match; otherwise
-    // take the union of the keys the matched rows carry, first seen first.
-    let mut names: Vec<String> = columns.to_vec();
-    if names.is_empty() {
-        for child in &matches {
-            if let Some(object) = child.as_object() {
-                for name in object.keys() {
-                    if !names.iter().any(|existing| existing == name) {
-                        names.push(name.clone());
-                    }
-                }
-            }
-        }
-    }
-
     let Some(object) = parent.as_object_mut() else {
         return;
     };
 
-    for name in names {
+    for (source, output) in columns {
         let value = if plan.is_list {
             serde_json::Value::Array(
                 matches
                     .iter()
-                    .map(|child| child.get(&name).cloned().unwrap_or(serde_json::Value::Null))
+                    .map(|child| {
+                        child
+                            .get(source)
+                            .cloned()
+                            .unwrap_or(serde_json::Value::Null)
+                    })
                     .collect(),
             )
         } else {
             matches
                 .first()
-                .and_then(|child| child.get(&name).cloned())
+                .and_then(|child| child.get(source).cloned())
                 .unwrap_or(serde_json::Value::Null)
         };
-        object.insert(name, value);
+        object.insert(output.clone(), value);
     }
 }
 
@@ -697,7 +690,10 @@ mod tests {
             &mut parent,
             &plan(false),
             &grouped,
-            &["first_name".to_string(), "last_name".to_string()],
+            &[
+                ("first_name".into(), "first_name".into()),
+                ("last_name".into(), "last_name".into()),
+            ],
         );
 
         // Flat, not nested under a key of its own.
@@ -714,7 +710,7 @@ mod tests {
             &mut parent,
             &plan(false),
             &HashMap::new(),
-            &["first_name".to_string()],
+            &[("first_name".into(), "first_name".into())],
         );
         assert_eq!(parent["first_name"], serde_json::Value::Null);
     }
@@ -731,20 +727,26 @@ mod tests {
         );
 
         let mut parent = serde_json::json!({"id": 1});
-        spread_into_parent(&mut parent, &plan(true), &grouped, &["title".to_string()]);
+        spread_into_parent(
+            &mut parent,
+            &plan(true),
+            &grouped,
+            &[("title".into(), "title".into())],
+        );
 
         assert_eq!(parent["title"], serde_json::json!(["a", "b"]));
     }
 
     #[test]
-    fn spread_without_a_column_list_takes_the_child_keys() {
+    fn spread_without_a_column_list_adds_nothing() {
+        // `...clients()` spreads no columns. Taking every column the child has
+        // would drop the related table's `id` on top of the parent's.
         let mut grouped = HashMap::new();
-        grouped.insert("1".to_string(), vec![serde_json::json!({"a": 1, "b": 2})]);
+        grouped.insert("1".to_string(), vec![serde_json::json!({"id": 7, "b": 2})]);
 
         let mut parent = serde_json::json!({"id": 1});
         spread_into_parent(&mut parent, &plan(false), &grouped, &[]);
 
-        assert_eq!(parent["a"], 1);
-        assert_eq!(parent["b"], 2);
+        assert_eq!(parent, serde_json::json!({"id": 1}));
     }
 }

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -50,7 +50,7 @@ pub enum Error {
     #[error("Unknown column: {0}")]
     UnknownColumn(String),
 
-    #[error("Invalid range: {0}")]
+    #[error("Requested range not satisfiable")]
     InvalidRange(String),
 
     #[error("Invalid media type: {0}")]
@@ -78,13 +78,18 @@ pub enum Error {
     // ========================================================================
     // Authentication/Authorization Errors (401/403)
     // ========================================================================
-    #[error("Invalid JWT: {0}")]
+    /// The token could not be decoded or its signature did not verify.
+    ///
+    /// Distinct from a claims error: nothing about the token was readable, so
+    /// there is nothing to say about what it claimed.
+    #[error("{0}")]
     InvalidJwt(String),
 
-    #[error("JWT expired")]
-    JwtExpired,
+    /// The token decoded, but a claim was missing, malformed or unsatisfied.
+    #[error("{0}")]
+    JwtClaim(String),
 
-    #[error("Missing authentication")]
+    #[error("Anonymous access is disabled")]
     MissingAuth,
 
     #[error("Insufficient permissions: {0}")]
@@ -96,8 +101,13 @@ pub enum Error {
     #[error("Resource not found: {0}")]
     NotFound(String),
 
-    #[error("Table not found: {0}")]
-    TableNotFound(String),
+    #[error("Table not found: {name}")]
+    TableNotFound {
+        /// The name the request asked for, schema-qualified.
+        name: String,
+        /// A table of a very similar name, where the schema has one.
+        suggestion: Option<String>,
+    },
 
     /// No function of that name accepts the arguments supplied.
     ///
@@ -117,8 +127,59 @@ pub enum Error {
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
 
-    #[error("Relationship not found: {0}")]
-    RelationshipNotFound(String),
+    #[error("Could not find a relationship between '{origin}' and '{target}' in the schema cache")]
+    RelationshipNotFound {
+        /// The table the embedding started from.
+        origin: String,
+        /// The resource the request asked to embed.
+        target: String,
+        /// The `!hint` that was meant to identify it, if any.
+        hint: Option<String>,
+        /// The schema that was searched.
+        schema: String,
+        /// A relationship of a very similar name, where there is one.
+        suggestion: Option<String>,
+    },
+
+    /// A filter or order names something the request never embedded.
+    ///
+    /// `?non_existent.name=like.*x*` is not a column with a dot in it, and
+    /// answering it as though the prefix were meaningless would silently
+    /// return the unfiltered table.
+    #[error("'{0}' is not an embedded resource in this request")]
+    NotAnEmbeddedResource(String),
+
+    /// Ordering by a column of a resource that yields many rows per parent.
+    ///
+    /// There is no single value to order on: the parent has a list.
+    #[error("A related order on '{relation}' is not possible")]
+    RelatedOrderNotPossible {
+        /// The table the request started from.
+        origin: String,
+        /// The embedded resource the order named.
+        relation: String,
+    },
+
+    /// A single object was asked for and the result is not one.
+    ///
+    /// `Accept: application/vnd.pgrst.object+json` says the client will accept
+    /// exactly one row; anything else is a negotiation failure rather than a
+    /// missing resource, which is why it is 406 and not 404.
+    #[error("Cannot coerce the result to a single JSON object")]
+    NotSingular {
+        /// How many rows the query actually returned.
+        rows: usize,
+    },
+
+    /// A path with more segments than any resource has.
+    #[error("Invalid path specified in request URL")]
+    InvalidResourcePath,
+
+    /// Preferences the server does not know, sent with `handling=strict`.
+    ///
+    /// Strict handling is a request to be told rather than have them ignored.
+    #[error("Invalid preferences given with handling=strict")]
+    InvalidPreferences(Vec<String>),
 
     // ========================================================================
     // Schema Cache Errors
@@ -166,11 +227,13 @@ impl Error {
             | Self::InvalidQueryParam(_)
             | Self::InvalidHeader(_)
             | Self::InvalidBody(_)
-            | Self::InvalidRange(_)
             | Self::InvalidMediaType(_)
             | Self::MissingParameter(_)
             | Self::AmbiguousRequest(_)
             | Self::UnknownColumn(_)
+            | Self::NotAnEmbeddedResource(_)
+            | Self::RelatedOrderNotPossible { .. }
+            | Self::InvalidPreferences(_)
             | Self::InvalidPlan(_)
             | Self::EmbeddingError(_)
             | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
@@ -181,23 +244,32 @@ impl Error {
             }
 
             // 401 Unauthorized
-            Self::InvalidJwt(_) | Self::JwtExpired | Self::MissingAuth => StatusCode::UNAUTHORIZED,
+            Self::InvalidJwt(_) | Self::JwtClaim(_) | Self::MissingAuth => StatusCode::UNAUTHORIZED,
 
             // 403 Forbidden
             Self::InsufficientPermissions(_) => StatusCode::FORBIDDEN,
 
             // 404 Not Found
             Self::NotFound(_)
-            | Self::TableNotFound(_)
+            | Self::TableNotFound { .. }
             | Self::FunctionNotFound { .. }
             | Self::ColumnNotFound(_)
-            | Self::RelationshipNotFound(_) => StatusCode::NOT_FOUND,
+            | Self::RelationshipNotFound { .. } => StatusCode::NOT_FOUND,
 
             // 405 Method Not Allowed
             Self::UnsupportedMethod(_) => StatusCode::METHOD_NOT_ALLOWED,
 
             // 406 Not Acceptable
-            Self::UnacceptableSchema { .. } => StatusCode::NOT_ACCEPTABLE,
+            Self::UnacceptableSchema { .. } | Self::NotSingular { .. } => {
+                StatusCode::NOT_ACCEPTABLE
+            }
+
+            Self::InvalidResourcePath => StatusCode::NOT_FOUND,
+
+            // A range the server cannot satisfy, which is what 416 is for --
+            // a negative limit asks for a window that does not exist rather
+            // than for one the server merely declines.
+            Self::InvalidRange(_) => StatusCode::RANGE_NOT_SATISFIABLE,
 
             // 500 Internal Server Error
             Self::SchemaCacheNotLoaded
@@ -225,23 +297,28 @@ impl Error {
             Self::UnsupportedMethod(_) => "PGRST104",
             Self::UnacceptableSchema { .. } => "PGRST106",
             Self::UnknownColumn(_) => "PGRST204",
-            Self::InvalidRange(_) => "PGRST107",
+            Self::InvalidRange(_) => "PGRST103",
             Self::InvalidMediaType(_) => "PGRST108",
             Self::MissingParameter(_) => "PGRST109",
             Self::AmbiguousRequest(_) => "PGRST110",
             Self::AmbiguousFunction { .. } => "PGRST203",
             Self::AmbiguousRelationship { .. } => "PGRST201",
 
-            Self::InvalidJwt(_) => "PGRST303",
-            Self::JwtExpired => "PGRST301",
+            Self::InvalidJwt(_) => "PGRST301",
+            Self::JwtClaim(_) => "PGRST303",
             Self::MissingAuth => "PGRST302",
             Self::InsufficientPermissions(_) => "PGRST203",
 
             Self::NotFound(_) => "PGRST205",
-            Self::TableNotFound(_) => "PGRST205",
+            Self::TableNotFound { .. } => "PGRST205",
             Self::FunctionNotFound { .. } => "PGRST202",
             Self::ColumnNotFound(_) => "PGRST204",
-            Self::RelationshipNotFound(_) => "PGRST200",
+            Self::RelationshipNotFound { .. } => "PGRST200",
+            Self::NotAnEmbeddedResource(_) => "PGRST108",
+            Self::NotSingular { .. } => "PGRST116",
+            Self::InvalidResourcePath => "PGRST125",
+            Self::RelatedOrderNotPossible { .. } => "PGRST118",
+            Self::InvalidPreferences(_) => "PGRST122",
 
             Self::SchemaCacheNotLoaded => "PGRST400",
             Self::SchemaCacheLoadFailed(_) => "PGRST401",
@@ -289,6 +366,38 @@ impl Error {
                     })
                     .collect(),
             )),
+            Self::RelationshipNotFound {
+                origin,
+                target,
+                hint,
+                schema,
+                ..
+            } => Some(serde_json::Value::String(format!(
+                "Searched for a foreign key relationship between '{}' and '{}'{} in the schema \
+                 '{}', but no matches were found.",
+                origin,
+                target,
+                match hint {
+                    Some(hint) => format!(" using the hint '{}'", hint),
+                    None => String::new(),
+                },
+                schema
+            ))),
+            Self::RelatedOrderNotPossible { origin, relation } => {
+                Some(serde_json::Value::String(format!(
+                    "'{}' and '{}' do not form a many-to-one or one-to-one relationship",
+                    origin, relation
+                )))
+            }
+            Self::InvalidRange(reason) => Some(serde_json::Value::String(reason.clone())),
+            Self::NotSingular { rows } => Some(serde_json::Value::String(format!(
+                "The result contains {} rows",
+                rows
+            ))),
+            Self::InvalidPreferences(invalid) => Some(serde_json::Value::String(format!(
+                "Invalid preferences: {}",
+                invalid.join(", ")
+            ))),
             Self::FunctionNotFound { name, params, .. } => Some(serde_json::Value::String(
                 format!(
                     "Searched for the function {} {}, but no matches were found in the schema cache.",
@@ -303,10 +412,18 @@ impl Error {
     /// Get a hint for resolving the error.
     pub fn hint(&self) -> Option<String> {
         match self {
-            Self::InvalidJwt(_) => {
-                Some("Check that the JWT is properly signed and not expired".into())
-            }
-            Self::MissingAuth => Some("Provide a valid JWT in the Authorization header".into()),
+            Self::NotAnEmbeddedResource(name) => Some(format!(
+                "Verify that '{}' is included in the 'select' query parameter.",
+                name
+            )),
+            Self::TableNotFound { suggestion, .. } => suggestion
+                .as_ref()
+                .map(|name| format!("Perhaps you meant the table '{}'", name)),
+            Self::RelationshipNotFound {
+                target, suggestion, ..
+            } => suggestion
+                .as_ref()
+                .map(|name| format!("Perhaps you meant '{}' instead of '{}'.", name, target)),
             Self::AmbiguousFunction { .. } => Some(
                 "Try renaming the parameters or the function itself in the database so function \
                  overloading can be resolved"
@@ -360,30 +477,138 @@ pub struct DatabaseError {
     pub column: Option<String>,
 }
 
+/// A response a database function asked for outright.
+#[derive(Clone, Debug)]
+pub struct RaisedResponse {
+    /// The HTTP status to answer with.
+    pub status: u16,
+    /// Headers to add to the response.
+    pub headers: Vec<(String, String)>,
+    /// The response body, verbatim.
+    pub body: serde_json::Value,
+}
+
 impl DatabaseError {
-    /// Get HTTP status code based on PostgreSQL error code.
+    /// The response a `RAISE sqlstate 'PGRST'` asked for.
+    ///
+    /// A function can take over the whole response by raising that SQLSTATE:
+    /// the message is the body, and the detail carries the status, an optional
+    /// status text and any headers. It is how a schema returns a 402 with its
+    /// own payload without the API layer knowing anything about billing.
+    ///
+    /// `None` when this is not that error, or when either JSON does not parse
+    /// -- the latter is a fault in the schema, and reporting it as such is
+    /// more use than a half-applied response.
+    pub fn raised_response(&self) -> Option<RaisedResponse> {
+        if self.code != "PGRST" {
+            return None;
+        }
+
+        let body: serde_json::Value = serde_json::from_str(&self.message).ok()?;
+        let control: serde_json::Value =
+            serde_json::from_str(self.details.as_deref().unwrap_or("{}")).ok()?;
+
+        Some(RaisedResponse {
+            status: control.get("status").and_then(serde_json::Value::as_u64)? as u16,
+            headers: control
+                .get("headers")
+                .and_then(serde_json::Value::as_object)
+                .map(|headers| {
+                    headers
+                        .iter()
+                        .filter_map(|(name, value)| {
+                            Some((name.clone(), value.as_str()?.to_string()))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
+            body,
+        })
+    }
+
+    /// The HTTP status a PostgreSQL error code maps to.
+    ///
+    /// PostgREST's table (`mapSQLtoHTTP` in `Error.hs`), which is part of its
+    /// contract rather than an implementation detail: a client distinguishes a
+    /// missing function from a bad argument by the status.
+    ///
+    /// The default is 400, not 500: the great majority of SQLSTATEs a request
+    /// can provoke are provoked by the request. Reporting them as server
+    /// errors tells the client to retry something that will never succeed.
     pub fn status_code(&self) -> StatusCode {
-        // PostgreSQL error codes: https://www.postgresql.org/docs/current/errcodes-appendix.html
-        match self.code.as_str() {
+        let code = self.code.as_str();
+        let message = self.message.as_str();
+
+        if let Some(raised) = self.raised_response() {
+            if let Ok(status) = StatusCode::from_u16(raised.status) {
+                return status;
+            }
+        }
+
+        // `PT<nnn>` is a status code raised by the schema itself: a function
+        // says `RAISE sqlstate 'PT402'` to answer 402, with the message as the
+        // status text.
+        if let Some(digits) = code.strip_prefix("PT") {
+            if let Ok(status) = digits.parse::<u16>() {
+                if let Ok(status) = StatusCode::from_u16(status) {
+                    return status;
+                }
+            }
+            return StatusCode::INTERNAL_SERVER_ERROR;
+        }
+
+        match code {
+            "23503" | "23505" => StatusCode::CONFLICT,
             // A write attempted inside the read-only transaction a read
             // request runs in. The request was not wrong, the method was.
             "25006" => StatusCode::METHOD_NOT_ALLOWED,
-            // Class 23 - Integrity Constraint Violation
-            c if c.starts_with("23") => StatusCode::CONFLICT,
-            // Class 42 - Syntax Error or Access Rule Violation
-            c if c.starts_with("42") => StatusCode::BAD_REQUEST,
-            // Class 28 - Invalid Authorization Specification
-            c if c.starts_with("28") => StatusCode::FORBIDDEN,
-            // Class 40 - Transaction Rollback
-            c if c.starts_with("40") => StatusCode::CONFLICT,
-            // Class 53 - Insufficient Resources
-            c if c.starts_with("53") => StatusCode::SERVICE_UNAVAILABLE,
-            // Class 54 - Program Limit Exceeded
-            c if c.starts_with("54") => StatusCode::PAYLOAD_TOO_LARGE,
-            // Class P0 - PL/pgSQL Errors (custom raised errors)
-            "P0001" => StatusCode::BAD_REQUEST, // RAISE EXCEPTION
-            // Default to internal server error
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
+            // Cardinality violation. `pg-safeupdate` raises it for an
+            // unqualified UPDATE or DELETE, which is the client's doing;
+            // anything else is a function or view misbehaving.
+            "21000" => match message.ends_with("requires a WHERE clause") {
+                true => StatusCode::BAD_REQUEST,
+                false => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            // Invalid parameter value, which is also how PostgreSQL reports a
+            // `SET ROLE` to a role that does not exist.
+            "22023" => match message.starts_with("role") && message.ends_with("does not exist") {
+                true => StatusCode::UNAUTHORIZED,
+                false => StatusCode::BAD_REQUEST,
+            },
+            "53400" => StatusCode::INTERNAL_SERVER_ERROR,
+            "57P01" => StatusCode::SERVICE_UNAVAILABLE,
+            "P0001" => StatusCode::BAD_REQUEST,
+            // `xmlagg` is missing only when the request asked for XML the
+            // server cannot produce, which is a negotiation failure.
+            "42883" => match message.starts_with("function xmlagg(") {
+                true => StatusCode::NOT_ACCEPTABLE,
+                false => StatusCode::NOT_FOUND,
+            },
+            "42P01" => StatusCode::NOT_FOUND,
+            "42P17" => StatusCode::INTERNAL_SERVER_ERROR,
+            // Without authentication the client may simply not have said who
+            // it is; with it, it has and is still not permitted.
+            "42501" => StatusCode::UNAUTHORIZED,
+            _ => match code.as_bytes() {
+                [b'0', b'8', ..] => StatusCode::SERVICE_UNAVAILABLE,
+                [b'0', b'9', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'0', b'L', ..] | [b'0', b'P', ..] => StatusCode::FORBIDDEN,
+                [b'2', b'5', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'2', b'8', ..] => StatusCode::FORBIDDEN,
+                [b'2', b'D', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'3', b'8', ..] | [b'3', b'9', ..] | [b'3', b'B', ..] => {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+                [b'4', b'0', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'5', b'3', ..] => StatusCode::SERVICE_UNAVAILABLE,
+                [b'5', b'4', ..] | [b'5', b'5', ..] | [b'5', b'7', ..] | [b'5', b'8', ..] => {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+                [b'F', b'0', ..] | [b'H', b'V', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'P', b'0', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                [b'X', b'X', ..] => StatusCode::INTERNAL_SERVER_ERROR,
+                _ => StatusCode::BAD_REQUEST,
+            },
         }
     }
 
@@ -410,7 +635,11 @@ mod tests {
         );
         assert_eq!(Error::MissingAuth.status_code(), StatusCode::UNAUTHORIZED);
         assert_eq!(
-            Error::TableNotFound("users".into()).status_code(),
+            Error::TableNotFound {
+                name: "users".into(),
+                suggestion: None
+            }
+            .status_code(),
             StatusCode::NOT_FOUND
         );
         assert_eq!(
@@ -425,7 +654,14 @@ mod tests {
         // code as a malformed path. PGRST101 means something else entirely.
         assert_eq!(Error::InvalidQueryParam("test".into()).code(), "PGRST100");
         assert_eq!(Error::MissingAuth.code(), "PGRST302");
-        assert_eq!(Error::TableNotFound("users".into()).code(), "PGRST205");
+        assert_eq!(
+            Error::TableNotFound {
+                name: "users".into(),
+                suggestion: None
+            }
+            .code(),
+            "PGRST205"
+        );
     }
 
     #[test]

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -135,12 +135,14 @@ pub enum Error {
         params: Vec<String>,
         /// A signature that does exist, where one does.
         candidate: Option<String>,
-        /// Whether a single unnamed `json` parameter was also considered.
+        /// The type of a single unnamed parameter that would also have
+        /// matched, spelled as the message spells it.
         ///
-        /// It is, over `POST`, where the whole body can be one argument --
-        /// and the message says so, since it widens what would have matched.
-        #[allow(dead_code)]
-        single_json: bool,
+        /// Over `POST` the whole body can be one argument, and which type it
+        /// could be is decided by the body's media type: `json/jsonb` for a
+        /// JSON body, `text`, `xml` or `bytea` for the others. Naming it says
+        /// what else was looked for besides the arguments themselves.
+        single_param: Option<String>,
     },
 
     #[error("Column not found: {0}")]
@@ -472,15 +474,23 @@ impl Error {
             Self::FunctionNotFound {
                 name,
                 params,
-                single_json,
+                single_param,
                 ..
             } => Some(serde_json::Value::String(format!(
-                "Searched for the function {} {}{}, but no matches were found in the schema cache.",
+                "Searched for the function {} {}, but no matches were found in the schema cache.",
                 name,
-                describe_params(params),
-                match single_json {
-                    true => " or with a single unnamed json/jsonb parameter",
-                    false => "",
+                match single_param.as_deref() {
+                    // A body that is one value carries no argument names, so
+                    // the only thing that could have matched is the parameter
+                    // that takes it.
+                    Some(other) if other != JSON_PARAM =>
+                        format!("with a single unnamed {} parameter", other),
+                    Some(_) => format!(
+                        "{} or with a single unnamed {} parameter",
+                        describe_params(params),
+                        JSON_PARAM
+                    ),
+                    None => describe_params(params),
                 }
             ))),
             _ => None,
@@ -507,9 +517,17 @@ impl Error {
                  overloading can be resolved"
                     .into(),
             ),
-            Self::FunctionNotFound { candidate, .. } => candidate
+            // A body that is one value names no arguments, so there is no
+            // near miss to point at: any function of that name would have
+            // done, and none of them takes this body.
+            Self::FunctionNotFound {
+                candidate,
+                single_param,
+                ..
+            } if !names_only_one_param(single_param.as_deref()) => candidate
                 .as_ref()
                 .map(|c| format!("Perhaps you meant to call the function {}", c)),
+            Self::FunctionNotFound { .. } => None,
             // The schemas a server exposes are part of its contract, not an
             // internal detail, so naming them is how the client is told what
             // to ask for instead.
@@ -527,6 +545,20 @@ impl Error {
 ///
 /// PostgREST words the no-argument case differently rather than printing an
 /// empty list, and the messages are matched verbatim by clients.
+/// How the message spells the type of a single unnamed JSON parameter.
+///
+/// It is the one media type that can also carry named arguments, so it reads
+/// as an alternative rather than as the only thing looked for.
+pub const JSON_PARAM: &str = "json/jsonb";
+
+/// Whether the request could only ever have matched one unnamed parameter.
+///
+/// True for a body that is one value -- text, xml or bytes -- which carries no
+/// argument names at all.
+pub fn names_only_one_param(single_param: Option<&str>) -> bool {
+    matches!(single_param, Some(other) if other != JSON_PARAM)
+}
+
 pub fn function_signature(name: &str, params: &[String]) -> String {
     match params.is_empty() {
         true => format!("{} without parameters", name),

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -145,6 +145,15 @@ pub enum Error {
         single_param: Option<String>,
     },
 
+    /// A `RAISE sqlstate 'PGRST'` the schema wrote wrongly.
+    ///
+    /// The message and the detail are both JSON documents with required keys,
+    /// and a function that gets one wrong has not asked for a response -- it
+    /// has a bug. Reporting it as the 500 it is says so; applying half of what
+    /// it asked for would not.
+    #[error("Could not parse JSON in the \"RAISE SQLSTATE 'PGRST'\" error")]
+    RaiseNotUnderstood(RaiseFault),
+
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
 
@@ -306,11 +315,15 @@ impl Error {
             Self::InsufficientPermissions(_) => StatusCode::FORBIDDEN,
 
             // 404 Not Found
-            Self::NotFound(_)
-            | Self::TableNotFound { .. }
-            | Self::FunctionNotFound { .. }
-            | Self::ColumnNotFound(_)
-            | Self::RelationshipNotFound { .. } => StatusCode::NOT_FOUND,
+            Self::NotFound(_) | Self::TableNotFound { .. } | Self::FunctionNotFound { .. } => {
+                StatusCode::NOT_FOUND
+            }
+
+            // A relationship or a column the schema does not have is a fault
+            // in the request, not a missing resource: the resource addressed
+            // by the URL exists, and `?select=` asked it for something it
+            // cannot give. The table it names is what a 404 would be about.
+            Self::ColumnNotFound(_) | Self::RelationshipNotFound { .. } => StatusCode::BAD_REQUEST,
 
             // 405 Method Not Allowed
             Self::UnsupportedMethod(_) | Self::InvalidRpcMethod(_) | Self::InvalidPutFilters => {
@@ -330,7 +343,8 @@ impl Error {
             Self::InvalidRange(_) => StatusCode::RANGE_NOT_SATISFIABLE,
 
             // 500 Internal Server Error
-            Self::InvalidGucHeaders
+            Self::RaiseNotUnderstood(_)
+            | Self::InvalidGucHeaders
             | Self::InvalidGucStatus
             | Self::SchemaCacheNotLoaded
             | Self::SchemaCacheLoadFailed(_)
@@ -384,6 +398,7 @@ impl Error {
             Self::PutLimitNotAllowed => "PGRST114",
             Self::PutMatchingPk => "PGRST115",
             Self::MaxAffectedExceeded(_) => "PGRST124",
+            Self::RaiseNotUnderstood(_) => "PGRST121",
             Self::InvalidGucHeaders => "PGRST111",
             Self::InvalidGucStatus => "PGRST112",
             Self::RelatedOrderNotPossible { .. } => "PGRST118",
@@ -471,6 +486,7 @@ impl Error {
                 "Invalid preferences: {}",
                 invalid.join(", ")
             ))),
+            Self::RaiseNotUnderstood(fault) => Some(serde_json::Value::String(fault.details())),
             Self::FunctionNotFound {
                 name,
                 params,
@@ -517,6 +533,7 @@ impl Error {
                  overloading can be resolved"
                     .into(),
             ),
+            Self::RaiseNotUnderstood(fault) => Some(fault.hint().into()),
             // A body that is one value names no arguments, so there is no
             // near miss to point at: any function of that name would have
             // done, and none of them takes this body.
@@ -587,11 +604,49 @@ pub struct DatabaseError {
     pub column: Option<String>,
 }
 
+/// What was wrong with a `RAISE sqlstate 'PGRST'`.
+#[derive(Clone, Debug)]
+pub enum RaiseFault {
+    /// The MESSAGE was not the JSON object it has to be.
+    Message(String),
+    /// The DETAIL was not the JSON object it has to be.
+    Detail(String),
+    /// There was no DETAIL, and the status has to come from somewhere.
+    NoDetail,
+}
+
+impl RaiseFault {
+    /// What the schema author has to look at.
+    pub fn details(&self) -> String {
+        match self {
+            Self::Message(raw) => format!("Invalid JSON value for MESSAGE: '{}'", raw),
+            Self::Detail(raw) => format!("Invalid JSON value for DETAIL: '{}'", raw),
+            Self::NoDetail => "DETAIL is missing in the RAISE statement".to_string(),
+        }
+    }
+
+    /// What the document should have contained.
+    pub fn hint(&self) -> &'static str {
+        match self {
+            Self::Message(_) => {
+                "MESSAGE must be a JSON object with obligatory keys: 'code', 'message' and \
+                 optional keys: 'details', 'hint'."
+            }
+            _ => {
+                "DETAIL must be a JSON object with obligatory keys: 'status', 'headers' and \
+                 optional key: 'status_text'."
+            }
+        }
+    }
+}
+
 /// A response a database function asked for outright.
 #[derive(Clone, Debug)]
 pub struct RaisedResponse {
     /// The HTTP status to answer with.
     pub status: u16,
+    /// The reason phrase, where the schema named one of its own.
+    pub status_text: Option<String>,
     /// Headers to add to the response.
     pub headers: Vec<(String, String)>,
     /// The response body, verbatim.
@@ -606,33 +661,70 @@ impl DatabaseError {
     /// status text and any headers. It is how a schema returns a 402 with its
     /// own payload without the API layer knowing anything about billing.
     ///
-    /// `None` when this is not that error, or when either JSON does not parse
-    /// -- the latter is a fault in the schema, and reporting it as such is
-    /// more use than a half-applied response.
-    pub fn raised_response(&self) -> Option<RaisedResponse> {
+    /// `None` when this is not that error. `Err` when it is and the schema
+    /// wrote it wrongly, which is a bug in the schema rather than a response
+    /// to half-apply.
+    pub fn raised_response(&self) -> Option<std::result::Result<RaisedResponse, RaiseFault>> {
         if self.code != "PGRST" {
             return None;
         }
+        Some(self.parse_raise())
+    }
 
-        let body: serde_json::Value = serde_json::from_str(&self.message).ok()?;
-        let control: serde_json::Value =
-            serde_json::from_str(self.details.as_deref().unwrap_or("{}")).ok()?;
+    fn parse_raise(&self) -> std::result::Result<RaisedResponse, RaiseFault> {
+        let object = |raw: &str| -> Option<serde_json::Map<String, serde_json::Value>> {
+            match serde_json::from_str(raw) {
+                Ok(serde_json::Value::Object(map)) => Some(map),
+                _ => None,
+            }
+        };
 
-        Some(RaisedResponse {
-            status: control.get("status").and_then(serde_json::Value::as_u64)? as u16,
-            headers: control
-                .get("headers")
-                .and_then(serde_json::Value::as_object)
-                .map(|headers| {
-                    headers
-                        .iter()
-                        .filter_map(|(name, value)| {
-                            Some((name.clone(), value.as_str()?.to_string()))
-                        })
-                        .collect()
-                })
-                .unwrap_or_default(),
-            body,
+        // The message is the body, and a body has to say what went wrong and
+        // under what code -- the two keys a client reads first.
+        let message =
+            object(&self.message).ok_or_else(|| RaiseFault::Message(self.message.clone()))?;
+        if !message.contains_key("code") || !message.contains_key("message") {
+            return Err(RaiseFault::Message(self.message.clone()));
+        }
+
+        let raw_detail = self.details.as_deref().ok_or(RaiseFault::NoDetail)?;
+        let detail =
+            object(raw_detail).ok_or_else(|| RaiseFault::Detail(raw_detail.to_string()))?;
+        let status = detail
+            .get("status")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| RaiseFault::Detail(raw_detail.to_string()))?;
+        let headers = detail
+            .get("headers")
+            .and_then(serde_json::Value::as_object)
+            .ok_or_else(|| RaiseFault::Detail(raw_detail.to_string()))?;
+
+        // Every key the error body has, present whether the schema wrote it or
+        // not: a client reading `details` should not have to tell "no detail"
+        // from "no such key".
+        let key = |name: &str| {
+            message
+                .get(name)
+                .cloned()
+                .unwrap_or(serde_json::Value::Null)
+        };
+
+        Ok(RaisedResponse {
+            status: status as u16,
+            status_text: detail
+                .get("status_text")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string),
+            headers: headers
+                .iter()
+                .filter_map(|(name, value)| Some((name.clone(), value.as_str()?.to_string())))
+                .collect(),
+            body: serde_json::json!({
+                "code": key("code"),
+                "message": key("message"),
+                "details": key("details"),
+                "hint": key("hint"),
+            }),
         })
     }
 
@@ -649,10 +741,16 @@ impl DatabaseError {
         let code = self.code.as_str();
         let message = self.message.as_str();
 
-        if let Some(raised) = self.raised_response() {
-            if let Ok(status) = StatusCode::from_u16(raised.status) {
-                return status;
+        match self.raised_response() {
+            Some(Ok(raised)) => {
+                if let Ok(status) = StatusCode::from_u16(raised.status) {
+                    return status;
+                }
             }
+            // A raise the schema wrote wrongly is the schema's fault, and a
+            // fault in the server's own data is a 500.
+            Some(Err(_)) => return StatusCode::INTERNAL_SERVER_ERROR,
+            None => {}
         }
 
         // `PT<nnn>` is a status code raised by the schema itself: a function

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
     #[error("Unsupported HTTP method: {0}")]
     UnsupportedMethod(String),
 
+    /// A method a function cannot be called with.
+    ///
+    /// A function is invoked with GET, HEAD or POST. The others are refused
+    /// with a message that says so rather than one about the method in
+    /// general, since the method is fine elsewhere in the API.
+    #[error("Cannot use the {0} method on RPC")]
+    InvalidRpcMethod(String),
+
     /// A profile header named a schema the server does not expose.
     ///
     /// Carries the schemas that *are* exposed, because the client needs them
@@ -127,6 +135,12 @@ pub enum Error {
         params: Vec<String>,
         /// A signature that does exist, where one does.
         candidate: Option<String>,
+        /// Whether a single unnamed `json` parameter was also considered.
+        ///
+        /// It is, over `POST`, where the whole body can be one argument --
+        /// and the message says so, since it widens what would have matched.
+        #[allow(dead_code)]
+        single_json: bool,
     },
 
     #[error("Column not found: {0}")]
@@ -179,6 +193,21 @@ pub enum Error {
     /// A path with more segments than any resource has.
     #[error("Invalid path specified in request URL")]
     InvalidResourcePath,
+
+    /// A `PUT` whose filters do not name exactly one row by its key.
+    ///
+    /// `PUT` writes the row the URL names, so the URL has to name exactly one:
+    /// every primary key column, with `eq`, and nothing else.
+    #[error("Filters must include all and only primary key columns with 'eq' operators")]
+    InvalidPutFilters,
+
+    /// A `PUT` carrying a page.
+    #[error("limit/offset querystring parameters are not allowed for PUT")]
+    PutLimitNotAllowed,
+
+    /// A `PUT` whose body names a different row from its URL.
+    #[error("Payload values do not match URL in primary key column(s)")]
+    PutMatchingPk,
 
     /// Preferences the server does not know, sent with `handling=strict`.
     ///
@@ -239,6 +268,8 @@ impl Error {
             | Self::NotAnEmbeddedResource(_)
             | Self::RelatedOrderNotPossible { .. }
             | Self::InvalidPreferences(_)
+            | Self::PutLimitNotAllowed
+            | Self::PutMatchingPk
             | Self::InvalidPlan(_)
             | Self::EmbeddingError(_)
             | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
@@ -262,7 +293,9 @@ impl Error {
             | Self::RelationshipNotFound { .. } => StatusCode::NOT_FOUND,
 
             // 405 Method Not Allowed
-            Self::UnsupportedMethod(_) => StatusCode::METHOD_NOT_ALLOWED,
+            Self::UnsupportedMethod(_) | Self::InvalidRpcMethod(_) | Self::InvalidPutFilters => {
+                StatusCode::METHOD_NOT_ALLOWED
+            }
 
             // 406 Not Acceptable
             Self::UnacceptableSchema { .. } | Self::NotSingular { .. } => {
@@ -301,7 +334,8 @@ impl Error {
             // that did not parse, which is what PGRST100 covers.
             Self::InvalidHeader(_) => "PGRST100",
             Self::InvalidBody(_) => "PGRST102",
-            Self::UnsupportedMethod(_) => "PGRST104",
+            Self::UnsupportedMethod(_) => "PGRST117",
+            Self::InvalidRpcMethod(_) => "PGRST101",
             Self::UnacceptableSchema { .. } => "PGRST106",
             Self::UnknownColumn { .. } => "PGRST204",
             Self::InvalidRange(_) => "PGRST103",
@@ -324,6 +358,9 @@ impl Error {
             Self::NotAnEmbeddedResource(_) => "PGRST108",
             Self::NotSingular { .. } => "PGRST116",
             Self::InvalidResourcePath => "PGRST125",
+            Self::InvalidPutFilters => "PGRST105",
+            Self::PutLimitNotAllowed => "PGRST114",
+            Self::PutMatchingPk => "PGRST115",
             Self::RelatedOrderNotPossible { .. } => "PGRST118",
             Self::InvalidPreferences(_) => "PGRST122",
 
@@ -405,13 +442,20 @@ impl Error {
                 "Invalid preferences: {}",
                 invalid.join(", ")
             ))),
-            Self::FunctionNotFound { name, params, .. } => Some(serde_json::Value::String(
-                format!(
-                    "Searched for the function {} {}, but no matches were found in the schema cache.",
-                    name,
-                    describe_params(params)
-                ),
-            )),
+            Self::FunctionNotFound {
+                name,
+                params,
+                single_json,
+                ..
+            } => Some(serde_json::Value::String(format!(
+                "Searched for the function {} {}{}, but no matches were found in the schema cache.",
+                name,
+                describe_params(params),
+                match single_json {
+                    true => " or with a single unnamed json/jsonb parameter",
+                    false => "",
+                }
+            ))),
             _ => None,
         }
     }

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -86,8 +86,20 @@ pub enum Error {
     #[error("Table not found: {0}")]
     TableNotFound(String),
 
-    #[error("Function not found: {0}")]
-    FunctionNotFound(String),
+    /// No function of that name accepts the arguments supplied.
+    ///
+    /// Carries what was looked for so the client can see why nothing matched:
+    /// the name, the argument names it was called with, and the signature of
+    /// an overload that does exist, where one does.
+    #[error("Could not find the function {name}")]
+    FunctionNotFound {
+        /// The function's qualified name, without arguments.
+        name: String,
+        /// The argument names it was called with.
+        params: Vec<String>,
+        /// A signature that does exist, where one does.
+        candidate: Option<String>,
+    },
 
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
@@ -159,7 +171,7 @@ impl Error {
             // 404 Not Found
             Self::NotFound(_)
             | Self::TableNotFound(_)
-            | Self::FunctionNotFound(_)
+            | Self::FunctionNotFound { .. }
             | Self::ColumnNotFound(_)
             | Self::RelationshipNotFound(_) => StatusCode::NOT_FOUND,
 
@@ -207,7 +219,7 @@ impl Error {
 
             Self::NotFound(_) => "PGRST205",
             Self::TableNotFound(_) => "PGRST205",
-            Self::FunctionNotFound(_) => "PGRST202",
+            Self::FunctionNotFound { .. } => "PGRST202",
             Self::ColumnNotFound(_) => "PGRST204",
             Self::RelationshipNotFound(_) => "PGRST200",
 
@@ -236,9 +248,14 @@ impl Error {
     }
 
     /// Get additional details for the error.
-    fn details(&self) -> Option<String> {
+    pub fn details(&self) -> Option<String> {
         match self {
             Self::Database(db_err) => db_err.details.clone(),
+            Self::FunctionNotFound { name, params, .. } => Some(format!(
+                "Searched for the function {} {}, but no matches were found in the schema cache.",
+                name,
+                describe_params(params)
+            )),
             _ => None,
         }
     }
@@ -250,6 +267,9 @@ impl Error {
                 Some("Check that the JWT is properly signed and not expired".into())
             }
             Self::MissingAuth => Some("Provide a valid JWT in the Authorization header".into()),
+            Self::FunctionNotFound { candidate, .. } => candidate
+                .as_ref()
+                .map(|c| format!("Perhaps you meant to call the function {}", c)),
             // The schemas a server exposes are part of its contract, not an
             // internal detail, so naming them is how the client is told what
             // to ask for instead.
@@ -260,6 +280,25 @@ impl Error {
             Self::Database(db_err) => db_err.hint.clone(),
             _ => None,
         }
+    }
+}
+
+/// How a function's argument list reads in an error message.
+///
+/// PostgREST words the no-argument case differently rather than printing an
+/// empty list, and the messages are matched verbatim by clients.
+pub fn function_signature(name: &str, params: &[String]) -> String {
+    match params.is_empty() {
+        true => format!("{} without parameters", name),
+        false => format!("{}({})", name, params.join(", ")),
+    }
+}
+
+fn describe_params(params: &[String]) -> String {
+    match params.len() {
+        0 => "without parameters".to_string(),
+        1 => format!("with parameter {}", params[0]),
+        _ => format!("with parameters {}", params.join(", ")),
     }
 }
 

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -28,6 +28,25 @@ pub enum Error {
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParam(String),
 
+    /// A fragment of the query string the grammar could not read.
+    ///
+    /// Reported the way a parser reports: what was being read, the text as the
+    /// client wrote it, where reading stopped, and what would have been
+    /// accepted there. All four are the client's own input or the API's own
+    /// grammar, so none of it is a disclosure -- and without them the client
+    /// is told only that something in a URL it wrote is wrong.
+    #[error("\"failed to parse {kind} ({text})\" (line 1, column {column})")]
+    UnparsableQuery {
+        /// What was being read: `filter`, `logic tree`, `order`.
+        kind: &'static str,
+        /// The fragment, as it was written.
+        text: String,
+        /// Where reading stopped, counting from one.
+        column: usize,
+        /// What was found there and what would have been accepted.
+        expected: String,
+    },
+
     #[error("Invalid header: {0}")]
     InvalidHeader(&'static str),
 
@@ -292,6 +311,7 @@ impl Error {
             | Self::InvalidBody(_)
             | Self::MissingParameter(_)
             | Self::AmbiguousRequest(_)
+            | Self::UnparsableQuery { .. }
             | Self::UnknownColumn { .. }
             | Self::NotAnEmbeddedResource(_)
             | Self::RelatedOrderNotPossible { .. }
@@ -365,7 +385,7 @@ impl Error {
             // PGRST100 is the parse failure in PostgREST's taxonomy, covering
             // both the path and the query string; PGRST101 is a function
             // invoked with a method its volatility does not allow.
-            Self::InvalidQueryParam(_) => "PGRST100",
+            Self::InvalidQueryParam(_) | Self::UnparsableQuery { .. } => "PGRST100",
             // Not one of PostgREST's own: a malformed header is a request
             // that did not parse, which is what PGRST100 covers.
             Self::InvalidHeader(_) => "PGRST100",
@@ -487,6 +507,9 @@ impl Error {
                 invalid.join(", ")
             ))),
             Self::RaiseNotUnderstood(fault) => Some(serde_json::Value::String(fault.details())),
+            Self::UnparsableQuery { expected, .. } => {
+                Some(serde_json::Value::String(expected.clone()))
+            }
             Self::FunctionNotFound {
                 name,
                 params,

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -117,6 +117,19 @@ pub enum Error {
     #[error("{0}")]
     InvalidJwt(String),
 
+    /// No key this server holds could decode the token.
+    ///
+    /// Its own code would be indistinguishable from any other decode failure,
+    /// so what separates it is the detail: the client is being told to look at
+    /// which key signed the token, not at the token's contents.
+    #[error("No suitable key or wrong key type")]
+    NoSuitableJwtKey,
+
+    /// The server is configured to read tokens and has nothing to read them
+    /// with. A fault in the deployment, not in the request.
+    #[error("Server lacks JWT secret")]
+    JwtSecretMissing,
+
     /// The token decoded, but a claim was missing, malformed or unsatisfied.
     #[error("{0}")]
     JwtClaim(String),
@@ -329,7 +342,10 @@ impl Error {
             }
 
             // 401 Unauthorized
-            Self::InvalidJwt(_) | Self::JwtClaim(_) | Self::MissingAuth => StatusCode::UNAUTHORIZED,
+            Self::InvalidJwt(_)
+            | Self::NoSuitableJwtKey
+            | Self::JwtClaim(_)
+            | Self::MissingAuth => StatusCode::UNAUTHORIZED,
 
             // 403 Forbidden
             Self::InsufficientPermissions(_) => StatusCode::FORBIDDEN,
@@ -363,7 +379,8 @@ impl Error {
             Self::InvalidRange(_) => StatusCode::RANGE_NOT_SATISFIABLE,
 
             // 500 Internal Server Error
-            Self::RaiseNotUnderstood(_)
+            Self::JwtSecretMissing
+            | Self::RaiseNotUnderstood(_)
             | Self::InvalidGucHeaders
             | Self::InvalidGucStatus
             | Self::SchemaCacheNotLoaded
@@ -401,7 +418,8 @@ impl Error {
             Self::AmbiguousFunction { .. } => "PGRST203",
             Self::AmbiguousRelationship { .. } => "PGRST201",
 
-            Self::InvalidJwt(_) => "PGRST301",
+            Self::InvalidJwt(_) | Self::NoSuitableJwtKey => "PGRST301",
+            Self::JwtSecretMissing => "PGRST300",
             Self::JwtClaim(_) => "PGRST303",
             Self::MissingAuth => "PGRST302",
             Self::InsufficientPermissions(_) => "PGRST203",
@@ -507,6 +525,9 @@ impl Error {
                 invalid.join(", ")
             ))),
             Self::RaiseNotUnderstood(fault) => Some(serde_json::Value::String(fault.details())),
+            Self::NoSuitableJwtKey => Some(serde_json::Value::String(
+                "No suitable key was found to decode the JWT".into(),
+            )),
             Self::UnparsableQuery { expected, .. } => {
                 Some(serde_json::Value::String(expected.clone()))
             }

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -105,6 +105,8 @@ pub enum Error {
         target: String,
         /// Each candidate as `(cardinality, description)`.
         candidates: Vec<(String, String)>,
+        /// How the client would name each candidate: `big_projects!jobs`.
+        disambiguated: Vec<String>,
     },
 
     // ========================================================================
@@ -476,6 +478,7 @@ impl Error {
                 origin,
                 target,
                 candidates,
+                ..
             } => Some(serde_json::Value::Array(
                 candidates
                     .iter()
@@ -577,6 +580,20 @@ impl Error {
                  overloading can be resolved"
                     .into(),
             ),
+            Self::AmbiguousRelationship {
+                target,
+                disambiguated,
+                ..
+            } => Some(format!(
+                "Try changing '{}' to one of the following: {}. Find the desired relationship in \
+                 the 'details' key.",
+                target,
+                disambiguated
+                    .iter()
+                    .map(|name| format!("'{}'", name))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )),
             Self::RaiseNotUnderstood(fault) => Some(fault.hint().into()),
             // A body that is one value names no arguments, so there is no
             // near miss to point at: any function of that name would have

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -66,6 +66,15 @@ pub enum Error {
     #[error("Could not choose the best candidate function between: {}", .candidates.join(", "))]
     AmbiguousFunction { candidates: Vec<String> },
 
+    /// Several relationships connect the two resources and none was named.
+    #[error("Could not embed because more than one relationship was found for '{origin}' and '{target}'")]
+    AmbiguousRelationship {
+        origin: String,
+        target: String,
+        /// Each candidate as `(cardinality, description)`.
+        candidates: Vec<(String, String)>,
+    },
+
     // ========================================================================
     // Authentication/Authorization Errors (401/403)
     // ========================================================================
@@ -167,7 +176,9 @@ impl Error {
             | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
 
             // The request names something real, but not which one of it.
-            Self::AmbiguousFunction { .. } => StatusCode::MULTIPLE_CHOICES,
+            Self::AmbiguousFunction { .. } | Self::AmbiguousRelationship { .. } => {
+                StatusCode::MULTIPLE_CHOICES
+            }
 
             // 401 Unauthorized
             Self::InvalidJwt(_) | Self::JwtExpired | Self::MissingAuth => StatusCode::UNAUTHORIZED,
@@ -219,6 +230,7 @@ impl Error {
             Self::MissingParameter(_) => "PGRST109",
             Self::AmbiguousRequest(_) => "PGRST110",
             Self::AmbiguousFunction { .. } => "PGRST203",
+            Self::AmbiguousRelationship { .. } => "PGRST201",
 
             Self::InvalidJwt(_) => "PGRST303",
             Self::JwtExpired => "PGRST301",
@@ -256,13 +268,33 @@ impl Error {
     }
 
     /// Get additional details for the error.
-    pub fn details(&self) -> Option<String> {
+    pub fn details(&self) -> Option<serde_json::Value> {
         match self {
-            Self::Database(db_err) => db_err.details.clone(),
-            Self::FunctionNotFound { name, params, .. } => Some(format!(
-                "Searched for the function {} {}, but no matches were found in the schema cache.",
-                name,
-                describe_params(params)
+            Self::Database(db_err) => db_err.details.clone().map(serde_json::Value::String),
+            // A structured list rather than a sentence: each candidate is
+            // named so the client can pick one and say which.
+            Self::AmbiguousRelationship {
+                origin,
+                target,
+                candidates,
+            } => Some(serde_json::Value::Array(
+                candidates
+                    .iter()
+                    .map(|(cardinality, description)| {
+                        serde_json::json!({
+                            "cardinality": cardinality,
+                            "embedding": format!("{} with {}", origin, target),
+                            "relationship": description,
+                        })
+                    })
+                    .collect(),
+            )),
+            Self::FunctionNotFound { name, params, .. } => Some(serde_json::Value::String(
+                format!(
+                    "Searched for the function {} {}, but no matches were found in the schema cache.",
+                    name,
+                    describe_params(params)
+                ),
             )),
             _ => None,
         }

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -209,6 +209,13 @@ pub enum Error {
     #[error("Payload values do not match URL in primary key column(s)")]
     PutMatchingPk,
 
+    /// A mutation touched more rows than `Prefer: max-affected` allowed.
+    ///
+    /// The preference is a guard against a filter that turned out to match
+    /// more than the client meant; nothing is committed when it trips.
+    #[error("Query result exceeds max-affected preference constraint")]
+    MaxAffectedExceeded(i64),
+
     /// Preferences the server does not know, sent with `handling=strict`.
     ///
     /// Strict handling is a request to be told rather than have them ignored.
@@ -270,6 +277,7 @@ impl Error {
             | Self::InvalidPreferences(_)
             | Self::PutLimitNotAllowed
             | Self::PutMatchingPk
+            | Self::MaxAffectedExceeded(_)
             | Self::InvalidPlan(_)
             | Self::EmbeddingError(_)
             | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
@@ -361,6 +369,7 @@ impl Error {
             Self::InvalidPutFilters => "PGRST105",
             Self::PutLimitNotAllowed => "PGRST114",
             Self::PutMatchingPk => "PGRST115",
+            Self::MaxAffectedExceeded(_) => "PGRST124",
             Self::RelatedOrderNotPossible { .. } => "PGRST118",
             Self::InvalidPreferences(_) => "PGRST122",
 
@@ -434,6 +443,10 @@ impl Error {
                 )))
             }
             Self::InvalidRange(reason) => Some(serde_json::Value::String(reason.clone())),
+            Self::MaxAffectedExceeded(affected) => Some(serde_json::Value::String(format!(
+                "The query affects {} rows",
+                affected
+            ))),
             Self::NotSingular { rows } => Some(serde_json::Value::String(format!(
                 "The result contains {} rows",
                 rows

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -66,7 +66,7 @@ pub enum Error {
     #[error("Requested range not satisfiable")]
     InvalidRange(String),
 
-    #[error("Invalid media type: {0}")]
+    #[error("None of these media types are available: {0}")]
     InvalidMediaType(String),
 
     #[error("Missing required parameter: {0}")]
@@ -268,7 +268,6 @@ impl Error {
             | Self::InvalidQueryParam(_)
             | Self::InvalidHeader(_)
             | Self::InvalidBody(_)
-            | Self::InvalidMediaType(_)
             | Self::MissingParameter(_)
             | Self::AmbiguousRequest(_)
             | Self::UnknownColumn { .. }
@@ -306,9 +305,9 @@ impl Error {
             }
 
             // 406 Not Acceptable
-            Self::UnacceptableSchema { .. } | Self::NotSingular { .. } => {
-                StatusCode::NOT_ACCEPTABLE
-            }
+            Self::UnacceptableSchema { .. }
+            | Self::NotSingular { .. }
+            | Self::InvalidMediaType(_) => StatusCode::NOT_ACCEPTABLE,
 
             Self::InvalidResourcePath => StatusCode::NOT_FOUND,
 

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -37,8 +37,15 @@ pub enum Error {
     #[error("Unsupported HTTP method: {0}")]
     UnsupportedMethod(String),
 
-    #[error("Unacceptable schema: {0}")]
-    UnacceptableSchema(String),
+    /// A profile header named a schema the server does not expose.
+    ///
+    /// Carries the schemas that *are* exposed, because the client needs them
+    /// to correct the request and they are part of the API's own contract.
+    #[error("Invalid schema: {requested}")]
+    UnacceptableSchema {
+        requested: String,
+        exposed: Vec<String>,
+    },
 
     #[error("Unknown column: {0}")]
     UnknownColumn(String),
@@ -160,7 +167,7 @@ impl Error {
             Self::UnsupportedMethod(_) => StatusCode::METHOD_NOT_ALLOWED,
 
             // 406 Not Acceptable
-            Self::UnacceptableSchema(_) => StatusCode::NOT_ACCEPTABLE,
+            Self::UnacceptableSchema { .. } => StatusCode::NOT_ACCEPTABLE,
 
             // 500 Internal Server Error
             Self::SchemaCacheNotLoaded
@@ -186,23 +193,23 @@ impl Error {
             Self::InvalidHeader(_) => "PGRST102",
             Self::InvalidBody(_) => "PGRST103",
             Self::UnsupportedMethod(_) => "PGRST104",
-            Self::UnacceptableSchema(_) => "PGRST105",
-            Self::UnknownColumn(_) => "PGRST106",
+            Self::UnacceptableSchema { .. } => "PGRST106",
+            Self::UnknownColumn(_) => "PGRST204",
             Self::InvalidRange(_) => "PGRST107",
             Self::InvalidMediaType(_) => "PGRST108",
             Self::MissingParameter(_) => "PGRST109",
             Self::AmbiguousRequest(_) => "PGRST110",
 
-            Self::InvalidJwt(_) => "PGRST200",
-            Self::JwtExpired => "PGRST201",
-            Self::MissingAuth => "PGRST202",
+            Self::InvalidJwt(_) => "PGRST303",
+            Self::JwtExpired => "PGRST301",
+            Self::MissingAuth => "PGRST302",
             Self::InsufficientPermissions(_) => "PGRST203",
 
-            Self::NotFound(_) => "PGRST300",
-            Self::TableNotFound(_) => "PGRST301",
-            Self::FunctionNotFound(_) => "PGRST302",
-            Self::ColumnNotFound(_) => "PGRST303",
-            Self::RelationshipNotFound(_) => "PGRST304",
+            Self::NotFound(_) => "PGRST205",
+            Self::TableNotFound(_) => "PGRST205",
+            Self::FunctionNotFound(_) => "PGRST202",
+            Self::ColumnNotFound(_) => "PGRST204",
+            Self::RelationshipNotFound(_) => "PGRST200",
 
             Self::SchemaCacheNotLoaded => "PGRST400",
             Self::SchemaCacheLoadFailed(_) => "PGRST401",
@@ -237,14 +244,19 @@ impl Error {
     }
 
     /// Get a hint for resolving the error.
-    fn hint(&self) -> Option<String> {
+    pub fn hint(&self) -> Option<String> {
         match self {
             Self::InvalidJwt(_) => {
                 Some("Check that the JWT is properly signed and not expired".into())
             }
             Self::MissingAuth => Some("Provide a valid JWT in the Authorization header".into()),
-            Self::TableNotFound(_) => Some("Check the table name and schema".into()),
-            Self::UnknownColumn(_) => Some("Check column names against the table schema".into()),
+            // The schemas a server exposes are part of its contract, not an
+            // internal detail, so naming them is how the client is told what
+            // to ask for instead.
+            Self::UnacceptableSchema { exposed, .. } => Some(format!(
+                "Only the following schemas are exposed: {}",
+                exposed.join(", ")
+            )),
             Self::Database(db_err) => db_err.hint.clone(),
             _ => None,
         }
@@ -328,8 +340,8 @@ mod tests {
         // A malformed query string is a parse failure, PGRST100 -- the same
         // code as a malformed path. PGRST101 means something else entirely.
         assert_eq!(Error::InvalidQueryParam("test".into()).code(), "PGRST100");
-        assert_eq!(Error::MissingAuth.code(), "PGRST202");
-        assert_eq!(Error::TableNotFound("users".into()).code(), "PGRST301");
+        assert_eq!(Error::MissingAuth.code(), "PGRST302");
+        assert_eq!(Error::TableNotFound("users".into()).code(), "PGRST205");
     }
 
     #[test]

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -209,6 +209,17 @@ pub enum Error {
     #[error("Payload values do not match URL in primary key column(s)")]
     PutMatchingPk,
 
+    /// A function set `response.headers` to something that is not headers.
+    #[error(
+        "response.headers guc must be a JSON array composed of objects with a single key and a \
+         string value"
+    )]
+    InvalidGucHeaders,
+
+    /// A function set `response.status` to something that is not a status.
+    #[error("response.status guc must be a valid status code")]
+    InvalidGucStatus,
+
     /// A mutation touched more rows than `Prefer: max-affected` allowed.
     ///
     /// The preference is a guard against a filter that turned out to match
@@ -317,7 +328,9 @@ impl Error {
             Self::InvalidRange(_) => StatusCode::RANGE_NOT_SATISFIABLE,
 
             // 500 Internal Server Error
-            Self::SchemaCacheNotLoaded
+            Self::InvalidGucHeaders
+            | Self::InvalidGucStatus
+            | Self::SchemaCacheNotLoaded
             | Self::SchemaCacheLoadFailed(_)
             | Self::ConnectionPool(_)
             | Self::Internal(_)
@@ -369,6 +382,8 @@ impl Error {
             Self::PutLimitNotAllowed => "PGRST114",
             Self::PutMatchingPk => "PGRST115",
             Self::MaxAffectedExceeded(_) => "PGRST124",
+            Self::InvalidGucHeaders => "PGRST111",
+            Self::InvalidGucStatus => "PGRST112",
             Self::RelatedOrderNotPossible { .. } => "PGRST118",
             Self::InvalidPreferences(_) => "PGRST122",
 

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("Invalid header: {0}")]
     InvalidHeader(&'static str),
 
-    #[error("Invalid request body: {0}")]
+    #[error("{0}")]
     InvalidBody(String),
 
     #[error("Unsupported HTTP method: {0}")]
@@ -47,8 +47,13 @@ pub enum Error {
         exposed: Vec<String>,
     },
 
-    #[error("Unknown column: {0}")]
-    UnknownColumn(String),
+    #[error("Could not find the '{column}' column of '{relation}' in the schema cache")]
+    UnknownColumn {
+        /// The column the request named.
+        column: String,
+        /// The relation it was looked for on.
+        relation: String,
+    },
 
     #[error("Requested range not satisfiable")]
     InvalidRange(String),
@@ -230,7 +235,7 @@ impl Error {
             | Self::InvalidMediaType(_)
             | Self::MissingParameter(_)
             | Self::AmbiguousRequest(_)
-            | Self::UnknownColumn(_)
+            | Self::UnknownColumn { .. }
             | Self::NotAnEmbeddedResource(_)
             | Self::RelatedOrderNotPossible { .. }
             | Self::InvalidPreferences(_)
@@ -292,13 +297,15 @@ impl Error {
             // both the path and the query string; PGRST101 is a function
             // invoked with a method its volatility does not allow.
             Self::InvalidQueryParam(_) => "PGRST100",
-            Self::InvalidHeader(_) => "PGRST102",
-            Self::InvalidBody(_) => "PGRST103",
+            // Not one of PostgREST's own: a malformed header is a request
+            // that did not parse, which is what PGRST100 covers.
+            Self::InvalidHeader(_) => "PGRST100",
+            Self::InvalidBody(_) => "PGRST102",
             Self::UnsupportedMethod(_) => "PGRST104",
             Self::UnacceptableSchema { .. } => "PGRST106",
-            Self::UnknownColumn(_) => "PGRST204",
+            Self::UnknownColumn { .. } => "PGRST204",
             Self::InvalidRange(_) => "PGRST103",
-            Self::InvalidMediaType(_) => "PGRST108",
+            Self::InvalidMediaType(_) => "PGRST107",
             Self::MissingParameter(_) => "PGRST109",
             Self::AmbiguousRequest(_) => "PGRST110",
             Self::AmbiguousFunction { .. } => "PGRST203",

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -179,7 +179,10 @@ impl Error {
         match self {
             Self::InvalidPath(_) => "PGRST100",
             Self::AggregatesNotAllowed => "PGRST123",
-            Self::InvalidQueryParam(_) => "PGRST101",
+            // PGRST100 is the parse failure in PostgREST's taxonomy, covering
+            // both the path and the query string; PGRST101 is a function
+            // invoked with a method its volatility does not allow.
+            Self::InvalidQueryParam(_) => "PGRST100",
             Self::InvalidHeader(_) => "PGRST102",
             Self::InvalidBody(_) => "PGRST103",
             Self::UnsupportedMethod(_) => "PGRST104",
@@ -266,6 +269,9 @@ impl DatabaseError {
     pub fn status_code(&self) -> StatusCode {
         // PostgreSQL error codes: https://www.postgresql.org/docs/current/errcodes-appendix.html
         match self.code.as_str() {
+            // A write attempted inside the read-only transaction a read
+            // request runs in. The request was not wrong, the method was.
+            "25006" => StatusCode::METHOD_NOT_ALLOWED,
             // Class 23 - Integrity Constraint Violation
             c if c.starts_with("23") => StatusCode::CONFLICT,
             // Class 42 - Syntax Error or Access Rule Violation
@@ -319,7 +325,9 @@ mod tests {
 
     #[test]
     fn test_error_codes() {
-        assert_eq!(Error::InvalidQueryParam("test".into()).code(), "PGRST101");
+        // A malformed query string is a parse failure, PGRST100 -- the same
+        // code as a malformed path. PGRST101 means something else entirely.
+        assert_eq!(Error::InvalidQueryParam("test".into()).code(), "PGRST100");
         assert_eq!(Error::MissingAuth.code(), "PGRST202");
         assert_eq!(Error::TableNotFound("users".into()).code(), "PGRST301");
     }
@@ -342,7 +350,7 @@ mod tests {
     fn test_error_to_json() {
         let error = Error::InvalidQueryParam("bad filter".into());
         let json = error.to_json();
-        assert_eq!(json["code"], "PGRST101");
+        assert_eq!(json["code"], "PGRST100");
         assert!(json["message"].as_str().unwrap().contains("bad filter"));
     }
 }

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -62,6 +62,10 @@ pub enum Error {
     #[error("Ambiguous request: {0}")]
     AmbiguousRequest(String),
 
+    /// Several signatures of a function fit the arguments equally well.
+    #[error("Could not choose the best candidate function between: {}", .candidates.join(", "))]
+    AmbiguousFunction { candidates: Vec<String> },
+
     // ========================================================================
     // Authentication/Authorization Errors (401/403)
     // ========================================================================
@@ -162,6 +166,9 @@ impl Error {
             | Self::EmbeddingError(_)
             | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
 
+            // The request names something real, but not which one of it.
+            Self::AmbiguousFunction { .. } => StatusCode::MULTIPLE_CHOICES,
+
             // 401 Unauthorized
             Self::InvalidJwt(_) | Self::JwtExpired | Self::MissingAuth => StatusCode::UNAUTHORIZED,
 
@@ -211,6 +218,7 @@ impl Error {
             Self::InvalidMediaType(_) => "PGRST108",
             Self::MissingParameter(_) => "PGRST109",
             Self::AmbiguousRequest(_) => "PGRST110",
+            Self::AmbiguousFunction { .. } => "PGRST203",
 
             Self::InvalidJwt(_) => "PGRST303",
             Self::JwtExpired => "PGRST301",
@@ -267,6 +275,11 @@ impl Error {
                 Some("Check that the JWT is properly signed and not expired".into())
             }
             Self::MissingAuth => Some("Provide a valid JWT in the Authorization header".into()),
+            Self::AmbiguousFunction { .. } => Some(
+                "Try renaming the parameters or the function itself in the database so function \
+                 overloading can be resolved"
+                    .into(),
+            ),
             Self::FunctionNotFound { candidate, .. } => candidate
                 .as_ref()
                 .map(|c| format!("Perhaps you meant to call the function {}", c)),

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -188,6 +188,14 @@ pub enum Error {
     #[error("Could not parse JSON in the \"RAISE SQLSTATE 'PGRST'\" error")]
     RaiseNotUnderstood(RaiseFault),
 
+    /// `Accept: application/geo+json` on rows that carry no geometry.
+    ///
+    /// PostGIS raises this from `ST_AsGeoJSON` on a record with no geometry
+    /// column, and it is a database error rather than one of PostgREST's own
+    /// -- so it keeps the SQLSTATE it came with.
+    #[error("geometry column is missing")]
+    MissingGeometryColumn,
+
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
 
@@ -336,7 +344,8 @@ impl Error {
             | Self::MaxAffectedExceeded(_)
             | Self::InvalidPlan(_)
             | Self::EmbeddingError(_)
-            | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
+            | Self::AggregatesNotAllowed
+            | Self::MissingGeometryColumn => StatusCode::BAD_REQUEST,
 
             // The request names something real, but not which one of it.
             Self::AmbiguousFunction { .. } | Self::AmbiguousRelationship { .. } => {
@@ -429,6 +438,7 @@ impl Error {
             Self::NotFound(_) => "PGRST205",
             Self::TableNotFound { .. } => "PGRST205",
             Self::FunctionNotFound { .. } => "PGRST202",
+            Self::MissingGeometryColumn => "22023",
             Self::ColumnNotFound(_) => "PGRST204",
             Self::RelationshipNotFound { .. } => "PGRST200",
             Self::NotAnEmbeddedResource(_) => "PGRST108",

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -17,6 +17,14 @@ pub enum Error {
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 
+    /// An aggregate was requested while `db-aggregates-enabled` is off.
+    ///
+    /// Off is the default, matching PostgREST: an unrestricted aggregate over
+    /// a large table is an easy way to make a server do far more work than the
+    /// request looks like it asks for.
+    #[error("Use of aggregate functions is not allowed")]
+    AggregatesNotAllowed,
+
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParam(String),
 
@@ -132,7 +140,8 @@ impl Error {
             | Self::AmbiguousRequest(_)
             | Self::UnknownColumn(_)
             | Self::InvalidPlan(_)
-            | Self::EmbeddingError(_) => StatusCode::BAD_REQUEST,
+            | Self::EmbeddingError(_)
+            | Self::AggregatesNotAllowed => StatusCode::BAD_REQUEST,
 
             // 401 Unauthorized
             Self::InvalidJwt(_) | Self::JwtExpired | Self::MissingAuth => StatusCode::UNAUTHORIZED,
@@ -169,6 +178,7 @@ impl Error {
     pub fn code(&self) -> &'static str {
         match self {
             Self::InvalidPath(_) => "PGRST100",
+            Self::AggregatesNotAllowed => "PGRST123",
             Self::InvalidQueryParam(_) => "PGRST101",
             Self::InvalidHeader(_) => "PGRST102",
             Self::InvalidBody(_) => "PGRST103",

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -57,6 +57,10 @@ pub struct CallPlan {
     /// want as JSON.
     #[serde(default)]
     pub media_type: Option<String>,
+    /// The type that domain is a domain over -- what says whether the value
+    /// is bytes or text.
+    #[serde(default)]
+    pub media_base_type: Option<String>,
     /// The columns the result has, where the function declares its own.
     ///
     /// `RETURNS TABLE(a text, b colour)` has no table to read the result's
@@ -128,7 +132,8 @@ impl CallPlan {
                 .iter()
                 .map(|p| (p.name.clone(), p.type_max_length.clone()))
                 .collect(),
-            media_type: routine.produced_media_type().map(str::to_string),
+            media_type: routine.media_type.clone(),
+            media_base_type: routine.media_base_type.clone(),
             output_columns: routine.output_columns.clone(),
             variadic_params: routine
                 .params
@@ -381,6 +386,7 @@ mod tests {
         Routine {
             output_columns: Vec::new(),
             media_type: None,
+            media_base_type: None,
             schema: "public".into(),
             name: "get_users".into(),
             description: None,

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -22,6 +22,13 @@ pub struct CallPlan {
     pub return_type: Option<String>,
     /// Whether the function is set-returning
     pub returns_set: bool,
+    /// Whether the function returns nothing at all.
+    ///
+    /// A `void` function has no result to report, which is 204 rather than a
+    /// body of `null` -- and `RetType::Void` has no type name, so asking for
+    /// one would never find it.
+    #[serde(default)]
+    pub returns_void: bool,
     /// Whether the return type is composite (row type or `record`): its
     /// columns are real output columns, never the function-name wrapper.
     #[serde(default)]
@@ -72,6 +79,7 @@ impl CallPlan {
             returns_scalar,
             return_type: routine.return_type.type_name().map(str::to_string),
             returns_set: routine.return_type.is_set_returning(),
+            returns_void: matches!(routine.return_type, crate::schema_cache::RetType::Void),
             returns_composite: routine.returns_composite,
             volatility: format!("{:?}", routine.volatility),
             param_types: routine

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -42,6 +42,10 @@ pub struct CallPlan {
     /// as `text` leaves PostgreSQL unable to resolve any signature that isn't
     /// text -- `add_them(a => text, b => text) does not exist` -- so each one
     /// is cast to its declared type at call time.
+    ///
+    /// The type is the one an argument can be cast to without losing part of
+    /// itself: a `char(4)` parameter is stored as bare `character`, whose
+    /// length is one, and a parameter's length is not enforced anyway.
     #[serde(default)]
     pub param_types: Vec<(String, String)>,
     /// The names of the parameters declared `VARIADIC`.
@@ -62,6 +66,19 @@ pub enum CallParams {
     Positional(Vec<String>),
     /// Single JSON object passed as first argument
     SingleObject(bytes::Bytes),
+    /// The whole request body, as the one parameter the function does not name.
+    ///
+    /// `unnamed_json_param(json)` declares a parameter with no name, so no
+    /// argument can be addressed to it; what it takes is the body itself,
+    /// cast to the type it declares. An absent body is that parameter's
+    /// `NULL`, not a call with no arguments -- the function has one either
+    /// way.
+    SingleUnnamed {
+        /// The raw body, absent when the request had none.
+        body: Option<bytes::Bytes>,
+        /// The type the parameter declares, which the body is cast to.
+        pg_type: String,
+    },
     /// No parameters
     None,
 }
@@ -92,7 +109,7 @@ impl CallPlan {
             param_types: routine
                 .params
                 .iter()
-                .map(|p| (p.name.clone(), p.param_type.clone()))
+                .map(|p| (p.name.clone(), p.type_max_length.clone()))
                 .collect(),
             variadic_params: routine
                 .params
@@ -111,6 +128,23 @@ impl CallPlan {
 
 /// Extract call parameters from request.
 fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallParams> {
+    // A parameter with no name cannot be given an argument by name. What such
+    // a function takes is the body itself, whatever the body says.
+    if let [param] = routine.params.as_slice() {
+        if param.name.is_empty() {
+            let body = match &request.payload {
+                Some(Payload::ProcessedJson { raw, .. })
+                | Some(Payload::RawJson(raw))
+                | Some(Payload::RawPayload(raw)) => Some(raw.clone()),
+                Some(Payload::ProcessedUrlEncoded { .. }) | None => None,
+            };
+            return Ok(CallParams::SingleUnnamed {
+                body,
+                pg_type: param.param_type.clone(),
+            });
+        }
+    }
+
     // Check for JSON body first
     if let Some(payload) = &request.payload {
         match payload {

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -44,6 +44,13 @@ pub struct CallPlan {
     /// is cast to its declared type at call time.
     #[serde(default)]
     pub param_types: Vec<(String, String)>,
+    /// The names of the parameters declared `VARIADIC`.
+    ///
+    /// Named notation spells one `VARIADIC v := ...`; `v => ...` finds no
+    /// function at all, because the array is the whole of the variadic tail
+    /// rather than one value of it.
+    #[serde(default)]
+    pub variadic_params: Vec<String>,
 }
 
 /// How parameters are passed to the function.
@@ -87,6 +94,12 @@ impl CallPlan {
                 .iter()
                 .map(|p| (p.name.clone(), p.param_type.clone()))
                 .collect(),
+            variadic_params: routine
+                .params
+                .iter()
+                .filter(|p| p.variadic)
+                .map(|p| p.name.clone())
+                .collect(),
         })
     }
 
@@ -106,8 +119,37 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
                 let value: serde_json::Value =
                     serde_json::from_slice(raw).map_err(|e| Error::InvalidBody(e.to_string()))?;
 
+                // A call takes one set of arguments. A body written as an
+                // array offers several, and PostgREST reads the first --
+                // `LIMIT 1` over the record set it makes of the body.
+                let value = match value {
+                    serde_json::Value::Array(rows)
+                        if rows.first().is_some_and(serde_json::Value::is_object) =>
+                    {
+                        rows.into_iter().next().unwrap_or(serde_json::Value::Null)
+                    }
+                    other => other,
+                };
+
                 match value {
                     serde_json::Value::Object(map) => {
+                        // `?columns=` names which of the body's keys are
+                        // arguments, and a key the function does not declare
+                        // is not one -- the body may carry more than the call
+                        // needs.
+                        let map: serde_json::Map<String, serde_json::Value> = map
+                            .into_iter()
+                            .filter(|(name, _)| {
+                                request
+                                    .query_params
+                                    .columns
+                                    .as_ref()
+                                    .map(|columns| columns.contains(name))
+                                    .unwrap_or(true)
+                                    && routine.params.iter().any(|p| &p.name == name)
+                            })
+                            .collect();
+
                         // Named parameters from JSON object
                         let params: Vec<(String, String)> = map
                             .into_iter()
@@ -154,8 +196,14 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
                 }
             }
             Payload::ProcessedUrlEncoded { data, .. } => {
-                // Named parameters from form data
-                return Ok(CallParams::Named(data.clone()));
+                // A form body is named arguments like any other, repeats and
+                // all: the same name twice is one variadic argument or the
+                // last of them, never two arguments.
+                return Ok(named_arguments(
+                    data.iter()
+                        .map(|(name, value)| (name.clone(), value.clone())),
+                    routine,
+                ));
             }
             Payload::RawJson(raw) | Payload::RawPayload(raw) => {
                 return Ok(CallParams::SingleObject(raw.clone()));
@@ -206,6 +254,46 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
 
     // No parameters
     Ok(CallParams::None)
+}
+
+/// Group named arguments, collapsing repeats the way a call must.
+///
+/// A name given more than once is one argument, not two: for a variadic
+/// parameter every value goes into the array it takes, and for any other the
+/// last one wins -- repeating it cannot mean asking for two values where the
+/// signature has room for one. Names the function does not declare are left
+/// out; the body may carry more than the call needs.
+fn named_arguments(
+    supplied: impl IntoIterator<Item = (String, String)>,
+    routine: &Routine,
+) -> CallParams {
+    let mut grouped: Vec<(String, Vec<String>)> = Vec::new();
+    for (name, value) in supplied {
+        if !routine.params.iter().any(|p| p.name == name) {
+            continue;
+        }
+        match grouped.iter_mut().find(|(existing, _)| *existing == name) {
+            Some((_, values)) => values.push(value),
+            None => grouped.push((name, vec![value])),
+        }
+    }
+
+    let args: Vec<(String, String)> = grouped
+        .into_iter()
+        .map(|(name, values)| {
+            let variadic = routine.params.iter().any(|p| p.name == name && p.variadic);
+            let value = match variadic {
+                true => array_literal(&values),
+                false => values.last().cloned().unwrap_or_default(),
+            };
+            (name, value)
+        })
+        .collect();
+
+    match args.is_empty() {
+        true => CallParams::None,
+        false => CallParams::Named(args),
+    }
 }
 
 /// Render values as a PostgreSQL array literal.

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -139,12 +139,36 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
     // are arguments -- the rest are filters on the function's result, which
     // is how `/rpc/getallprojects?id=eq.1` filters rather than failing.
     if !request.query_params.params.is_empty() {
-        let args: Vec<(String, String)> = request
-            .query_params
-            .params
-            .iter()
-            .filter(|(name, _)| routine.params.iter().any(|p| &p.name == name))
-            .cloned()
+        let mut args: Vec<(String, Vec<String>)> = Vec::new();
+        for (name, value) in &request.query_params.params {
+            // A value carrying an operator filters the result; only a bare
+            // one is an argument. `?id=5&id=gt.2` is both at once.
+            if crate::api_request::value_is_filter(value) {
+                continue;
+            }
+            if !routine.params.iter().any(|p| &p.name == name) {
+                continue;
+            }
+            match args.iter_mut().find(|(existing, _)| existing == name) {
+                Some((_, values)) => values.push(value.clone()),
+                None => args.push((name.clone(), vec![value.clone()])),
+            }
+        }
+
+        // A name given more than once is one argument, not two: for a
+        // variadic parameter every value goes into the array it takes, and
+        // for any other the last one wins -- repeating it cannot mean asking
+        // for two values where the signature has room for one.
+        let args: Vec<(String, String)> = args
+            .into_iter()
+            .map(|(name, values)| {
+                let variadic = routine.params.iter().any(|p| p.name == name && p.variadic);
+                let value = match variadic {
+                    true => array_literal(&values),
+                    false => values.last().cloned().unwrap_or_default(),
+                };
+                (name, value)
+            })
             .collect();
 
         if !args.is_empty() {
@@ -154,6 +178,19 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
 
     // No parameters
     Ok(CallParams::None)
+}
+
+/// Render values as a PostgreSQL array literal.
+///
+/// Every element is quoted, which is always valid and saves deciding which
+/// ones would otherwise need it -- an element containing a comma, a brace or a
+/// quote of its own would silently change the array's shape.
+fn array_literal(values: &[String]) -> String {
+    let elements: Vec<String> = values
+        .iter()
+        .map(|value| format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\"")))
+        .collect();
+    format!("{{{}}}", elements.join(","))
 }
 
 #[cfg(test)]

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -14,6 +14,12 @@ pub struct CallPlan {
     pub params: CallParams,
     /// Whether to return a scalar result
     pub returns_scalar: bool,
+    /// The declared return type, as PostgreSQL spells it.
+    ///
+    /// Used to decide whether this process can decode the result or whether
+    /// the database should render it, exactly as for a table's columns.
+    #[serde(default)]
+    pub return_type: Option<String>,
     /// Whether the function is set-returning
     pub returns_set: bool,
     /// Whether the return type is composite (row type or `record`): its
@@ -64,6 +70,7 @@ impl CallPlan {
             function: qi,
             params,
             returns_scalar,
+            return_type: routine.return_type.type_name().map(str::to_string),
             returns_set: routine.return_type.is_set_returning(),
             returns_composite: routine.returns_composite,
             volatility: format!("{:?}", routine.volatility),

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -207,8 +207,18 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
                         let params: Vec<(String, String)> = map
                             .into_iter()
                             .map(|(k, v)| {
+                                // A `json` parameter takes the body's value as
+                                // the body wrote it: a JSON string is a JSON
+                                // string, and unquoting it first turns
+                                // `"{\"key\": 3}"` into an object the caller
+                                // did not pass -- or, for `"text"`, into
+                                // something that is not JSON at all.
+                                let takes_json = routine.params.iter().any(|p| {
+                                    p.name == k && matches!(p.param_type.as_str(), "json" | "jsonb")
+                                });
                                 // Extract string values without JSON quotes
                                 let value = match v {
+                                    ref value if takes_json => value.to_string(),
                                     serde_json::Value::String(s) => s,
                                     serde_json::Value::Null => String::new(),
                                     // A JSON array for a parameter the function

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -108,6 +108,26 @@ fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallPa
                                 let value = match v {
                                     serde_json::Value::String(s) => s,
                                     serde_json::Value::Null => String::new(),
+                                    // A JSON array for a parameter the function
+                                    // declares as an array is that array, not a
+                                    // string spelled in JSON: `{"v":["a","b"]}`
+                                    // passes two values to a variadic. PostgreSQL
+                                    // reads `{...}`, not `[...]`.
+                                    serde_json::Value::Array(items)
+                                        if routine.params.iter().any(|p| {
+                                            p.name == k && p.param_type.ends_with("[]")
+                                        }) =>
+                                    {
+                                        array_literal(
+                                            &items
+                                                .iter()
+                                                .map(|item| match item {
+                                                    serde_json::Value::String(s) => s.clone(),
+                                                    other => other.to_string(),
+                                                })
+                                                .collect::<Vec<_>>(),
+                                        )
+                                    }
                                     other => other.to_string(),
                                 };
                                 (k, value)

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -48,6 +48,23 @@ pub struct CallPlan {
     /// length is one, and a parameter's length is not enforced anyway.
     #[serde(default)]
     pub param_types: Vec<(String, String)>,
+    /// The media type the function's value already is, where its return type
+    /// is a domain that says so.
+    ///
+    /// The result is that media type rather than something to serialise as
+    /// JSON, so it is returned verbatim -- but only where the client asked for
+    /// it, since a function whose value is a PNG is still a value a client may
+    /// want as JSON.
+    #[serde(default)]
+    pub media_type: Option<String>,
+    /// The columns the result has, where the function declares its own.
+    ///
+    /// `RETURNS TABLE(a text, b colour)` has no table to read the result's
+    /// shape from, so `SELECT *` is all that can be asked for -- and a column
+    /// of a type this process cannot decode comes back null. Knowing the
+    /// columns is what lets the database render those instead.
+    #[serde(default)]
+    pub output_columns: Vec<(String, String)>,
     /// The names of the parameters declared `VARIADIC`.
     ///
     /// Named notation spells one `VARIADIC v := ...`; `v => ...` finds no
@@ -111,6 +128,8 @@ impl CallPlan {
                 .iter()
                 .map(|p| (p.name.clone(), p.type_max_length.clone()))
                 .collect(),
+            media_type: routine.produced_media_type().map(str::to_string),
+            output_columns: routine.output_columns.clone(),
             variadic_params: routine
                 .params
                 .iter()
@@ -350,6 +369,8 @@ mod tests {
 
     fn make_routine() -> Routine {
         Routine {
+            output_columns: Vec::new(),
+            media_type: None,
             schema: "public".into(),
             name: "get_users".into(),
             description: None,

--- a/crates/postrust-core/src/plan/call_plan.rs
+++ b/crates/postrust-core/src/plan/call_plan.rs
@@ -22,6 +22,15 @@ pub struct CallPlan {
     pub returns_composite: bool,
     /// Function volatility (for transaction handling)
     pub volatility: String,
+    /// Declared parameter types, in the routine's own order, as
+    /// `(name, pg_type)`.
+    ///
+    /// Arguments arrive from the URL or a JSON body as strings. Binding them
+    /// as `text` leaves PostgreSQL unable to resolve any signature that isn't
+    /// text -- `add_them(a => text, b => text) does not exist` -- so each one
+    /// is cast to its declared type at call time.
+    #[serde(default)]
+    pub param_types: Vec<(String, String)>,
 }
 
 /// How parameters are passed to the function.
@@ -58,6 +67,11 @@ impl CallPlan {
             returns_set: routine.return_type.is_set_returning(),
             returns_composite: routine.returns_composite,
             volatility: format!("{:?}", routine.volatility),
+            param_types: routine
+                .params
+                .iter()
+                .map(|p| (p.name.clone(), p.param_type.clone()))
+                .collect(),
         })
     }
 
@@ -68,7 +82,7 @@ impl CallPlan {
 }
 
 /// Extract call parameters from request.
-fn extract_call_params(request: &ApiRequest, _routine: &Routine) -> Result<CallParams> {
+fn extract_call_params(request: &ApiRequest, routine: &Routine) -> Result<CallParams> {
     // Check for JSON body first
     if let Some(payload) = &request.payload {
         match payload {
@@ -114,9 +128,21 @@ fn extract_call_params(request: &ApiRequest, _routine: &Routine) -> Result<CallP
         }
     }
 
-    // Fall back to query parameters
+    // Fall back to query parameters. Only those naming a declared parameter
+    // are arguments -- the rest are filters on the function's result, which
+    // is how `/rpc/getallprojects?id=eq.1` filters rather than failing.
     if !request.query_params.params.is_empty() {
-        return Ok(CallParams::Named(request.query_params.params.clone()));
+        let args: Vec<(String, String)> = request
+            .query_params
+            .params
+            .iter()
+            .filter(|(name, _)| routine.params.iter().any(|p| &p.name == name))
+            .cloned()
+            .collect();
+
+        if !args.is_empty() {
+            return Ok(CallParams::Named(args));
+        }
     }
 
     // No parameters

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -10,7 +10,7 @@ mod types;
 
 pub use call_plan::{CallParams, CallPlan};
 pub use mutate_plan::MutatePlan;
-pub use read_plan::{ReadPlan, ReadPlanTree};
+pub use read_plan::{resolve_top_level_range, ReadPlan, ReadPlanTree};
 pub use types::*;
 
 use crate::api_request::{Action, ApiRequest, DbAction, QualifiedIdentifier};

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -138,6 +138,19 @@ fn validate_embed_paths(request: &ApiRequest) -> Result<()> {
 /// taking nothing at all, while `/rpc/add_them?a=1&b=2&smthelse=x` is a call
 /// with an argument no signature declares.
 fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
+    use crate::api_request::Payload;
+
+    // Over POST the arguments are the body's keys, and the query string holds
+    // filters over the result. Reading only the query string there picked the
+    // signature that takes nothing at all.
+    match &request.payload {
+        Some(Payload::ProcessedJson { keys, .. }) => return keys.iter().cloned().collect(),
+        Some(Payload::ProcessedUrlEncoded { data, .. }) => {
+            return data.iter().map(|(name, _)| name.clone()).collect()
+        }
+        _ => {}
+    }
+
     // A filter on an embedded resource is keyed by its path -- `clients.id`
     // -- and is no more an argument than a filter on the result itself.
     let embedded: HashSet<String> = request
@@ -264,7 +277,7 @@ fn create_db_plan(
 
         DbAction::RelationMut { qi, mutation } => {
             let table = schema_cache.require_table(qi)?;
-            let mutate_plan = MutatePlan::from_request(request, table, mutation)?;
+            let mutate_plan = MutatePlan::from_request(request, table, mutation, schema_cache)?;
 
             let read_plan = if request.preferences.representation.needs_body() {
                 let rp = ReadPlan::for_mutation(request, table, schema_cache)?;

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -85,22 +85,29 @@ fn nearest_overload(
     supplied: &[String],
 ) -> Option<String> {
     // Looser than a name: these are lists, and one wrong entry in three should
-    // still find the signature that was meant.
+    // still find the signature that was meant. Revealing a parameter list is
+    // not a disclosure, either -- the client is trying to name it.
     const MIN_SIMILARITY: f64 = 0.33;
 
-    let sorted = |names: &mut Vec<String>| -> String {
+    // Compared as the parameter list is written -- parentheses included --
+    // because that is what the client sees and what it would have to change.
+    let listed = |names: &mut Vec<String>| -> String {
         names.sort();
-        names.join(", ")
+        format!("({})", names.join(", "))
     };
-    let asked = sorted(&mut supplied.to_vec());
+    let asked = listed(&mut supplied.to_vec());
 
-    routines
+    let candidates: Vec<String> = routines
         .iter()
-        .map(|routine| sorted(&mut routine.params.iter().map(|p| p.name.clone()).collect()))
-        .map(|params| (crate::schema_cache::similarity(&params, &asked), params))
-        .filter(|(score, _)| *score >= MIN_SIMILARITY)
-        .max_by(|(a, _), (b, _)| a.total_cmp(b))
-        .map(|(_, params)| format!("{}({})", qi, params))
+        .map(|routine| listed(&mut routine.params.iter().map(|p| p.name.clone()).collect()))
+        .collect();
+
+    crate::schema_cache::closest(
+        candidates.iter().map(String::as_str),
+        &asked,
+        MIN_SIMILARITY,
+    )
+    .map(|params| format!("{}{}", qi, params))
 }
 
 /// Check that every dotted filter, order or range names a resource that was
@@ -173,11 +180,41 @@ fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
     // Over POST the arguments are the body's keys, and the query string holds
     // filters over the result. Reading only the query string there picked the
     // signature that takes nothing at all.
-    match &request.payload {
-        Some(Payload::ProcessedJson { keys, .. }) => return keys.iter().cloned().collect(),
-        Some(Payload::ProcessedUrlEncoded { data, .. }) => {
-            return data.iter().map(|(name, _)| name.clone()).collect()
+    //
+    // `?columns=` overrides them: it says which of the body's keys are
+    // arguments, so a body carrying more than the call needs still names one
+    // signature rather than none.
+    let is_post = matches!(
+        request.action,
+        Action::Db(DbAction::Routine {
+            invoke_method: crate::api_request::InvokeMethod::Inv,
+            ..
+        })
+    );
+    if is_post {
+        if let Some(columns) = &request.query_params.columns {
+            let mut names: Vec<String> = columns.iter().cloned().collect();
+            names.sort();
+            return names;
         }
+    }
+
+    // A name is reported and matched as a set, so the order the body or the
+    // query string happened to use is not part of it.
+    let sorted = |mut names: Vec<String>| -> Vec<String> {
+        names.sort();
+        names.dedup();
+        names
+    };
+
+    match &request.payload {
+        Some(Payload::ProcessedJson { keys, .. }) => return sorted(keys.iter().cloned().collect()),
+        Some(Payload::ProcessedUrlEncoded { data, .. }) => {
+            return sorted(data.iter().map(|(name, _)| name.clone()).collect())
+        }
+        // A raw body is one unnamed argument, so it names no parameter at all.
+        Some(Payload::RawJson(_)) | Some(Payload::RawPayload(_)) => return Vec::new(),
+        None if is_post => return Vec::new(),
         _ => {}
     }
 
@@ -204,6 +241,7 @@ fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
             names.push(name.clone());
         }
     }
+    names.sort();
     names
 }
 
@@ -214,73 +252,143 @@ fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
 /// PostgreSQL then rejects with a message about a function that does not
 /// exist, where the truth is that none of them matched.
 ///
-/// A signature fits when every argument names one of its parameters and every
-/// parameter it requires is supplied. Among those that fit, the one matching
-/// most of its parameters wins; where several match equally the call is
-/// ambiguous and saying so is more use than picking one.
+/// Two kinds of signature can answer a call. One names its parameters, and
+/// fits when the arguments supplied are exactly its required ones plus any of
+/// its optional ones. The other has a single parameter with no name, and takes
+/// the whole request body as that one argument -- so it fits whatever the body
+/// says, and only when the body's media type matches the parameter's type.
+///
+/// A named match always wins; the unnamed one is what a call falls back to. If
+/// nothing is left the function was not found, and if more than one remains at
+/// the same level the call is ambiguous -- saying so is more use than picking
+/// one.
 fn select_overload<'a>(
     routines: &'a [Routine],
     request: &ApiRequest,
 ) -> Result<Option<&'a Routine>> {
-    use crate::api_request::Payload;
-
-    // A body that is not named arguments -- a bare scalar, a raw payload --
-    // says nothing about which signature was meant, so there is nothing to
-    // choose on and the first is as good an answer as any.
-    if matches!(
-        request.payload,
-        Some(Payload::RawJson(_)) | Some(Payload::RawPayload(_))
-    ) {
-        return Ok(routines.first());
-    }
-
     let supplied = supplied_arguments(request);
-
-    let mut fitting: Vec<&Routine> = routines
-        .iter()
-        .filter(|routine| {
-            supplied
-                .iter()
-                .all(|name| routine.params.iter().any(|p| &p.name == name))
-                && routine
-                    .params
-                    .iter()
-                    .filter(|p| p.required)
-                    .all(|p| supplied.contains(&p.name))
+    let is_post = matches!(
+        request.action,
+        Action::Db(DbAction::Routine {
+            invoke_method: crate::api_request::InvokeMethod::Inv,
+            ..
         })
-        .collect();
+    );
 
-    let best = fitting
-        .iter()
-        .map(|routine| {
-            routine
-                .params
-                .iter()
-                .filter(|p| supplied.contains(&p.name))
-                .count()
-        })
-        .max();
+    let (named, unnamed): (Vec<&Routine>, Vec<&Routine>) =
+        routines
+            .iter()
+            .fold((Vec::new(), Vec::new()), |mut acc, r| {
+                if matches_params(r, &supplied, is_post, &request.content_media_type) {
+                    acc.0.push(r);
+                } else if takes_whole_body(r, is_post, &request.content_media_type) {
+                    acc.1.push(r);
+                }
+                acc
+            });
 
-    let Some(best) = best else {
-        return Ok(None);
+    let candidates = match named.is_empty() {
+        true => unnamed,
+        false => named,
     };
 
-    fitting.retain(|routine| {
+    match candidates.len() {
+        0 => Ok(None),
+        1 => Ok(candidates.first().copied()),
+        _ => Err(Error::AmbiguousFunction {
+            candidates: candidates.iter().map(|r| signature_of(r)).collect(),
+        }),
+    }
+}
+
+/// Whether a signature's parameters are exactly what the request supplied.
+///
+/// Required parameters must all be given and optional ones may be; an argument
+/// naming no parameter at all disqualifies the signature, which is what makes
+/// `add_them(a, b)` not answer a call passing `a`, `b` and `smthelse`.
+fn matches_params(
+    routine: &Routine,
+    supplied: &[String],
+    is_post: bool,
+    content: &crate::api_request::MediaType,
+) -> bool {
+    if routine.params.is_empty() {
+        // A body posted as text, xml or bytes is one unnamed argument. A
+        // signature taking nothing cannot receive it, however empty the
+        // argument list looks.
+        return supplied.is_empty() && !(is_post && is_raw_body_type(content));
+    }
+
+    let declares = |name: &String, required: bool| {
         routine
             .params
             .iter()
-            .filter(|p| supplied.contains(&p.name))
-            .count()
-            == best
-    });
+            .any(|p| &p.name == name && p.required == required)
+    };
 
-    if fitting.len() > 1 {
-        return Err(Error::AmbiguousFunction {
-            candidates: fitting.iter().map(|r| signature_of(r)).collect(),
-        });
+    routine
+        .params
+        .iter()
+        .filter(|p| p.required)
+        .all(|p| supplied.contains(&p.name))
+        && supplied
+            .iter()
+            .all(|name| declares(name, true) || declares(name, false))
+}
+
+/// Whether a signature is the single unnamed parameter that takes the body.
+///
+/// Only over `POST`, and only where the body's media type is the one that
+/// parameter's type can receive: a `json` parameter takes a JSON body, a
+/// `text` one a plain-text body, and so on. A GET has no body to pass.
+fn takes_whole_body(
+    routine: &Routine,
+    is_post: bool,
+    content: &crate::api_request::MediaType,
+) -> bool {
+    use crate::api_request::MediaType;
+
+    if !is_post {
+        return false;
     }
+    let [param] = routine.params.as_slice() else {
+        return false;
+    };
+    if !param.name.is_empty() {
+        return false;
+    }
+    matches!(
+        (content, param.param_type.as_str()),
+        (MediaType::ApplicationJson, "json" | "jsonb")
+            | (MediaType::TextPlain, "text")
+            | (MediaType::TextXml, "xml")
+            | (MediaType::OctetStream, "bytea")
+    )
+}
 
-    Ok(fitting.first().copied())
+/// The type a single unnamed parameter would have, for a body of this type.
+///
+/// `None` where no such parameter could take the body at all, which is every
+/// media type that is neither JSON nor one of the three that carry a single
+/// value.
+fn single_param_type(content: &crate::api_request::MediaType) -> Option<String> {
+    use crate::api_request::MediaType;
+    match content {
+        MediaType::ApplicationJson => Some(crate::error::JSON_PARAM.to_string()),
+        MediaType::TextPlain => Some("text".to_string()),
+        MediaType::TextXml => Some("xml".to_string()),
+        MediaType::OctetStream => Some("bytea".to_string()),
+        _ => None,
+    }
+}
+
+/// Media types whose body is one value rather than a set of named arguments.
+fn is_raw_body_type(content: &crate::api_request::MediaType) -> bool {
+    use crate::api_request::MediaType;
+    matches!(
+        content,
+        MediaType::TextPlain | MediaType::TextXml | MediaType::OctetStream
+    )
 }
 
 /// A function's signature as PostgREST prints it when naming candidates.
@@ -331,10 +439,16 @@ fn create_db_plan(
         DbAction::Routine { qi, invoke_method } => {
             let supplied = supplied_arguments(request);
 
-            // Over POST the whole body can be one unnamed `json` argument, so
-            // a signature taking that would also have matched. The message
-            // says which signatures were looked for, so it says so too.
-            let single_json = matches!(invoke_method, crate::api_request::InvokeMethod::Inv);
+            // Over POST the whole body can be one unnamed argument, and the
+            // body's media type decides which type that parameter could be.
+            // The message says which signatures were looked for, so it says
+            // so too.
+            let single_param = match invoke_method {
+                crate::api_request::InvokeMethod::Inv => {
+                    single_param_type(&request.content_media_type)
+                }
+                _ => None,
+            };
 
             // The name is reported as it was called, arguments and all, so the
             // client can see which signature was looked for.
@@ -342,7 +456,7 @@ fn create_db_plan(
                 name: qi.to_string(),
                 params: supplied.clone(),
                 candidate,
-                single_json,
+                single_param: single_param.clone(),
             };
 
             // Nothing of that name: the client most likely misspelled it, so

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -115,9 +115,19 @@ fn create_db_plan(
 
             let call_plan = CallPlan::from_request(request, routine)?;
 
+            // The rows a function returns are shaped like any other read:
+            // selected, filtered, ordered, paged and embedded on. That needs a
+            // table to resolve columns against, so it applies exactly when the
+            // function returns rows of one this cache knows.
+            let read = schema_cache
+                .routine_returned_table(qi)
+                .map(|table| ReadPlan::from_request(request, table, schema_cache))
+                .transpose()?
+                .map(ReadPlanTree::leaf);
+
             Ok(DbActionPlan::Call {
                 call: call_plan,
-                read: None,
+                read,
             })
         }
 

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -72,6 +72,39 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
     }
 }
 
+/// The arguments a request supplies to a function.
+///
+/// On a function call every query parameter is a candidate argument, but a
+/// value carrying an operator -- `id=gt.1` -- is a filter over the result
+/// instead. That is what lets `/rpc/getallprojects?id=gt.1` call a function
+/// taking nothing at all, while `/rpc/add_them?a=1&b=2&smthelse=x` is a call
+/// with an argument no signature declares.
+fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
+    // A filter on an embedded resource is keyed by its path -- `clients.id`
+    // -- and is no more an argument than a filter on the result itself.
+    let embedded: HashSet<String> = request
+        .query_params
+        .filters
+        .iter()
+        .map(|(path, filter)| {
+            let mut key = path.join(".");
+            key.push('.');
+            key.push_str(&filter.field.name);
+            key
+        })
+        .collect();
+
+    request
+        .query_params
+        .params
+        .iter()
+        .map(|(name, _)| name.clone())
+        .filter(|name| {
+            !request.query_params.filter_fields.contains(name) && !embedded.contains(name)
+        })
+        .collect()
+}
+
 /// Choose which signature of a function the supplied arguments call.
 ///
 /// A name may carry several, and taking whichever happened to be loaded first
@@ -79,45 +112,82 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
 /// PostgreSQL then rejects with a message about a function that does not
 /// exist, where the truth is that none of them matched.
 ///
-/// A signature fits when every parameter it requires is supplied. A key that
-/// names no parameter is not disqualifying: on a function call an unrecognised
-/// key filters the result rather than arguing with the signature, which is why
-/// `/rpc/getallprojects?id=gt.1` calls a function taking nothing at all.
-///
-/// Among those that fit, the one matching most of its parameters wins, and the
-/// shorter signature breaks a tie -- it leaves least to defaults the caller
-/// did not ask for.
-fn select_overload<'a>(routines: &'a [Routine], request: &ApiRequest) -> Option<&'a Routine> {
+/// A signature fits when every argument names one of its parameters and every
+/// parameter it requires is supplied. Among those that fit, the one matching
+/// most of its parameters wins; where several match equally the call is
+/// ambiguous and saying so is more use than picking one.
+fn select_overload<'a>(
+    routines: &'a [Routine],
+    request: &ApiRequest,
+) -> Result<Option<&'a Routine>> {
     // Arguments in a body are not inspected here. The payload is parsed
     // further down, and a mismatch there is PostgreSQL's to report.
     if request.payload.is_some() {
-        return routines.first();
+        return Ok(routines.first());
     }
 
-    let supplied: HashSet<&str> = request
-        .query_params
-        .params
-        .iter()
-        .map(|(name, _)| name.as_str())
-        .collect();
+    let supplied = supplied_arguments(request);
 
-    routines
+    let mut fitting: Vec<&Routine> = routines
         .iter()
         .filter(|routine| {
+            supplied
+                .iter()
+                .all(|name| routine.params.iter().any(|p| &p.name == name))
+                && routine
+                    .params
+                    .iter()
+                    .filter(|p| p.required)
+                    .all(|p| supplied.contains(&p.name))
+        })
+        .collect();
+
+    let best = fitting
+        .iter()
+        .map(|routine| {
             routine
                 .params
                 .iter()
-                .filter(|p| p.required)
-                .all(|p| supplied.contains(p.name.as_str()))
+                .filter(|p| supplied.contains(&p.name))
+                .count()
         })
-        .max_by_key(|routine| {
-            let matched = routine
-                .params
-                .iter()
-                .filter(|p| supplied.contains(p.name.as_str()))
-                .count();
-            (matched, std::cmp::Reverse(routine.params.len()))
-        })
+        .max();
+
+    let Some(best) = best else {
+        return Ok(None);
+    };
+
+    fitting.retain(|routine| {
+        routine
+            .params
+            .iter()
+            .filter(|p| supplied.contains(&p.name))
+            .count()
+            == best
+    });
+
+    if fitting.len() > 1 {
+        return Err(Error::AmbiguousFunction {
+            candidates: fitting.iter().map(|r| signature_of(r)).collect(),
+        });
+    }
+
+    Ok(fitting.first().copied())
+}
+
+/// A function's signature as PostgREST prints it when naming candidates.
+fn signature_of(routine: &Routine) -> String {
+    format!(
+        "{}.{}({})",
+        routine.schema,
+        routine.name,
+        routine
+            .params
+            .iter()
+            .map(|p| format!("{} => {}", p.name, p.param_type))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// Create a database action plan.
@@ -154,12 +224,7 @@ fn create_db_plan(
             qi,
             invoke_method: _,
         } => {
-            let supplied: Vec<String> = request
-                .query_params
-                .params
-                .iter()
-                .map(|(name, _)| name.clone())
-                .collect();
+            let supplied = supplied_arguments(request);
 
             // The name is reported as it was called, arguments and all, so the
             // client can see which signature was looked for.
@@ -173,7 +238,7 @@ fn create_db_plan(
                 .get_routines(qi)
                 .ok_or_else(|| not_found(None))?;
 
-            let routine = select_overload(routines, request).ok_or_else(|| {
+            let routine = select_overload(routines, request)?.ok_or_else(|| {
                 // The name exists but nothing takes these arguments, so an
                 // overload that does exist is worth naming.
                 let candidate = routines.first().map(|r| {

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -73,6 +73,36 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
     }
 }
 
+/// The overload whose parameters most resemble the ones supplied.
+///
+/// Compared as one string of sorted names -- `a, b, c` -- because what a
+/// client gets wrong is usually one name out of several, and comparing the
+/// lists as a whole is what notices that. `None` when nothing is close enough
+/// to be worth saying; a bad guess is worse than silence.
+fn nearest_overload(
+    qi: &QualifiedIdentifier,
+    routines: &[crate::schema_cache::Routine],
+    supplied: &[String],
+) -> Option<String> {
+    // Looser than a name: these are lists, and one wrong entry in three should
+    // still find the signature that was meant.
+    const MIN_SIMILARITY: f64 = 0.33;
+
+    let sorted = |names: &mut Vec<String>| -> String {
+        names.sort();
+        names.join(", ")
+    };
+    let asked = sorted(&mut supplied.to_vec());
+
+    routines
+        .iter()
+        .map(|routine| sorted(&mut routine.params.iter().map(|p| p.name.clone()).collect()))
+        .map(|params| (crate::schema_cache::similarity(&params, &asked), params))
+        .filter(|(score, _)| *score >= MIN_SIMILARITY)
+        .max_by(|(a, _), (b, _)| a.total_cmp(b))
+        .map(|(_, params)| format!("{}({})", qi, params))
+}
+
 /// Check that every dotted filter, order or range names a resource that was
 /// embedded.
 ///
@@ -309,25 +339,18 @@ fn create_db_plan(
                 single_json,
             };
 
+            // Nothing of that name: the client most likely misspelled it, so
+            // the nearest name in the schema is worth offering.
             let routines = schema_cache
                 .get_routines(qi)
-                .ok_or_else(|| not_found(None))?;
+                .ok_or_else(|| not_found(schema_cache.similar_routine(qi)))?;
 
             let routine = select_overload(routines, request)?.ok_or_else(|| {
-                // The name exists but nothing takes these arguments, so an
-                // overload that does exist is worth naming.
-                let candidate = routines.first().map(|r| {
-                    format!(
-                        "{}({})",
-                        qi,
-                        r.params
-                            .iter()
-                            .map(|p| p.name.clone())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
-                });
-                not_found(candidate)
+                // The name exists but nothing takes these arguments, so the
+                // overload whose parameters most resemble the ones supplied is
+                // the one to offer -- not simply the first, which says nothing
+                // about what the client asked for.
+                not_found(nearest_overload(qi, routines, &supplied))
             })?;
 
             let call_plan = CallPlan::from_request(request, routine)?;

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -292,11 +292,13 @@ fn create_db_plan(
             })
         }
 
-        DbAction::Routine {
-            qi,
-            invoke_method: _,
-        } => {
+        DbAction::Routine { qi, invoke_method } => {
             let supplied = supplied_arguments(request);
+
+            // Over POST the whole body can be one unnamed `json` argument, so
+            // a signature taking that would also have matched. The message
+            // says which signatures were looked for, so it says so too.
+            let single_json = matches!(invoke_method, crate::api_request::InvokeMethod::Inv);
 
             // The name is reported as it was called, arguments and all, so the
             // client can see which signature was looked for.
@@ -304,6 +306,7 @@ fn create_db_plan(
                 name: qi.to_string(),
                 params: supplied.clone(),
                 candidate,
+                single_json,
             };
 
             let routines = schema_cache

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -84,10 +84,18 @@ fn nearest_overload(
     routines: &[crate::schema_cache::Routine],
     supplied: &[String],
 ) -> Option<String> {
-    // Looser than a name: these are lists, and one wrong entry in three should
-    // still find the signature that was meant. Revealing a parameter list is
-    // not a disclosure, either -- the client is trying to name it.
-    const MIN_SIMILARITY: f64 = 0.33;
+    // No floor at all, unlike a name: the nearest signature that shares any
+    // character sequence with what was asked for is offered. A client that got
+    // one parameter of three wrong is not close by any similarity measure --
+    // `(a, b)` against `(a, b, smthelse)` scores a third -- and naming a
+    // parameter list discloses nothing, since the client is trying to write
+    // one. A name is different: there a bad guess names an object the client
+    // did not know about, which is why that hint keeps its floor.
+    //
+    // Fitted against every hint the reference gives rather than reasoned from:
+    // a floor of a third answers seven of the eight correctly, which is
+    // exactly the kind of nearly-right that looks settled.
+    const MIN_SIMILARITY: f64 = 0.0;
 
     // Compared as the parameter list is written -- parentheses included --
     // because that is what the client sees and what it would have to change.

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -15,7 +15,8 @@ pub use types::*;
 
 use crate::api_request::{Action, ApiRequest, DbAction, QualifiedIdentifier};
 use crate::error::{Error, Result};
-use crate::schema_cache::SchemaCache;
+use crate::schema_cache::{Routine, SchemaCache};
+use std::collections::HashSet;
 
 /// The execution plan for an API request.
 #[derive(Clone, Debug)]
@@ -71,6 +72,54 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
     }
 }
 
+/// Choose which signature of a function the supplied arguments call.
+///
+/// A name may carry several, and taking whichever happened to be loaded first
+/// calls the wrong one -- or calls one the arguments do not fit, which
+/// PostgreSQL then rejects with a message about a function that does not
+/// exist, where the truth is that none of them matched.
+///
+/// A signature fits when every parameter it requires is supplied. A key that
+/// names no parameter is not disqualifying: on a function call an unrecognised
+/// key filters the result rather than arguing with the signature, which is why
+/// `/rpc/getallprojects?id=gt.1` calls a function taking nothing at all.
+///
+/// Among those that fit, the one matching most of its parameters wins, and the
+/// shorter signature breaks a tie -- it leaves least to defaults the caller
+/// did not ask for.
+fn select_overload<'a>(routines: &'a [Routine], request: &ApiRequest) -> Option<&'a Routine> {
+    // Arguments in a body are not inspected here. The payload is parsed
+    // further down, and a mismatch there is PostgreSQL's to report.
+    if request.payload.is_some() {
+        return routines.first();
+    }
+
+    let supplied: HashSet<&str> = request
+        .query_params
+        .params
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect();
+
+    routines
+        .iter()
+        .filter(|routine| {
+            routine
+                .params
+                .iter()
+                .filter(|p| p.required)
+                .all(|p| supplied.contains(p.name.as_str()))
+        })
+        .max_by_key(|routine| {
+            let matched = routine
+                .params
+                .iter()
+                .filter(|p| supplied.contains(p.name.as_str()))
+                .count();
+            (matched, std::cmp::Reverse(routine.params.len()))
+        })
+}
+
 /// Create a database action plan.
 fn create_db_plan(
     request: &ApiRequest,
@@ -105,13 +154,41 @@ fn create_db_plan(
             qi,
             invoke_method: _,
         } => {
+            let supplied: Vec<String> = request
+                .query_params
+                .params
+                .iter()
+                .map(|(name, _)| name.clone())
+                .collect();
+
+            // The name is reported as it was called, arguments and all, so the
+            // client can see which signature was looked for.
+            let not_found = |candidate: Option<String>| Error::FunctionNotFound {
+                name: qi.to_string(),
+                params: supplied.clone(),
+                candidate,
+            };
+
             let routines = schema_cache
                 .get_routines(qi)
-                .ok_or_else(|| Error::FunctionNotFound(qi.to_string()))?;
+                .ok_or_else(|| not_found(None))?;
 
-            let routine = routines
-                .first()
-                .ok_or_else(|| Error::FunctionNotFound(qi.to_string()))?;
+            let routine = select_overload(routines, request).ok_or_else(|| {
+                // The name exists but nothing takes these arguments, so an
+                // overload that does exist is worth naming.
+                let candidate = routines.first().map(|r| {
+                    format!(
+                        "{}({})",
+                        qi,
+                        r.params
+                            .iter()
+                            .map(|p| p.name.clone())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                });
+                not_found(candidate)
+            })?;
 
             let call_plan = CallPlan::from_request(request, routine)?;
 

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -63,6 +63,7 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
             if matches!(db_action, DbAction::SchemaRead { .. }) {
                 return Ok(ActionPlan::Info(InfoPlan::OpenApiSpec));
             }
+            validate_embed_paths(request)?;
             let plan = create_db_plan(request, db_action, schema_cache)?;
             Ok(ActionPlan::Db(plan))
         }
@@ -70,6 +71,63 @@ pub fn create_action_plan(request: &ApiRequest, schema_cache: &SchemaCache) -> R
         Action::RoutineInfo { qi, .. } => Ok(ActionPlan::Info(InfoPlan::RoutineInfo(qi.clone()))),
         Action::SchemaInfo => Ok(ActionPlan::Info(InfoPlan::OpenApiSpec)),
     }
+}
+
+/// Check that every dotted filter, order or range names a resource that was
+/// embedded.
+///
+/// `?non_existent_projects.name=like.*x*` looks like a filter on an embedded
+/// resource, and answering it as though the prefix meant nothing would return
+/// the whole table with no sign that the filter was dropped. PostgREST reports
+/// the first segment it cannot account for, which is the one the client got
+/// wrong.
+fn validate_embed_paths(request: &ApiRequest) -> Result<()> {
+    use crate::api_request::SelectItem;
+
+    // An embed answers to the alias the request gave it and to the relation's
+    // own name: `the_tasks:tasks(*)` is addressed by either.
+    fn descend<'a>(items: &'a [SelectItem], segment: &str) -> Option<&'a [SelectItem]> {
+        items.iter().find_map(|item| match item {
+            SelectItem::Relation {
+                relation,
+                alias,
+                select,
+                ..
+            } if relation == segment || alias.as_deref() == Some(segment) => {
+                Some(select.as_slice())
+            }
+            SelectItem::SpreadRelation {
+                relation, select, ..
+            } if relation == segment => Some(select.as_slice()),
+            _ => None,
+        })
+    }
+
+    let check = |path: &[String]| -> Result<()> {
+        let mut items = request.query_params.select.as_slice();
+        for segment in path {
+            items = descend(items, segment)
+                .ok_or_else(|| Error::NotAnEmbeddedResource(segment.clone()))?;
+        }
+        Ok(())
+    };
+
+    for (path, _) in &request.query_params.filters {
+        check(path)?;
+    }
+    for (path, _) in &request.query_params.order {
+        check(path)?;
+    }
+    for (path, _) in &request.query_params.logic {
+        check(path)?;
+    }
+    for path in request.query_params.ranges.keys() {
+        if !path.is_empty() {
+            check(&path.split('.').map(String::from).collect::<Vec<_>>())?;
+        }
+    }
+
+    Ok(())
 }
 
 /// The arguments a request supplies to a function.
@@ -94,15 +152,16 @@ fn supplied_arguments(request: &ApiRequest) -> Vec<String> {
         })
         .collect();
 
-    request
-        .query_params
-        .params
-        .iter()
-        .map(|(name, _)| name.clone())
-        .filter(|name| {
-            !request.query_params.filter_fields.contains(name) && !embedded.contains(name)
-        })
-        .collect()
+    let mut names: Vec<String> = Vec::new();
+    for (name, value) in &request.query_params.params {
+        if crate::api_request::value_is_filter(value) || embedded.contains(name) {
+            continue;
+        }
+        if !names.contains(name) {
+            names.push(name.clone());
+        }
+    }
+    names
 }
 
 /// Choose which signature of a function the supplied arguments call.

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -222,9 +222,15 @@ fn select_overload<'a>(
     routines: &'a [Routine],
     request: &ApiRequest,
 ) -> Result<Option<&'a Routine>> {
-    // Arguments in a body are not inspected here. The payload is parsed
-    // further down, and a mismatch there is PostgreSQL's to report.
-    if request.payload.is_some() {
+    use crate::api_request::Payload;
+
+    // A body that is not named arguments -- a bare scalar, a raw payload --
+    // says nothing about which signature was meant, so there is nothing to
+    // choose on and the first is as good an answer as any.
+    if matches!(
+        request.payload,
+        Some(Payload::RawJson(_)) | Some(Payload::RawPayload(_))
+    ) {
         return Ok(routines.first());
     }
 
@@ -359,8 +365,13 @@ fn create_db_plan(
             // selected, filtered, ordered, paged and embedded on. That needs a
             // table to resolve columns against, so it applies exactly when the
             // function returns rows of one this cache knows.
+            //
+            // The table is the one *this* overload returns: a name may carry
+            // several signatures returning different things, and taking the
+            // first would shape the result of one call by the columns of
+            // another.
             let read = schema_cache
-                .routine_returned_table(qi)
+                .returned_table(routine)
                 .map(|table| ReadPlan::from_request(request, table, schema_cache))
                 .transpose()?
                 .map(ReadPlanTree::leaf);

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -246,7 +246,7 @@ fn get_payload_columns(
         // also declared how one arrives: the value is read out of the body as
         // JSON and handed to that cast, rather than to PostgreSQL's own input
         // function for the type underneath.
-        if let Some(function) = schema_cache.representation("json", &column.nominal_type) {
+        if let Some(function) = schema_cache.representation("json", column.representation_type()) {
             field.ir_type = "json".to_string();
             field.transform = Some(function.to_string());
         }

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -85,14 +85,25 @@ impl MutatePlan {
         let apply_defaults =
             request.preferences.missing == crate::api_request::PreferMissing::ApplyDefaults;
 
-        let on_conflict = request.query_params.on_conflict.as_ref().map(|cols| {
-            let resolution = request
-                .preferences
-                .resolution
-                .clone()
-                .unwrap_or(PreferResolution::MergeDuplicates);
-            (resolution, cols.clone())
-        });
+        // `Prefer: resolution=` says what to do about a duplicate; `on_conflict=`
+        // says which columns make one. Without the latter the answer is the
+        // primary key, which is what "duplicate" means when nothing else is
+        // said -- and without a resolution there is nothing to do about one.
+        let on_conflict = request
+            .preferences
+            .resolution
+            .clone()
+            .and_then(|resolution| {
+                let columns = request
+                    .query_params
+                    .on_conflict
+                    .clone()
+                    .unwrap_or_else(|| table.pk_cols.clone());
+                match columns.is_empty() {
+                    true => None,
+                    false => Some((resolution, columns)),
+                }
+            });
 
         Ok(Self::Insert {
             target: qi,
@@ -283,9 +294,23 @@ fn validate_put(request: &ApiRequest, table: &Table) -> Result<()> {
     }
 
     // The body may leave a key out -- the URL already said what it is -- but
-    // where it names one it has to be the same one.
+    // where it names one it has to be the same one. A body written as an
+    // array is checked element by element: `PUT` writes the row the URL names
+    // and no other, however many the body offers.
     if let Some(Payload::ProcessedJson { raw, .. }) = &request.payload {
-        if let Ok(serde_json::Value::Object(row)) = serde_json::from_slice(raw) {
+        let rows = match serde_json::from_slice(raw) {
+            Ok(serde_json::Value::Object(row)) => vec![row],
+            Ok(serde_json::Value::Array(rows)) => rows
+                .into_iter()
+                .filter_map(|row| match row {
+                    serde_json::Value::Object(row) => Some(row),
+                    _ => None,
+                })
+                .collect(),
+            _ => vec![],
+        };
+
+        for row in rows {
             for key in &table.pk_cols {
                 let Some(value) = row.get(key) else { continue };
                 let value = match value {

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -88,8 +88,7 @@ impl MutatePlan {
         let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let returning = get_returning_columns(request, table);
-        let apply_defaults =
-            request.preferences.missing == crate::api_request::PreferMissing::ApplyDefaults;
+        let apply_defaults = asked_for_defaults(request);
 
         // `Prefer: resolution=` says what to do about a duplicate; `on_conflict=`
         // says which columns make one. Without the latter the answer is the
@@ -135,8 +134,7 @@ impl MutatePlan {
         let body = get_body_bytes(request)?;
         let where_clauses = build_mutation_where(request, table)?;
         let returning = get_returning_columns(request, table);
-        let apply_defaults =
-            request.preferences.missing == crate::api_request::PreferMissing::ApplyDefaults;
+        let apply_defaults = asked_for_defaults(request);
 
         Ok(Self::Update {
             target: qi,
@@ -184,7 +182,7 @@ impl MutatePlan {
             where_clauses: vec![],
             returning,
             pk_cols: table.pk_cols.clone(),
-            apply_defaults: true,
+            apply_defaults: asked_for_defaults(request),
             reports_inserted: !table.is_view && !table.is_partitioned,
         })
     }
@@ -237,6 +235,7 @@ fn get_payload_columns(
         })?;
 
         let mut field = CoercibleField::simple(key, &column.nominal_type);
+        field.default = column.default.clone();
         // A schema that declared how one of its domains is written in JSON
         // also declared how one arrives: the value is read out of the body as
         // JSON and handed to that cast, rather than to PostgreSQL's own input
@@ -249,6 +248,19 @@ fn get_payload_columns(
     }
 
     Ok(columns)
+}
+
+/// Whether the request asked for a column it left out to take its default.
+///
+/// Read from what was actually sent rather than from the parsed field, which
+/// cannot say whether `missing=default` was requested or is merely the value
+/// the field holds when nothing was.
+fn asked_for_defaults(request: &ApiRequest) -> bool {
+    request
+        .preferences
+        .applied
+        .iter()
+        .any(|pref| pref == "missing=default")
 }
 
 /// Check that a `PUT` names exactly one row, and that its body agrees.

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -149,6 +149,8 @@ impl MutatePlan {
         qi: QualifiedIdentifier,
         schema_cache: &crate::schema_cache::SchemaCache,
     ) -> Result<Self> {
+        validate_put(request, table)?;
+
         let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let returning = get_returning_columns(request, table);
@@ -228,6 +230,76 @@ fn get_payload_columns(
     }
 
     Ok(columns)
+}
+
+/// Check that a `PUT` names exactly one row, and that its body agrees.
+///
+/// `PUT` replaces the row the URL identifies, so the URL has to identify one:
+/// every primary key column, compared with `eq`, and nothing else. A page
+/// makes no sense on top of that, and a body naming a different row would
+/// write somewhere the client did not ask for.
+fn validate_put(request: &ApiRequest, table: &Table) -> Result<()> {
+    use crate::api_request::{Operation, QuantOperator};
+
+    if request
+        .query_params
+        .ranges
+        .values()
+        .any(|range| range.limit.is_some() || range.offset != 0)
+    {
+        return Err(Error::PutLimitNotAllowed);
+    }
+
+    let mut keyed: std::collections::HashMap<&str, &str> = std::collections::HashMap::new();
+    for filter in &request.query_params.filters_root {
+        let Operation::Quant {
+            op: QuantOperator::Equal,
+            quantifier: None,
+            value,
+        } = &filter.op_expr.operation
+        else {
+            return Err(Error::InvalidPutFilters);
+        };
+        if filter.op_expr.negated {
+            return Err(Error::InvalidPutFilters);
+        }
+        keyed.insert(&filter.field.name, value);
+    }
+
+    // Anything else in the query string that filters -- a logic group, a
+    // filter on an embedded resource -- also fails to name exactly one row.
+    if !request.query_params.logic.is_empty() || !request.query_params.filters.is_empty() {
+        return Err(Error::InvalidPutFilters);
+    }
+
+    if table.pk_cols.is_empty()
+        || keyed.len() != table.pk_cols.len()
+        || !table
+            .pk_cols
+            .iter()
+            .all(|key| keyed.contains_key(key.as_str()))
+    {
+        return Err(Error::InvalidPutFilters);
+    }
+
+    // The body may leave a key out -- the URL already said what it is -- but
+    // where it names one it has to be the same one.
+    if let Some(Payload::ProcessedJson { raw, .. }) = &request.payload {
+        if let Ok(serde_json::Value::Object(row)) = serde_json::from_slice(raw) {
+            for key in &table.pk_cols {
+                let Some(value) = row.get(key) else { continue };
+                let value = match value {
+                    serde_json::Value::String(text) => text.clone(),
+                    other => other.to_string(),
+                };
+                if keyed.get(key.as_str()) != Some(&value.as_str()) {
+                    return Err(Error::PutMatchingPk);
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Get body as bytes.

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -87,7 +87,7 @@ impl MutatePlan {
     ) -> Result<Self> {
         let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
-        let returning = get_returning_columns(request, table);
+        let returning = get_returning_columns(request, table, true);
         let apply_defaults = asked_for_defaults(request);
 
         // `Prefer: resolution=` says what to do about a duplicate; `on_conflict=`
@@ -133,7 +133,7 @@ impl MutatePlan {
         let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let where_clauses = build_mutation_where(request, table)?;
-        let returning = get_returning_columns(request, table);
+        let returning = get_returning_columns(request, table, false);
         let apply_defaults = asked_for_defaults(request);
 
         Ok(Self::Update {
@@ -149,7 +149,7 @@ impl MutatePlan {
     /// Create a DELETE plan.
     fn create_delete(request: &ApiRequest, table: &Table, qi: QualifiedIdentifier) -> Result<Self> {
         let where_clauses = build_mutation_where(request, table)?;
-        let returning = get_returning_columns(request, table);
+        let returning = get_returning_columns(request, table, false);
 
         Ok(Self::Delete {
             target: qi,
@@ -169,7 +169,7 @@ impl MutatePlan {
 
         let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
-        let returning = get_returning_columns(request, table);
+        let returning = get_returning_columns(request, table, true);
 
         // Upsert uses PK for conflict
         let on_conflict = Some((PreferResolution::MergeDuplicates, table.pk_cols.clone()));
@@ -347,14 +347,74 @@ fn get_body_bytes(request: &ApiRequest) -> Result<Option<bytes::Bytes>> {
     }
 }
 
-/// Get returning columns.
-fn get_returning_columns(_request: &ApiRequest, table: &Table) -> Vec<String> {
-    // Every column, always. What the client asked for is decided by the read
-    // that runs over the result -- `?select=` may name computed fields and
-    // embedded resources, neither of which a `RETURNING` list can express --
-    // and the primary key is needed for the `Location` header whether or not
-    // the client asked to see it.
-    table.column_names().map(|s| s.to_string()).collect()
+/// The columns a mutation has to return.
+///
+/// `RETURNING` runs with the caller's privileges, so asking for a column the
+/// role may write but not read fails the whole statement. A role granted
+/// `INSERT` on an audit table and nothing else is an ordinary arrangement, and
+/// returning every column made it impossible to insert into one.
+///
+/// So: only what the response will actually read. That is the selected
+/// columns, whatever the result is ordered by, and the key a `Location` header
+/// is built from. A caller wanting no representation reads nothing, and the
+/// list is then empty.
+///
+/// The exceptions return the whole row, because they need it: `*` says so, and
+/// a computed field is a function of the row rather than of any column.
+fn get_returning_columns(request: &ApiRequest, table: &Table, creates: bool) -> Vec<String> {
+    use crate::api_request::SelectItem;
+
+    let everything = || -> Vec<String> { table.column_names().map(str::to_string).collect() };
+
+    let mut wanted: Vec<String> = Vec::new();
+
+    // `headers-only` reads no columns but still needs the key.
+    if request.preferences.representation.needs_body() {
+        if request.query_params.select.is_empty() {
+            return everything();
+        }
+        for item in &request.query_params.select {
+            match item {
+                SelectItem::Field { field, .. } => {
+                    if field.name == "*" || table.computed_columns.contains_key(&field.name) {
+                        return everything();
+                    }
+                    wanted.push(field.name.clone());
+                }
+                // An embed joins on a column of this row, and that column was
+                // added to the selection before planning began.
+                SelectItem::Relation { .. } | SelectItem::SpreadRelation { .. } => {}
+            }
+        }
+        // Ordering the returned rows by a column means reading that column,
+        // whether or not the client asked to see it. A term naming an
+        // embedded resource orders by something this statement cannot return
+        // at all.
+        for (path, terms) in &request.query_params.order {
+            if !path.is_empty() {
+                continue;
+            }
+            for term in terms {
+                if let crate::api_request::OrderTerm::Field { field, .. } = term {
+                    wanted.push(field.name.clone());
+                }
+            }
+        }
+    }
+
+    // The created row's own address is built from its key, whether or not the
+    // client asked to see it.
+    if creates {
+        wanted.extend(table.pk_cols.iter().cloned());
+    }
+
+    // A name that is not a column of this table cannot be returned from it;
+    // where it is anything real -- a JSON path, an alias -- the read resolves
+    // it against what did come back.
+    wanted.retain(|name| table.get_column(name).is_some());
+    wanted.sort();
+    wanted.dedup();
+    wanted
 }
 
 /// Build WHERE clauses for mutations.
@@ -373,6 +433,16 @@ fn build_mutation_where(request: &ApiRequest, table: &Table) -> Result<Vec<Coerc
         clauses.push(CoercibleLogicTree::Stmt(CoercibleFilter::from_filter(
             filter, &pg_type,
         )));
+    }
+
+    // `?or=(...)` names rows exactly as a plain filter does, and a mutation
+    // that reads only the plain ones has no `WHERE` at all -- so
+    // `DELETE /entities?or=(id.eq.1,id.eq.2)` deleted every row in the table.
+    // A request that names two rows must never touch a third.
+    for (path, tree) in &request.query_params.logic {
+        if path.is_empty() {
+            clauses.push(CoercibleLogicTree::from_logic_tree(tree, type_resolver));
+        }
     }
 
     Ok(clauses)

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -56,20 +56,30 @@ pub enum MutatePlan {
 
 impl MutatePlan {
     /// Create a mutation plan from an API request.
-    pub fn from_request(request: &ApiRequest, table: &Table, mutation: &Mutation) -> Result<Self> {
+    pub fn from_request(
+        request: &ApiRequest,
+        table: &Table,
+        mutation: &Mutation,
+        schema_cache: &crate::schema_cache::SchemaCache,
+    ) -> Result<Self> {
         let qi = table.qualified_identifier();
 
         match mutation {
-            Mutation::Create => Self::create_insert(request, table, qi),
-            Mutation::Update => Self::create_update(request, table, qi),
+            Mutation::Create => Self::create_insert(request, table, qi, schema_cache),
+            Mutation::Update => Self::create_update(request, table, qi, schema_cache),
             Mutation::Delete => Self::create_delete(request, table, qi),
-            Mutation::SingleUpsert => Self::create_upsert(request, table, qi),
+            Mutation::SingleUpsert => Self::create_upsert(request, table, qi, schema_cache),
         }
     }
 
     /// Create an INSERT plan.
-    fn create_insert(request: &ApiRequest, table: &Table, qi: QualifiedIdentifier) -> Result<Self> {
-        let columns = get_payload_columns(request, table)?;
+    fn create_insert(
+        request: &ApiRequest,
+        table: &Table,
+        qi: QualifiedIdentifier,
+        schema_cache: &crate::schema_cache::SchemaCache,
+    ) -> Result<Self> {
+        let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let returning = get_returning_columns(request, table);
         let apply_defaults =
@@ -97,8 +107,13 @@ impl MutatePlan {
     }
 
     /// Create an UPDATE plan.
-    fn create_update(request: &ApiRequest, table: &Table, qi: QualifiedIdentifier) -> Result<Self> {
-        let columns = get_payload_columns(request, table)?;
+    fn create_update(
+        request: &ApiRequest,
+        table: &Table,
+        qi: QualifiedIdentifier,
+        schema_cache: &crate::schema_cache::SchemaCache,
+    ) -> Result<Self> {
+        let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let where_clauses = build_mutation_where(request, table)?;
         let returning = get_returning_columns(request, table);
@@ -128,8 +143,13 @@ impl MutatePlan {
     }
 
     /// Create a PUT (upsert) plan.
-    fn create_upsert(request: &ApiRequest, table: &Table, qi: QualifiedIdentifier) -> Result<Self> {
-        let columns = get_payload_columns(request, table)?;
+    fn create_upsert(
+        request: &ApiRequest,
+        table: &Table,
+        qi: QualifiedIdentifier,
+        schema_cache: &crate::schema_cache::SchemaCache,
+    ) -> Result<Self> {
+        let columns = get_payload_columns(request, table, schema_cache)?;
         let body = get_body_bytes(request)?;
         let returning = get_returning_columns(request, table);
 
@@ -168,21 +188,43 @@ impl MutatePlan {
 }
 
 /// Get columns from payload.
-fn get_payload_columns(request: &ApiRequest, table: &Table) -> Result<Vec<CoercibleField>> {
+fn get_payload_columns(
+    request: &ApiRequest,
+    table: &Table,
+    schema_cache: &crate::schema_cache::SchemaCache,
+) -> Result<Vec<CoercibleField>> {
     let keys = match &request.payload {
         Some(Payload::ProcessedJson { keys, .. }) => keys,
         Some(Payload::ProcessedUrlEncoded { keys, .. }) => keys,
         _ => return Ok(vec![]),
     };
 
+    // `?columns=` names the columns to write and fixes their order, which is
+    // what makes a bulk insert of ragged rows well-defined. Without it the
+    // body's own keys are the columns.
+    let names: Vec<&String> = match &request.query_params.columns {
+        Some(columns) => columns.iter().collect(),
+        None => keys.iter().collect(),
+    };
+
     let mut columns = Vec::new();
 
-    for key in keys {
-        let column = table
-            .get_column(key)
-            .ok_or_else(|| Error::UnknownColumn(key.clone()))?;
+    for key in names {
+        let column = table.get_column(key).ok_or_else(|| Error::UnknownColumn {
+            column: key.clone(),
+            relation: table.name.clone(),
+        })?;
 
-        columns.push(CoercibleField::simple(key, &column.data_type));
+        let mut field = CoercibleField::simple(key, &column.nominal_type);
+        // A schema that declared how one of its domains is written in JSON
+        // also declared how one arrives: the value is read out of the body as
+        // JSON and handed to that cast, rather than to PostgreSQL's own input
+        // function for the type underneath.
+        if let Some(function) = schema_cache.representation("json", &column.nominal_type) {
+            field.ir_type = "json".to_string();
+            field.transform = Some(function.to_string());
+        }
+        columns.push(field);
     }
 
     Ok(columns)
@@ -210,13 +252,13 @@ fn get_body_bytes(request: &ApiRequest) -> Result<Option<bytes::Bytes>> {
 }
 
 /// Get returning columns.
-fn get_returning_columns(request: &ApiRequest, table: &Table) -> Vec<String> {
-    if request.preferences.representation.needs_body() {
-        table.column_names().map(|s| s.to_string()).collect()
-    } else {
-        // Always return PK for Location header
-        table.pk_cols.clone()
-    }
+fn get_returning_columns(_request: &ApiRequest, table: &Table) -> Vec<String> {
+    // Every column, always. What the client asked for is decided by the read
+    // that runs over the result -- `?select=` may name computed fields and
+    // embedded resources, neither of which a `RETURNING` list can express --
+    // and the primary key is needed for the `Location` header whether or not
+    // the client asked to see it.
+    table.column_names().map(|s| s.to_string()).collect()
 }
 
 /// Build WHERE clauses for mutations.

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -174,12 +174,18 @@ impl MutatePlan {
         // Upsert uses PK for conflict
         let on_conflict = Some((PreferResolution::MergeDuplicates, table.pk_cols.clone()));
 
+        // The URL's filters narrow the *body*, not the table: a `PUT` writes
+        // the row the URL names, so a body row naming a different one is left
+        // unwritten rather than rejected outright. Whether exactly one row
+        // came of it is checked afterwards.
+        let where_clauses = build_mutation_where(request, table)?;
+
         Ok(Self::Insert {
             target: qi,
             columns,
             body,
             on_conflict,
-            where_clauses: vec![],
+            where_clauses,
             returning,
             pk_cols: table.pk_cols.clone(),
             apply_defaults: asked_for_defaults(request),
@@ -313,36 +319,9 @@ fn validate_put(request: &ApiRequest, table: &Table) -> Result<()> {
         return Err(Error::InvalidPutFilters);
     }
 
-    // The body may leave a key out -- the URL already said what it is -- but
-    // where it names one it has to be the same one. A body written as an
-    // array is checked element by element: `PUT` writes the row the URL names
-    // and no other, however many the body offers.
-    if let Some(Payload::ProcessedJson { raw, .. }) = &request.payload {
-        let rows = match serde_json::from_slice(raw) {
-            Ok(serde_json::Value::Object(row)) => vec![row],
-            Ok(serde_json::Value::Array(rows)) => rows
-                .into_iter()
-                .filter_map(|row| match row {
-                    serde_json::Value::Object(row) => Some(row),
-                    _ => None,
-                })
-                .collect(),
-            _ => vec![],
-        };
-
-        for row in rows {
-            for key in &table.pk_cols {
-                let Some(value) = row.get(key) else { continue };
-                let value = match value {
-                    serde_json::Value::String(text) => text.clone(),
-                    other => other.to_string(),
-                };
-                if keyed.get(key.as_str()) != Some(&value.as_str()) {
-                    return Err(Error::PutMatchingPk);
-                }
-            }
-        }
-    }
+    // Whether the body agrees with the URL is not decided here: the filters
+    // are applied to the body itself, so a row naming another key is simply
+    // not written, and the count that comes back says whether exactly one was.
 
     Ok(())
 }

--- a/crates/postrust-core/src/plan/mutate_plan.rs
+++ b/crates/postrust-core/src/plan/mutate_plan.rs
@@ -27,6 +27,12 @@ pub enum MutatePlan {
         pk_cols: Vec<String>,
         /// Apply defaults for missing columns
         apply_defaults: bool,
+        /// Whether the statement can report which rows it created.
+        ///
+        /// It asks PostgreSQL for `xmax`, which a plain table will give back
+        /// and a view or a partitioned table will not.
+        #[serde(default)]
+        reports_inserted: bool,
     },
     /// UPDATE operation
     Update {
@@ -114,6 +120,7 @@ impl MutatePlan {
             returning,
             pk_cols: table.pk_cols.clone(),
             apply_defaults,
+            reports_inserted: !table.is_view && !table.is_partitioned,
         })
     }
 
@@ -178,6 +185,7 @@ impl MutatePlan {
             returning,
             pk_cols: table.pk_cols.clone(),
             apply_defaults: true,
+            reports_inserted: !table.is_view && !table.is_partitioned,
         })
     }
 
@@ -408,6 +416,7 @@ mod tests {
             returning: vec![],
             pk_cols: vec![],
             apply_defaults: true,
+            reports_inserted: false,
         };
         assert!(insert.has_body());
 

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -122,12 +122,39 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
                 cast,
                 alias,
             } => {
-                let column = table
-                    .get_column(&field.name)
-                    .ok_or_else(|| Error::ColumnNotFound(field.name.clone()))?;
+                // A bare `count` means COUNT(*) -- PostgREST's original
+                // spelling, still accepted and, unlike `count()`, not gated
+                // behind db-aggregates-enabled. A table that really has a
+                // column of that name wins, which is why this is decided here
+                // rather than in the parser.
+                let legacy_count = aggregate.is_none()
+                    && field.name == "count"
+                    && field.json_path.is_empty()
+                    && table.get_column("count").is_none();
+
+                // `count()` has no column behind it, so there is nothing to
+                // resolve and no type to carry.
+                let pg_type = if field.name.is_empty() || legacy_count {
+                    String::new()
+                } else {
+                    table
+                        .get_column(&field.name)
+                        .ok_or_else(|| Error::ColumnNotFound(field.name.clone()))?
+                        .data_type
+                        .clone()
+                };
+
+                let (field, aggregate) = if legacy_count {
+                    (
+                        &crate::api_request::Field::simple(""),
+                        &Some(crate::api_request::AggregateFunction::Count),
+                    )
+                } else {
+                    (field, aggregate)
+                };
 
                 fields.push(CoercibleSelectField {
-                    field: CoercibleField::from_field(field, &column.data_type),
+                    field: CoercibleField::from_field(field, &pg_type),
                     aggregate: aggregate.clone(),
                     aggregate_cast: aggregate_cast.clone(),
                     cast: cast.clone(),

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -290,6 +290,7 @@ fn build_relation_selects(
                 relation,
                 hint: _,
                 join_type,
+                select: _,
             } => {
                 let _rel = schema_cache
                     .find_relationship(&table.qualified_identifier(), relation, &table.schema)

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -58,7 +58,9 @@ impl ReadPlan {
             let Some(column) = table.get_column(&field.field.name) else {
                 continue;
             };
-            if let Some(function) = schema_cache.representation(&column.nominal_type, "json") {
+            if let Some(function) =
+                schema_cache.representation(column.representation_type(), "json")
+            {
                 field.field.transform = Some(function.to_string());
             }
         }
@@ -337,7 +339,7 @@ fn attach_representation(field: &mut CoercibleField, table: &Table, schema_cache
     let Some(column) = table.get_column(&field.name) else {
         return;
     };
-    if let Some(function) = schema_cache.representation("text", &column.nominal_type) {
+    if let Some(function) = schema_cache.representation("text", column.representation_type()) {
         field.transform = Some(function.to_string());
     }
 }

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -268,13 +268,18 @@ fn build_relation_selects(
             SelectItem::Relation {
                 relation,
                 alias,
-                hint: _,
+                hint,
                 join_type,
                 select: _,
             } => {
                 // Verify relationship exists
                 let _rel = schema_cache
-                    .find_relationship(&table.qualified_identifier(), relation, &table.schema)
+                    .find_relationship(
+                        &table.qualified_identifier(),
+                        relation,
+                        hint.as_deref(),
+                        &table.schema,
+                    )?
                     .ok_or_else(|| Error::RelationshipNotFound(relation.clone()))?;
 
                 rel_selects.push(RelSelectField {
@@ -288,12 +293,17 @@ fn build_relation_selects(
             }
             SelectItem::SpreadRelation {
                 relation,
-                hint: _,
+                hint,
                 join_type,
                 select: _,
             } => {
                 let _rel = schema_cache
-                    .find_relationship(&table.qualified_identifier(), relation, &table.schema)
+                    .find_relationship(
+                        &table.qualified_identifier(),
+                        relation,
+                        hint.as_deref(),
+                        &table.schema,
+                    )?
                     .ok_or_else(|| Error::RelationshipNotFound(relation.clone()))?;
 
                 rel_selects.push(RelSelectField {

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -45,10 +45,52 @@ impl ReadPlan {
         let qi = table.qualified_identifier();
 
         // Build select fields
-        let select = build_select_fields(&request.query_params.select, table)?;
+        let mut select = build_select_fields(&request.query_params.select, table)?;
+
+        // A schema may declare how a value of one of its domains is written on
+        // the wire -- a `color` as `"#01E240"` rather than as the integer it is
+        // stored as. The cast it declared does the rendering, in the database,
+        // which is also the only place that knows about it.
+        for field in select.iter_mut() {
+            if field.field.transform.is_some() || field.aggregate.is_some() {
+                continue;
+            }
+            let Some(column) = table.get_column(&field.field.name) else {
+                continue;
+            };
+            if let Some(function) = schema_cache.representation(&column.nominal_type, "json") {
+                field.field.transform = Some(function.to_string());
+            }
+        }
+
+        // `Prefer: timezone` changes how a `timestamptz` reads, and only
+        // PostgreSQL knows the session's zone -- this process would render
+        // every one of them in UTC. Handing the rendering to the database is
+        // what PostgREST does for every value; here it is done only where the
+        // answer depends on it.
+        if request.preferences.timezone.is_some() {
+            for field in select.iter_mut() {
+                if field.cast.is_none()
+                    && field.aggregate.is_none()
+                    && field.field.json_path.is_empty()
+                    && matches!(
+                        field.field.ir_type.as_str(),
+                        "timestamptz"
+                            | "timetz"
+                            | "timestamp with time zone"
+                            | "time with time zone"
+                    )
+                {
+                    field.field.transform = Some("to_jsonb".to_string());
+                }
+            }
+        }
 
         // Build where clauses from filters
-        let where_clauses = build_where_clauses(request, table)?;
+        let mut where_clauses = build_where_clauses(request, table)?;
+        for clause in where_clauses.iter_mut() {
+            attach_representation_tree(clause, table, schema_cache);
+        }
 
         // Build order terms
         let order = build_order_terms(request, table)?;
@@ -143,8 +185,17 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
 
                 // `count()` has no column behind it, so there is nothing to
                 // resolve and no type to carry.
+                // A name the table has no column for may still be a function
+                // of its row type, which reads as a column.
+                let computed = match table.get_column(&field.name) {
+                    Some(_) => None,
+                    None => table.get_computed_column(&field.name),
+                };
+
                 let pg_type = if field.name.is_empty() || legacy_count {
                     String::new()
+                } else if let Some(computed) = computed {
+                    computed.data_type.clone()
                 } else {
                     table
                         .get_column(&field.name)
@@ -162,8 +213,14 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
                     (field, aggregate)
                 };
 
+                let mut resolved = CoercibleField::from_field(field, &pg_type);
+                resolved.computed = computed.map(|computed| crate::plan::ComputedRef {
+                    function: computed.function.clone(),
+                    relation: table.name.clone(),
+                });
+
                 fields.push(CoercibleSelectField {
-                    field: CoercibleField::from_field(field, &pg_type),
+                    field: resolved,
                     aggregate: aggregate.clone(),
                     aggregate_cast: aggregate_cast.clone(),
                     cast: cast.clone(),
@@ -257,7 +314,78 @@ fn build_where_clauses(request: &ApiRequest, table: &Table) -> Result<Vec<Coerci
         }
     }
 
+    for clause in clauses.iter_mut() {
+        attach_computed_tree(clause, table);
+    }
+
     Ok(clauses)
+}
+
+/// Point a filter's value at the function that parses it.
+///
+/// The mirror of the output representation: where a schema declares a cast
+/// from `text` to one of its domains, a filter value written in the domain's
+/// own spelling is read by that cast rather than by PostgreSQL's input
+/// function for the underlying type.
+fn attach_representation(field: &mut CoercibleField, table: &Table, schema_cache: &SchemaCache) {
+    let Some(column) = table.get_column(&field.name) else {
+        return;
+    };
+    if let Some(function) = schema_cache.representation("text", &column.nominal_type) {
+        field.transform = Some(function.to_string());
+    }
+}
+
+/// Walk a logic tree, giving every filter in it its input representation.
+fn attach_representation_tree(
+    tree: &mut CoercibleLogicTree,
+    table: &Table,
+    schema_cache: &SchemaCache,
+) {
+    match tree {
+        CoercibleLogicTree::Expr { children, .. } => {
+            for child in children {
+                attach_representation_tree(child, table, schema_cache);
+            }
+        }
+        CoercibleLogicTree::Stmt(filter) => {
+            attach_representation(&mut filter.field, table, schema_cache)
+        }
+        CoercibleLogicTree::NullEmbed { .. } => {}
+    }
+}
+
+/// Point a field at the function behind it, where the table has no such column.
+///
+/// A filter or an order term names a field the same way a select does, so a
+/// computed field has to be recognised in all three -- `?always_true=is.true`
+/// and `?order=anti_id.desc` are as much a part of PostgREST's contract as
+/// `?select=always_true`.
+fn attach_computed(field: &mut CoercibleField, table: &Table) {
+    if table.get_column(&field.name).is_some() {
+        return;
+    }
+    if let Some(computed) = table.get_computed_column(&field.name) {
+        field.ir_type = computed.data_type.clone();
+        field.base_type = computed.data_type.clone();
+        field.computed = Some(crate::plan::ComputedRef {
+            function: computed.function.clone(),
+            relation: table.name.clone(),
+        });
+    }
+}
+
+/// Walk a logic tree, resolving every field it names.
+fn attach_computed_tree(tree: &mut CoercibleLogicTree, table: &Table) {
+    match tree {
+        CoercibleLogicTree::Expr { children, .. } => {
+            for child in children {
+                attach_computed_tree(child, table);
+            }
+        }
+        CoercibleLogicTree::Stmt(filter) => attach_computed(&mut filter.field, table),
+        CoercibleLogicTree::NullEmbed { .. } => {}
+    }
 }
 
 /// Build order terms from request.
@@ -277,7 +405,9 @@ fn build_order_terms(request: &ApiRequest, table: &Table) -> Result<Vec<Coercibl
                     .map(|c| c.data_type.as_str())
                     .unwrap_or("text");
 
-                terms.push(CoercibleOrderTerm::from_order_term(term, pg_type));
+                let mut resolved = CoercibleOrderTerm::from_order_term(term, pg_type);
+                attach_computed(&mut resolved.field, table);
+                terms.push(resolved);
             }
         }
     }
@@ -310,7 +440,14 @@ fn build_relation_selects(
                         hint.as_deref(),
                         &table.schema,
                     )?
-                    .ok_or_else(|| Error::RelationshipNotFound(relation.clone()))?;
+                    .ok_or_else(|| {
+                        schema_cache.relationship_not_found(
+                            &table.qualified_identifier(),
+                            relation,
+                            hint.as_deref(),
+                            &table.schema,
+                        )
+                    })?;
 
                 rel_selects.push(RelSelectField {
                     name: relation.clone(),
@@ -334,7 +471,14 @@ fn build_relation_selects(
                         hint.as_deref(),
                         &table.schema,
                     )?
-                    .ok_or_else(|| Error::RelationshipNotFound(relation.clone()))?;
+                    .ok_or_else(|| {
+                        schema_cache.relationship_not_found(
+                            &table.qualified_identifier(),
+                            relation,
+                            hint.as_deref(),
+                            &table.schema,
+                        )
+                    })?;
 
                 rel_selects.push(RelSelectField {
                     name: relation.clone(),

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -219,10 +219,31 @@ fn build_where_clauses(request: &ApiRequest, table: &Table) -> Result<Vec<Coerci
             .unwrap_or_else(|| "text".to_string())
     };
 
+    // `?clients=is.null` names an embedded resource, not a column: it asks
+    // whether the embed matched. That is decided where the embed exists, which
+    // is above this query, so it is left out here. A real column of the same
+    // name wins, since then the filter means what it usually means.
+    let embedded: std::collections::HashSet<&str> = request
+        .query_params
+        .select
+        .iter()
+        .filter_map(|item| match item {
+            SelectItem::Relation {
+                relation, alias, ..
+            } => Some(alias.as_deref().unwrap_or(relation)),
+            SelectItem::SpreadRelation { relation, .. } => Some(relation.as_str()),
+            SelectItem::Field { .. } => None,
+        })
+        .filter(|name| table.get_column(name).is_none())
+        .collect();
+
     let mut clauses = Vec::new();
 
     // Add root filters
     for filter in &request.query_params.filters_root {
+        if embedded.contains(filter.field.name.as_str()) {
+            continue;
+        }
         let pg_type = type_resolver(&filter.field.name);
         clauses.push(CoercibleLogicTree::Stmt(CoercibleFilter::from_filter(
             filter, &pg_type,

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -131,6 +131,15 @@ impl ReadPlan {
         plan.from = QualifiedIdentifier::unqualified(crate::query::MUTATION_RESULT);
         plan.from_alias = None;
         plan.where_clauses.clear();
+
+        // A computed field is a function of the row it is read from, and the
+        // rows here are the statement's result rather than the table's.
+        for field in plan.select.iter_mut() {
+            if let Some(computed) = field.field.computed.as_mut() {
+                computed.relation = crate::query::MUTATION_RESULT.to_string();
+            }
+        }
+
         Ok(plan)
     }
 

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -260,14 +260,14 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
 /// server-configured `max_rows` is then applied as a ceiling, so a request that
 /// asks for no limit -- or for more rows than the server permits -- cannot pull
 /// an unbounded result set into memory.
-fn resolve_top_level_range(request: &ApiRequest) -> Range {
+pub fn resolve_top_level_range(request: &ApiRequest) -> Range {
     let mut range = request.top_level_range.clone();
 
     if let Some(from_params) = request.query_params.ranges.get("") {
         if from_params.limit.is_some() {
             range.limit = from_params.limit;
         }
-        if from_params.offset != 0 {
+        if from_params.offset_explicit {
             range.offset = from_params.offset;
         }
     }

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -121,8 +121,14 @@ impl ReadPlan {
         schema_cache: &SchemaCache,
     ) -> Result<Self> {
         let mut plan = Self::from_request(request, table, schema_cache)?;
-        // For mutations, we select from the CTE result
-        plan.from_alias = Some("pgrst_mutation_result".to_string());
+
+        // The rows read are the ones the mutation returned, not the table's.
+        // The filters chose which rows to affect and have already done their
+        // work; applying them again here would be harmless for an update and
+        // wrong for a delete, whose rows are gone by then.
+        plan.from = QualifiedIdentifier::unqualified(crate::query::MUTATION_RESULT);
+        plan.from_alias = None;
+        plan.where_clauses.clear();
         Ok(plan)
     }
 

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -115,6 +115,15 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
 
     for item in items {
         match item {
+            // `*` stands for every column, and may sit alongside others.
+            SelectItem::Field { field, .. } if field.name == "*" => {
+                fields.extend(
+                    table
+                        .columns
+                        .iter()
+                        .map(|(name, col)| CoercibleSelectField::simple(name, &col.data_type)),
+                );
+            }
             SelectItem::Field {
                 field,
                 aggregate,

--- a/crates/postrust-core/src/plan/read_plan.rs
+++ b/crates/postrust-core/src/plan/read_plan.rs
@@ -234,6 +234,7 @@ fn build_select_fields(items: &[SelectItem], table: &Table) -> Result<Vec<Coerci
                 resolved.computed = computed.map(|computed| crate::plan::ComputedRef {
                     function: computed.function.clone(),
                     relation: table.name.clone(),
+                    row_type: table.qualified_identifier(),
                 });
 
                 fields.push(CoercibleSelectField {
@@ -324,9 +325,14 @@ fn build_where_clauses(request: &ApiRequest, table: &Table) -> Result<Vec<Coerci
         )));
     }
 
-    // Add logic trees
+    // Add logic trees.
+    //
+    // One made entirely of embedded resource names is about whether those
+    // embeds matched, which nothing here can answer -- the embeds are not in
+    // scope until they have been joined. It is applied out there instead.
+    let embeds = crate::api_request::embedded_names(&request.query_params.select);
     for (path, tree) in &request.query_params.logic {
-        if path.is_empty() {
+        if path.is_empty() && !tree.names_only(&embeds) {
             clauses.push(CoercibleLogicTree::from_logic_tree(tree, type_resolver));
         }
     }
@@ -388,6 +394,7 @@ fn attach_computed(field: &mut CoercibleField, table: &Table) {
         field.computed = Some(crate::plan::ComputedRef {
             function: computed.function.clone(),
             relation: table.name.clone(),
+            row_type: table.qualified_identifier(),
         });
     }
 }

--- a/crates/postrust-core/src/plan/types.rs
+++ b/crates/postrust-core/src/plan/types.rs
@@ -46,6 +46,15 @@ pub struct ComputedRef {
     pub function: QualifiedIdentifier,
     /// The relation whose row it takes, as it is named in the query.
     pub relation: String,
+    /// The type that row is, which is not always what the query can infer.
+    ///
+    /// A mutation reads its rows back out of a CTE, and a CTE's row is a
+    /// `record`: `computed_overload(record) is not unique` is PostgreSQL
+    /// declining to choose between the overload on `items` and the one on
+    /// `items2`, because nothing said which it had. Casting the row to the
+    /// relation's own type says so, and is a no-op everywhere it was already
+    /// unambiguous.
+    pub row_type: QualifiedIdentifier,
 }
 
 /// Whether a JSON path over a column of `pg_type` has to go through `to_jsonb`.

--- a/crates/postrust-core/src/plan/types.rs
+++ b/crates/postrust-core/src/plan/types.rs
@@ -30,6 +30,34 @@ pub struct CoercibleField {
     pub default: Option<String>,
     /// Whether to select full row
     pub full_row: bool,
+    /// A function to read this field from, rather than a column of the table.
+    ///
+    /// Carries the relation to pass it as well as the function itself: the
+    /// call is `always_true(items)`, and the name of the row is only known
+    /// where the plan was built.
+    #[serde(default)]
+    pub computed: Option<ComputedRef>,
+}
+
+/// A computed field: a function applied to the row.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ComputedRef {
+    /// The function to call.
+    pub function: QualifiedIdentifier,
+    /// The relation whose row it takes, as it is named in the query.
+    pub relation: String,
+}
+
+/// Whether a JSON path over a column of `pg_type` has to go through `to_jsonb`.
+///
+/// `->` and `->>` are only defined on `json` and `jsonb`. PostgREST lets them
+/// reach into anything the database can render as JSON -- a composite type, an
+/// array -- by converting the column first, so `numbers->0` indexes an
+/// `integer[]` and `num->i` reads a field of a composite. A column that is
+/// already JSON is left alone: converting it would be a no-op at best and, for
+/// `json`, a needless re-parse.
+fn needs_to_json(json_path: &JsonPath, pg_type: &str) -> bool {
+    !json_path.is_empty() && !matches!(pg_type, "json" | "jsonb")
 }
 
 impl CoercibleField {
@@ -46,6 +74,7 @@ impl CoercibleField {
             transform: None,
             default: None,
             full_row: false,
+            computed: None,
         }
     }
 
@@ -54,13 +83,14 @@ impl CoercibleField {
         Self {
             name: field.name.clone(),
             json_path: field.json_path.clone(),
-            to_json: false,
+            to_json: needs_to_json(&field.json_path, pg_type),
             to_tsvector: None,
             ir_type: pg_type.to_string(),
             base_type: pg_type.to_string(),
             transform: None,
             default: None,
             full_row: false,
+            computed: None,
         }
     }
 }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -222,9 +222,24 @@ impl QueryBuilder {
             frag.push("NOT (");
         }
 
-        // Column name
+        // Column name.
+        //
+        // A text-search operator wants a `tsvector` on the left. A column that
+        // is not already one is wrapped, so `text_search=fts.x` searches the
+        // text instead of failing to find an operator. A domain over tsvector
+        // is already one, hence the prefix test rather than an equality.
+        let to_tsvector = matches!(
+            filter.op_expr.operation,
+            crate::api_request::Operation::Fts { .. }
+        ) && !filter.field.ir_type.starts_with("tsvector");
+        if to_tsvector {
+            frag.push("to_tsvector(");
+        }
         frag.push(&escape_ident(&filter.field.name));
         push_json_path(&mut frag, &filter.field.json_path);
+        if to_tsvector {
+            frag.push(")");
+        }
 
         // Filter values are always bound as text, so a comparison against a
         // non-text column needs an explicit cast on the placeholder -- without
@@ -317,9 +332,15 @@ impl QueryBuilder {
                 frag.push(op.to_function());
                 frag.push("(");
                 if let Some(lang) = language {
-                    frag.push_param(lang.clone());
+                    // The text-search functions take their configuration as a
+                    // `regconfig`, and there is no `to_tsquery(text, text)` to
+                    // fall back on -- bound as plain text the call resolves to
+                    // no function at all.
+                    frag.push_typed_param(lang.clone(), "regconfig");
                     frag.push(", ");
                 }
+                // The query is text whatever the column holds, so it never
+                // takes the column's own cast.
                 frag.push_param(value.clone());
                 frag.push(")");
             }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -555,6 +555,7 @@ impl QueryBuilder {
                 where_clauses,
                 returning,
                 reports_inserted,
+                apply_defaults,
                 ..
             } => {
                 let qi = postrust_sql::identifier::QualifiedIdentifier::new(
@@ -599,7 +600,7 @@ impl QueryBuilder {
                             frag.push(&escape_ident(&column.name));
                         }
                         frag.push(" ");
-                        push_json_body(&mut frag, columns, body, false);
+                        push_json_body(&mut frag, columns, body, false, *apply_defaults);
 
                         // PUT names the row in the URL as well as in the body,
                         // and the two have to agree -- the conditions are
@@ -672,6 +673,7 @@ impl QueryBuilder {
                 body,
                 where_clauses,
                 returning,
+                apply_defaults,
                 ..
             } => {
                 let qi = postrust_sql::identifier::QualifiedIdentifier::new(
@@ -706,7 +708,7 @@ impl QueryBuilder {
                     frag.push(&escape_ident(&column.name));
                 }
                 frag.push(" ");
-                push_json_body(&mut frag, columns, body, true);
+                push_json_body(&mut frag, columns, body, true, *apply_defaults);
 
                 if !where_clauses.is_empty() {
                     frag.push(" WHERE ");
@@ -929,13 +931,56 @@ fn push_json_body(
     columns: &[crate::plan::CoercibleField],
     body: &bytes::Bytes,
     single: bool,
+    apply_defaults: bool,
 ) {
     let body = String::from_utf8_lossy(body).into_owned();
     let object = body.trim_start().starts_with('{');
 
+    // `Prefer: missing=default` asks for a column the body left out to take
+    // the value the table would have given it, rather than null. The defaults
+    // are merged underneath the body, so anything the body did name still
+    // wins -- which is why this is `defaults || body` and not the reverse.
+    let defaults: Vec<&crate::plan::CoercibleField> = match apply_defaults {
+        true => columns.iter().filter(|c| c.default.is_some()).collect(),
+        false => Vec::new(),
+    };
+    let merged = !defaults.is_empty();
+
     frag.push("FROM (SELECT ");
     frag.push_param(body);
-    frag.push("::json AS json_data) pgrst_payload, LATERAL (SELECT ");
+    frag.push(match merged {
+        true => "::jsonb AS json_data) pgrst_payload, ",
+        false => "::json AS json_data) pgrst_payload, ",
+    });
+
+    if merged {
+        let mut pairs = String::new();
+        for (i, column) in defaults.iter().enumerate() {
+            if i > 0 {
+                pairs.push_str(", ");
+            }
+            pairs.push_str(&format!(
+                "{}, {}",
+                postrust_sql::quote_literal(&column.name),
+                column.default.as_deref().unwrap_or("NULL")
+            ));
+        }
+        frag.push(match single || object {
+            true => "LATERAL (SELECT jsonb_build_object(",
+            false => "LATERAL (SELECT jsonb_agg(jsonb_build_object(",
+        });
+        frag.push(&pairs);
+        frag.push(match single || object {
+            true => ") || pgrst_payload.json_data AS val) pgrst_defaults, ",
+            false => {
+                ") || pgrst_element) AS val \
+                 FROM jsonb_array_elements(pgrst_payload.json_data) pgrst_element) \
+                 pgrst_defaults, "
+            }
+        });
+    }
+
+    frag.push("LATERAL (SELECT ");
     for (i, column) in columns.iter().enumerate() {
         if i > 0 {
             frag.push(", ");
@@ -957,9 +1002,11 @@ fn push_json_body(
     // update writes one set of values whatever it matches, so its body is one
     // object -- and a body that is not is an error PostgreSQL words better
     // than this could. An insert may be either, and the body says which.
-    frag.push(match single || object {
-        true => " FROM json_to_record(pgrst_payload.json_data) AS _(",
-        false => " FROM json_to_recordset(pgrst_payload.json_data) AS _(",
+    frag.push(match (merged, single || object) {
+        (false, true) => " FROM json_to_record(pgrst_payload.json_data) AS _(",
+        (false, false) => " FROM json_to_recordset(pgrst_payload.json_data) AS _(",
+        (true, true) => " FROM jsonb_to_record(pgrst_defaults.val) AS _(",
+        (true, false) => " FROM jsonb_to_recordset(pgrst_defaults.val) AS _(",
     });
     for (i, column) in columns.iter().enumerate() {
         if i > 0 {

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -806,11 +806,8 @@ impl QueryBuilder {
                     frag.append(column);
                 }
             }
-            None => {
-                if !render_as_json {
-                    frag.push("*");
-                }
-            }
+            None if !render_as_json => push_declared_columns(&mut frag, plan),
+            None => {}
         }
         if !render_as_json {
             frag.push(" FROM ");
@@ -1108,6 +1105,37 @@ fn push_qualified_field_ref(
         frag.push(&column);
     }
     push_json_path(frag, &field.json_path);
+}
+
+/// Project the columns a function declares, rather than asking for `*`.
+///
+/// `*` is all a caller can write when the result has no table behind it, and
+/// it leaves a column of a type this process cannot decode to arrive as null.
+/// Naming the columns is what lets those be rendered by the database, exactly
+/// as a table's are. A function that declares none still gets `*`: there is
+/// nothing better to say.
+fn push_declared_columns(frag: &mut SqlFragment, plan: &crate::plan::CallPlan) {
+    if plan.output_columns.is_empty() {
+        frag.push("*");
+        return;
+    }
+
+    for (i, (name, pg_type)) in plan.output_columns.iter().enumerate() {
+        if i > 0 {
+            frag.push(", ");
+        }
+        match decodable_type(pg_type) {
+            true => {
+                frag.push(&escape_ident(name));
+            }
+            false => {
+                frag.push("to_jsonb(");
+                frag.push(&escape_ident(name));
+                frag.push(") AS ");
+                frag.push(&escape_ident(name));
+            }
+        }
+    }
 }
 
 /// The type a JSON path leaves on the left of a comparison.

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -580,8 +580,29 @@ impl QueryBuilder {
 
         // The call itself is the source of rows; the read plan, when there is
         // one, shapes them exactly as it would shape a table's.
+        // A result this process cannot decode is rendered by the database,
+        // exactly as a column of such a type is. Without it a function
+        // returning `xml` or `bytea` answered null.
+        // A composite return -- OUT parameters, `RETURNS TABLE`, a row type --
+        // already expands to its own columns, and wrapping it would bury them
+        // under the function's name.
+        let render_as_json = read.is_none()
+            && !plan.returns_composite
+            && plan
+                .return_type
+                .as_deref()
+                .map(|t| !decodable_type(t) && t != "record")
+                .unwrap_or(false);
+
         let mut frag = SqlFragment::new();
         frag.push("SELECT ");
+        if render_as_json {
+            frag.push("to_jsonb(pgrst_scalar) AS ");
+            frag.push(&escape_ident(&plan.function.name));
+            frag.push(" FROM ");
+            frag.push(&from_qi(&qi));
+            frag.push("(");
+        }
         match read.filter(|tree| !tree.root.select.is_empty()) {
             Some(tree) => {
                 for (i, field) in tree.root.select.iter().enumerate() {
@@ -593,12 +614,16 @@ impl QueryBuilder {
                 }
             }
             None => {
-                frag.push("*");
+                if !render_as_json {
+                    frag.push("*");
+                }
             }
         }
-        frag.push(" FROM ");
-        frag.push(&from_qi(&qi));
-        frag.push("(");
+        if !render_as_json {
+            frag.push(" FROM ");
+            frag.push(&from_qi(&qi));
+            frag.push("(");
+        }
 
         // Arguments come off the wire as strings. Casting each one to the type
         // the function actually declares is what lets PostgreSQL resolve the
@@ -649,6 +674,9 @@ impl QueryBuilder {
         }
 
         frag.push(")");
+        if render_as_json {
+            frag.push(" AS pgrst_scalar");
+        }
 
         // Filters, ordering and paging over the returned rows.
         //

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -107,7 +107,7 @@ impl QueryBuilder {
         let render_as_json = field.aggregate.is_none()
             && field.cast.is_none()
             && field.field.json_path.is_empty()
-            && field.field.ir_type == "USER-DEFINED";
+            && !decodable_type(&field.field.ir_type);
         if render_as_json {
             frag.push("to_jsonb(");
             frag.push(&escape_ident(&field.field.name));
@@ -572,14 +572,31 @@ impl QueryBuilder {
     }
 
     /// Build an RPC call query.
-    pub fn build_call(plan: &CallPlan) -> Result<SqlFragment> {
+    pub fn build_call(plan: &CallPlan, read: Option<&ReadPlanTree>) -> Result<SqlFragment> {
         let qi = postrust_sql::identifier::QualifiedIdentifier::new(
             &plan.function.schema,
             &plan.function.name,
         );
 
+        // The call itself is the source of rows; the read plan, when there is
+        // one, shapes them exactly as it would shape a table's.
         let mut frag = SqlFragment::new();
-        frag.push("SELECT * FROM ");
+        frag.push("SELECT ");
+        match read.filter(|tree| !tree.root.select.is_empty()) {
+            Some(tree) => {
+                for (i, field) in tree.root.select.iter().enumerate() {
+                    if i > 0 {
+                        frag.push(", ");
+                    }
+                    let column = Self::build_select_field(field)?;
+                    frag.append(column);
+                }
+            }
+            None => {
+                frag.push("*");
+            }
+        }
+        frag.push(" FROM ");
         frag.push(&from_qi(&qi));
         frag.push("(");
 
@@ -632,6 +649,32 @@ impl QueryBuilder {
         }
 
         frag.push(")");
+
+        // Filters, ordering and paging over the returned rows.
+        //
+        // The call is left unaliased: a function returning a table's rows is
+        // referred to by that table's name, which is what an unqualified
+        // column in a filter resolves against.
+        if let Some(tree) = read {
+            for (i, clause) in tree.root.where_clauses.iter().enumerate() {
+                frag.push(if i == 0 { " WHERE " } else { " AND " });
+                let expr = Self::build_logic_tree(clause)?;
+                frag.append(expr);
+            }
+
+            for (i, term) in tree.root.order.iter().enumerate() {
+                frag.push(if i == 0 { " ORDER BY " } else { ", " });
+                let order = Self::build_order_term(term).into_fragment();
+                frag.append(order);
+            }
+
+            if let Some(limit) = tree.root.range.limit {
+                frag.push(&format!(" LIMIT {}", limit));
+            }
+            if tree.root.range.offset > 0 {
+                frag.push(&format!(" OFFSET {}", tree.root.range.offset));
+            }
+        }
 
         Ok(frag)
     }
@@ -689,6 +732,42 @@ fn json_path_alias(column: &str, path: &crate::api_request::JsonPath) -> String 
             _ => None,
         })
         .unwrap_or_else(|| column.to_string())
+}
+
+/// Whether this process can decode a column of this type.
+///
+/// The row converter maps a fixed set of types by name and otherwise reads the
+/// column as text, which only works for what PostgreSQL will hand over as
+/// text. Anything else -- `xml`, `bytea`, an array, a PostGIS geometry -- fails
+/// to decode and the column comes back null, so it is rendered in the database
+/// instead. An empty type is a field with no column behind it, such as
+/// `count()`, and never reaches this.
+fn decodable_type(data_type: &str) -> bool {
+    matches!(
+        data_type,
+        "" | "smallint"
+            | "integer"
+            | "bigint"
+            | "numeric"
+            | "decimal"
+            | "real"
+            | "double precision"
+            | "boolean"
+            | "text"
+            | "character varying"
+            | "character"
+            | "name"
+            | "date"
+            | "time"
+            | "time without time zone"
+            | "time with time zone"
+            | "timestamp"
+            | "timestamp without time zone"
+            | "timestamp with time zone"
+            | "uuid"
+            | "json"
+            | "jsonb"
+    )
 }
 
 fn castable_type(pg_type: &str) -> Option<&str> {

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -112,8 +112,15 @@ impl QueryBuilder {
         // the database's own rendering, which for a geometry is the GeoJSON
         // PostgREST returns. PostgREST gets it for free by building its whole
         // response in SQL; this is the same rendering, asked for by name.
+        //
+        // A column with a declared representation is already rendered by that
+        // -- the schema said how the value is written on the wire, and the
+        // generic fallback would render it some other way instead. A `bytea`
+        // with a base64 representation came out as `\x` and hex, which is
+        // PostgreSQL's rendering of bytes and not the schema's.
         let render_as_json = field.aggregate.is_none()
             && field.cast.is_none()
+            && field.field.transform.is_none()
             && field.field.json_path.is_empty()
             && !decodable_type(&field.field.ir_type);
         if render_as_json {
@@ -897,11 +904,25 @@ impl QueryBuilder {
             frag.push(" AS pgrst_scalar) pgrst_call");
         }
 
-        // Filters, ordering and paging over the returned rows.
+        // A function returning a table's rows is aliased to that table.
         //
-        // The call is left unaliased: a function returning a table's rows is
-        // referred to by that table's name, which is what an unqualified
-        // column in a filter resolves against.
+        // PostgreSQL names the range-table entry after the *function*, so
+        // `FROM test.search(...)` puts `search` in scope and not `items`. An
+        // unqualified column resolves either way, there being only one entry
+        // to resolve against -- which is why filters and ordering always
+        // worked and hid this. A computed column does not: it is a function of
+        // the whole row, written `test.always_true(items)`, and naming the row
+        // is the whole point of it. Unaliased, that is `column "items" does
+        // not exist` for a field the same request answers over the table
+        // itself.
+        if let Some(alias) = read.map(|tree| tree.root.from.name.as_str()) {
+            if !render_as_json && !alias.is_empty() {
+                frag.push(" AS ");
+                frag.push(&escape_ident(alias));
+            }
+        }
+
+        // Filters, ordering and paging over the returned rows.
         if let Some(tree) = read {
             for (i, clause) in tree.root.where_clauses.iter().enumerate() {
                 frag.push(if i == 0 { " WHERE " } else { " AND " });
@@ -1115,10 +1136,12 @@ fn push_qualified_field_ref(
     // name here is not -- so the call is written out.
     let column = match &field.computed {
         Some(computed) => format!(
-            "{}.{}({})",
+            "{}.{}({}::{}.{})",
             escape_ident(&computed.function.schema),
             escape_ident(&computed.function.name),
             escape_ident(&computed.relation),
+            escape_ident(&computed.row_type.schema),
+            escape_ident(&computed.row_type.name),
         ),
         None => match qualifier {
             Some(alias) => format!("{}.{}", escape_ident(alias), escape_ident(&field.name)),

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -6,8 +6,7 @@ use crate::plan::{
     CoercibleSelectField, MutatePlan, ReadPlan, ReadPlanTree,
 };
 use postrust_sql::{
-    escape_ident, from_qi, DeleteBuilder, InsertBuilder, OrderExpr, SelectBuilder, SqlFragment,
-    SqlParam, UpdateBuilder,
+    escape_ident, from_qi, OrderExpr, SelectBuilder, SqlFragment, SqlParam,
 };
 
 /// Query builder for converting plans to SQL.
@@ -525,6 +524,7 @@ impl QueryBuilder {
                 columns,
                 body,
                 on_conflict,
+                where_clauses,
                 returning,
                 ..
             } => {
@@ -533,63 +533,84 @@ impl QueryBuilder {
                     &target.name,
                 );
 
-                let mut builder = InsertBuilder::new().into_table(&qi);
+                let mut frag = SqlFragment::new();
+                frag.push("INSERT INTO ");
+                frag.push(&from_qi(&qi));
 
-                // Column names
-                let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
-                builder = builder.columns(col_names);
+                match (body, columns.is_empty()) {
+                    // A body naming no columns -- `{}` -- inserts a row of
+                    // defaults. There is no column list to write and no values
+                    // to read out of the body.
+                    (_, true) => {
+                        frag.push(" DEFAULT VALUES");
+                    }
+                    (Some(body), false) => {
+                        frag.push(" (");
+                        push_column_list(&mut frag, columns);
+                        frag.push(") SELECT ");
+                        for (i, column) in columns.iter().enumerate() {
+                            if i > 0 {
+                                frag.push(", ");
+                            }
+                            frag.push("pgrst_body.");
+                            frag.push(&escape_ident(&column.name));
+                        }
+                        frag.push(" ");
+                        push_json_body(&mut frag, &qi, columns, body, false);
 
-                if let Some(body_bytes) = body {
-                    let body_str = String::from_utf8_lossy(body_bytes);
-
-                    // `json_populate_recordset` only accepts an array, but a
-                    // single-row insert posts a bare object. Wrapping it here
-                    // keeps one code path for both shapes -- checking the
-                    // first token is enough, since the payload has already
-                    // been validated as JSON by this point.
-                    let rows = if body_str.trim_start().starts_with('{') {
-                        format!("[{body_str}]")
-                    } else {
-                        body_str.into_owned()
-                    };
-
-                    let mut frag = SqlFragment::new();
-                    frag.push("SELECT * FROM json_populate_recordset(NULL::");
-                    frag.push(&from_qi(&qi));
-                    frag.push(", ");
-                    frag.push_param(rows);
-                    frag.push("::json)");
-                    return Ok(frag);
+                        // PUT names the row in the URL as well as in the body,
+                        // and the two have to agree -- the conditions are
+                        // written against the body so that a mismatch inserts
+                        // nothing rather than the wrong row.
+                        if !where_clauses.is_empty() {
+                            frag.push(" WHERE ");
+                            for (i, clause) in where_clauses.iter().enumerate() {
+                                if i > 0 {
+                                    frag.push(" AND ");
+                                }
+                                frag.append(Self::build_logic_tree(clause)?);
+                            }
+                        }
+                    }
+                    (None, false) => {
+                        frag.push(" DEFAULT VALUES");
+                    }
                 }
 
-                // ON CONFLICT
                 if let Some((resolution, conflict_cols)) = on_conflict {
+                    frag.push(" ON CONFLICT (");
+                    for (i, column) in conflict_cols.iter().enumerate() {
+                        if i > 0 {
+                            frag.push(", ");
+                        }
+                        frag.push(&escape_ident(column));
+                    }
+                    frag.push(") DO ");
                     match resolution {
                         crate::api_request::PreferResolution::IgnoreDuplicates => {
-                            builder = builder.on_conflict_do_nothing();
+                            frag.push("NOTHING");
+                        }
+                        crate::api_request::PreferResolution::MergeDuplicates
+                            if columns.is_empty() =>
+                        {
+                            frag.push("NOTHING");
                         }
                         crate::api_request::PreferResolution::MergeDuplicates => {
-                            let set_cols: Vec<(String, SqlFragment)> = columns
-                                .iter()
-                                .map(|c| {
-                                    let mut frag = SqlFragment::new();
-                                    frag.push("EXCLUDED.");
-                                    frag.push(&escape_ident(&c.name));
-                                    (c.name.clone(), frag)
-                                })
-                                .collect();
-                            builder =
-                                builder.on_conflict_do_update(conflict_cols.clone(), set_cols);
+                            frag.push("UPDATE SET ");
+                            for (i, column) in columns.iter().enumerate() {
+                                if i > 0 {
+                                    frag.push(", ");
+                                }
+                                frag.push(&escape_ident(&column.name));
+                                frag.push(" = EXCLUDED.");
+                                frag.push(&escape_ident(&column.name));
+                            }
                         }
                     }
                 }
 
-                // RETURNING
-                for col in returning {
-                    builder = builder.returning(col);
-                }
-
-                Ok(builder.build())
+                push_returning(&mut frag, returning);
+                Ok(frag)
             }
 
             MutatePlan::Update {
@@ -605,56 +626,47 @@ impl QueryBuilder {
                     &target.name,
                 );
 
-                let builder = UpdateBuilder::new().table(&qi);
-
-                // SET columns from body
-                if let Some(body_bytes) = body {
-                    let body_str = String::from_utf8_lossy(body_bytes);
-                    // Simplified: would properly parse JSON and set columns
+                // An update that assigns nothing is not valid SQL, and it is
+                // also not an error: `PATCH` with `{}` matches rows and
+                // changes none of them. Selecting no rows from the table gives
+                // the same answer with the same column names, which is what a
+                // `?select=` over the result needs.
+                if columns.is_empty() || body.is_none() {
                     let mut frag = SqlFragment::new();
-                    frag.push("UPDATE ");
+                    frag.push("SELECT * FROM ");
                     frag.push(&from_qi(&qi));
-                    frag.push(" SET ");
-
-                    for (i, col) in columns.iter().enumerate() {
-                        if i > 0 {
-                            frag.push(", ");
-                        }
-                        frag.push(&escape_ident(&col.name));
-                        frag.push(" = (");
-                        frag.push_param(body_str.to_string());
-                        frag.push("::json->>");
-                        frag.push_param(col.name.clone());
-                        frag.push(")::");
-                        frag.push(&col.ir_type);
-                    }
-
-                    // WHERE
-                    if !where_clauses.is_empty() {
-                        frag.push(" WHERE ");
-                        for (i, clause) in where_clauses.iter().enumerate() {
-                            if i > 0 {
-                                frag.push(" AND ");
-                            }
-                            frag.append(Self::build_logic_tree(clause)?);
-                        }
-                    }
-
-                    // RETURNING
-                    if !returning.is_empty() {
-                        frag.push(" RETURNING ");
-                        for (i, col) in returning.iter().enumerate() {
-                            if i > 0 {
-                                frag.push(", ");
-                            }
-                            frag.push(&escape_ident(col));
-                        }
-                    }
-
+                    frag.push(" WHERE false");
                     return Ok(frag);
                 }
 
-                Ok(builder.build())
+                let body = body.as_ref().expect("checked above");
+                let mut frag = SqlFragment::new();
+                frag.push("UPDATE ");
+                frag.push(&from_qi(&qi));
+                frag.push(" SET ");
+                for (i, column) in columns.iter().enumerate() {
+                    if i > 0 {
+                        frag.push(", ");
+                    }
+                    frag.push(&escape_ident(&column.name));
+                    frag.push(" = pgrst_body.");
+                    frag.push(&escape_ident(&column.name));
+                }
+                frag.push(" ");
+                push_json_body(&mut frag, &qi, columns, body, true);
+
+                if !where_clauses.is_empty() {
+                    frag.push(" WHERE ");
+                    for (i, clause) in where_clauses.iter().enumerate() {
+                        if i > 0 {
+                            frag.push(" AND ");
+                        }
+                        frag.append(Self::build_logic_tree(clause)?);
+                    }
+                }
+
+                push_returning(&mut frag, returning);
+                Ok(frag)
             }
 
             MutatePlan::Delete {
@@ -667,20 +679,22 @@ impl QueryBuilder {
                     &target.name,
                 );
 
-                let mut builder = DeleteBuilder::new().from_table(&qi);
+                let mut frag = SqlFragment::new();
+                frag.push("DELETE FROM ");
+                frag.push(&from_qi(&qi));
 
-                // WHERE
-                for clause in where_clauses {
-                    let expr = Self::build_logic_tree(clause)?;
-                    builder = builder.where_raw(expr);
+                if !where_clauses.is_empty() {
+                    frag.push(" WHERE ");
+                    for (i, clause) in where_clauses.iter().enumerate() {
+                        if i > 0 {
+                            frag.push(" AND ");
+                        }
+                        frag.append(Self::build_logic_tree(clause)?);
+                    }
                 }
 
-                // RETURNING
-                for col in returning {
-                    builder = builder.returning(col);
-                }
-
-                Ok(builder.build())
+                push_returning(&mut frag, returning);
+                Ok(frag)
             }
         }
     }
@@ -835,6 +849,92 @@ impl QueryBuilder {
 /// what distinguishes `data->'1'` from `data->1` in PostgreSQL. Operands reach
 /// us already restricted to alphanumerics and underscores by the parser; the
 /// quote doubling is belt-and-braces so this stays safe if that ever loosens.
+/// The columns a mutation writes, as a comma-separated identifier list.
+fn push_column_list(frag: &mut SqlFragment, columns: &[crate::plan::CoercibleField]) {
+    for (i, column) in columns.iter().enumerate() {
+        if i > 0 {
+            frag.push(", ");
+        }
+        frag.push(&escape_ident(&column.name));
+    }
+}
+
+/// The `FROM` clause that turns a JSON body into rows of the table's columns.
+///
+/// The body is read as a record set of exactly the columns being written, each
+/// typed as the column is -- or as `json`, where a data representation is going
+/// to parse it -- so PostgreSQL does the conversion and this process never has
+/// to guess at a literal's spelling.
+///
+/// `single` reads one object rather than an array, which is what a `PATCH`
+/// body is.
+fn push_json_body(
+    frag: &mut SqlFragment,
+    qi: &postrust_sql::identifier::QualifiedIdentifier,
+    columns: &[crate::plan::CoercibleField],
+    body: &bytes::Bytes,
+    single: bool,
+) {
+    let _ = qi;
+    let body = String::from_utf8_lossy(body).into_owned();
+    let object = body.trim_start().starts_with('{');
+
+    frag.push("FROM (SELECT ");
+    frag.push_param(body);
+    frag.push("::json AS json_data) pgrst_payload, LATERAL (SELECT ");
+    for (i, column) in columns.iter().enumerate() {
+        if i > 0 {
+            frag.push(", ");
+        }
+        match &column.transform {
+            Some(parser) => {
+                frag.push(parser);
+                frag.push("(");
+                frag.push(&escape_ident(&column.name));
+                frag.push(") AS ");
+                frag.push(&escape_ident(&column.name));
+            }
+            None => {
+                frag.push(&escape_ident(&column.name));
+            }
+        }
+    }
+    // `json_to_record` takes one object and `json_to_recordset` an array. A
+    // `PATCH` body is one object either way; an insert may be either, and the
+    // body itself says which.
+    frag.push(match single || object {
+        true => " FROM json_to_record(pgrst_payload.json_data) AS _(",
+        false => " FROM json_to_recordset(pgrst_payload.json_data) AS _(",
+    });
+    for (i, column) in columns.iter().enumerate() {
+        if i > 0 {
+            frag.push(", ");
+        }
+        frag.push(&escape_ident(&column.name));
+        frag.push(" ");
+        frag.push(castable_type(&column.ir_type).unwrap_or("text"));
+    }
+    frag.push(")");
+    if single && !object {
+        frag.push(" LIMIT 1");
+    }
+    frag.push(") pgrst_body");
+}
+
+/// The `RETURNING` list, or nothing when there is none.
+fn push_returning(frag: &mut SqlFragment, returning: &[String]) {
+    if returning.is_empty() {
+        return;
+    }
+    frag.push(" RETURNING ");
+    for (i, column) in returning.iter().enumerate() {
+        if i > 0 {
+            frag.push(", ");
+        }
+        frag.push(&escape_ident(column));
+    }
+}
+
 /// A column reference, converted to JSON first where the path requires it.
 fn push_field_ref(frag: &mut SqlFragment, field: &crate::plan::CoercibleField) {
     // A computed field is a function of the whole row. PostgreSQL would also

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -682,4 +682,46 @@ mod tests {
         assert_eq!(castable_type("USER-DEFINED"), None);
         assert_eq!(castable_type("int4; DROP TABLE users"), None);
     }
+
+    /// Build the SQL for the single root filter in `query`.
+    fn filter_sql_for(query: &str, pg_type: &str) -> (String, Vec<String>) {
+        let params = crate::api_request::parse_query_params(query, false).unwrap();
+        let frag = QueryBuilder::filter_sql(&params.filters_root[0], pg_type).unwrap();
+        let bound = frag
+            .params()
+            .iter()
+            .map(|p| format!("{:?}", p))
+            .collect::<Vec<_>>();
+        (frag.sql().to_string(), bound)
+    }
+
+    #[test]
+    fn quantified_comparison_binds_an_array() {
+        let (sql, params) = filter_sql_for("id=eq(any).{1,2,3}", "int4");
+        assert!(sql.contains("= ANY("), "got {sql}");
+        assert!(sql.contains("int4[]"), "got {sql}");
+        assert_eq!(params.len(), 1);
+        assert!(params[0].contains("{1,2,3}"), "got {:?}", params[0]);
+    }
+
+    #[test]
+    fn quantified_all_renders_all() {
+        let (sql, _) = filter_sql_for("id=lt(all).{4,5}", "int4");
+        assert!(sql.contains("< ALL("), "got {sql}");
+    }
+
+    #[test]
+    fn quantified_like_maps_the_wildcard_inside_the_array() {
+        let (_, params) = filter_sql_for("name=like(any).{foo*,*bar}", "text");
+        assert!(params[0].contains("{foo%,%bar}"), "got {:?}", params[0]);
+    }
+
+    #[test]
+    fn array_column_is_not_double_arrayed() {
+        // An array-typed column already compares element-wise, so the cast is
+        // left alone rather than becoming `_text[]`.
+        let (sql, _) = filter_sql_for("tags=eq(any).{a,b}", "_text");
+        assert!(sql.contains("= ANY("), "got {sql}");
+        assert!(!sql.contains("_text[]"), "got {sql}");
+    }
 }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -5,9 +5,7 @@ use crate::plan::{
     CallParams, CallPlan, CoercibleFilter, CoercibleLogicTree, CoercibleOrderTerm,
     CoercibleSelectField, MutatePlan, ReadPlan, ReadPlanTree,
 };
-use postrust_sql::{
-    escape_ident, from_qi, OrderExpr, SelectBuilder, SqlFragment, SqlParam,
-};
+use postrust_sql::{escape_ident, from_qi, OrderExpr, SelectBuilder, SqlFragment, SqlParam};
 
 /// Query builder for converting plans to SQL.
 pub struct QueryBuilder;

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -780,7 +780,11 @@ impl QueryBuilder {
         // value straight to `to_jsonb`, which reads the names off the record
         // itself. That is where `returns_record()` gets `{"id": 1, ...}` from
         // without anyone having declared what its columns are.
+        // A function whose return type is a media-type domain has already
+        // produced the response body. Wrapping it in JSON would make the
+        // response a JSON string *about* a PNG rather than the PNG.
         let render_as_json = read.is_none()
+            && plan.media_type.is_none()
             && !plan.returns_composite
             && plan
                 .return_type

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -48,6 +48,15 @@ impl QueryBuilder {
             builder = builder.where_raw(expr);
         }
 
+        // GROUP BY. Selecting an aggregate alongside plain columns means one
+        // row per distinct combination of those columns, so every one of them
+        // has to be grouped -- PostgreSQL rejects the query otherwise.
+        if plan.select.iter().any(|f| f.aggregate.is_some()) {
+            for field in plan.select.iter().filter(|f| f.aggregate.is_none()) {
+                builder = builder.group_by(&field.field.name);
+            }
+        }
+
         // ORDER BY
         for term in &plan.order {
             let order = Self::build_order_term(term);
@@ -75,22 +84,71 @@ impl QueryBuilder {
             frag.push("(");
         }
 
-        // Column name with JSON path
-        frag.push(&escape_ident(&field.field.name));
+        // `count()` counts rows rather than a column's non-null values.
+        if field.aggregate.is_some() && field.field.name.is_empty() {
+            frag.push("*)");
+            if let Some(cast) = &field.aggregate_cast {
+                frag.push("::");
+                frag.push(cast);
+            }
+            frag.push(" AS ");
+            frag.push(&escape_ident(field.alias.as_deref().unwrap_or("count")));
+            return Ok(frag);
+        }
 
-        // Close aggregate
-        if field.aggregate.is_some() {
+        // Column name with JSON path.
+        //
+        // `::` binds tighter than `->>`, so a cast over a JSON path has to be
+        // parenthesised: `settings ->> 'foo'::json` would cast the *key*
+        // rather than the extracted value.
+        let needs_parens = field.cast.is_some() && !field.field.json_path.is_empty();
+        if needs_parens {
+            frag.push("(");
+        }
+        frag.push(&escape_ident(&field.field.name));
+        push_json_path(&mut frag, &field.field.json_path);
+        if needs_parens {
             frag.push(")");
         }
 
-        // Cast
+        // Cast on the column, inside the aggregate.
         if let Some(cast) = &field.cast {
             frag.push("::");
             frag.push(cast);
         }
 
+        // Close aggregate, then any cast applied to its result.
+        if let Some(agg) = &field.aggregate {
+            frag.push(")");
+            if let Some(cast) = &field.aggregate_cast {
+                frag.push("::");
+                frag.push(cast);
+            }
+            // An aggregate is an expression, so it needs a name. PostgREST
+            // uses the function's own, lowercased.
+            frag.push(" AS ");
+            frag.push(&escape_ident(
+                field
+                    .alias
+                    .as_deref()
+                    .unwrap_or(&agg.to_sql().to_lowercase()),
+            ));
+            return Ok(frag);
+        }
+
         // Alias
-        if let Some(alias) = &field.alias {
+        //
+        // A JSON path always needs one: `data -> 'a' ->> 'b'` is an expression,
+        // and PostgreSQL would label the column `?column?`. PostgREST names it
+        // after the last key in the path, falling back to the column itself
+        // when the path ends in an array index.
+        let implicit_alias = if field.alias.is_none() && !field.field.json_path.is_empty() {
+            Some(json_path_alias(&field.field.name, &field.field.json_path))
+        } else {
+            None
+        };
+
+        if let Some(alias) = field.alias.as_deref().or(implicit_alias.as_deref()) {
             frag.push(" AS ");
             frag.push(&escape_ident(alias));
         }
@@ -141,7 +199,18 @@ impl QueryBuilder {
         }
     }
 
-    /// Build a filter expression.
+    /// Build the SQL for a single filter against a column of `pg_type`.
+    ///
+    /// Exposed for the embedding path, which applies filters inside a child
+    /// subquery it assembles itself rather than through a full plan. Column
+    /// names are left unqualified: inside the child's subselect the innermost
+    /// `FROM` wins, so a bare name binds to the child. The caller is
+    /// responsible for having checked the column exists there -- otherwise the
+    /// name would resolve outward to the correlated parent instead.
+    pub fn filter_sql(filter: &crate::api_request::Filter, pg_type: &str) -> Result<SqlFragment> {
+        Self::build_filter(&CoercibleFilter::from_filter(filter, pg_type))
+    }
+
     fn build_filter(filter: &CoercibleFilter) -> Result<SqlFragment> {
         let mut frag = SqlFragment::new();
 
@@ -155,6 +224,7 @@ impl QueryBuilder {
 
         // Column name
         frag.push(&escape_ident(&filter.field.name));
+        push_json_path(&mut frag, &filter.field.json_path);
 
         // Filter values are always bound as text, so a comparison against a
         // non-text column needs an explicit cast on the placeholder -- without
@@ -187,6 +257,15 @@ impl QueryBuilder {
                 quantifier,
                 value,
             } => {
+                // PostgREST spells the LIKE wildcard `*` rather than `%`, and
+                // maps it unconditionally -- `*` is never a literal asterisk in
+                // a like/ilike operand. Other operators take the value as-is,
+                // so `match`/`imatch` regexes keep their own `*`.
+                let value = &match op {
+                    crate::api_request::QuantOperator::Like
+                    | crate::api_request::QuantOperator::ILike => value.replace('*', "%"),
+                    _ => value.clone(),
+                };
                 frag.push(" ");
                 frag.push(op.to_sql());
                 frag.push(" ");
@@ -255,7 +334,14 @@ impl QueryBuilder {
 
     /// Build an ORDER BY term.
     fn build_order_term(term: &CoercibleOrderTerm) -> OrderExpr {
-        let mut order = OrderExpr::new(&term.field.name);
+        let mut order = if term.field.json_path.is_empty() {
+            OrderExpr::new(&term.field.name)
+        } else {
+            let mut frag = SqlFragment::new();
+            frag.push(&escape_ident(&term.field.name));
+            push_json_path(&mut frag, &term.field.json_path);
+            OrderExpr::raw(frag.sql())
+        };
 
         if let Some(dir) = &term.direction {
             order = match dir {
@@ -296,16 +382,25 @@ impl QueryBuilder {
                 let col_names: Vec<String> = columns.iter().map(|c| c.name.clone()).collect();
                 builder = builder.columns(col_names);
 
-                // For bulk insert, we'd use json_populate_recordset
-                // For now, simplified single-row insert
                 if let Some(body_bytes) = body {
-                    // This would be expanded with proper JSON handling
                     let body_str = String::from_utf8_lossy(body_bytes);
+
+                    // `json_populate_recordset` only accepts an array, but a
+                    // single-row insert posts a bare object. Wrapping it here
+                    // keeps one code path for both shapes -- checking the
+                    // first token is enough, since the payload has already
+                    // been validated as JSON by this point.
+                    let rows = if body_str.trim_start().starts_with('{') {
+                        format!("[{body_str}]")
+                    } else {
+                        body_str.into_owned()
+                    };
+
                     let mut frag = SqlFragment::new();
                     frag.push("SELECT * FROM json_populate_recordset(NULL::");
                     frag.push(&from_qi(&qi));
                     frag.push(", ");
-                    frag.push_param(body_str.to_string());
+                    frag.push_param(rows);
                     frag.push("::json)");
                     return Ok(frag);
                 }
@@ -445,6 +540,18 @@ impl QueryBuilder {
         frag.push(&from_qi(&qi));
         frag.push("(");
 
+        // Arguments come off the wire as strings. Casting each one to the type
+        // the function actually declares is what lets PostgreSQL resolve the
+        // signature; binding everything as `text` only works for text-taking
+        // functions. An argument the schema cache doesn't know is left
+        // untyped, so PostgreSQL applies its own inference rather than failing.
+        let declared_type = |name: &str| {
+            plan.param_types
+                .iter()
+                .find(|(n, _)| n == name)
+                .map(|(_, t)| t.clone())
+        };
+
         match &plan.params {
             CallParams::Named(params) => {
                 for (i, (name, value)) in params.iter().enumerate() {
@@ -453,7 +560,12 @@ impl QueryBuilder {
                     }
                     frag.push(&escape_ident(name));
                     frag.push(" => ");
-                    frag.push_param(SqlParam::Text(value.clone()));
+                    match declared_type(name) {
+                        Some(pg_type) => {
+                            frag.push_typed_param(SqlParam::Text(value.clone()), &pg_type)
+                        }
+                        None => frag.push_param(SqlParam::Text(value.clone())),
+                    };
                 }
             }
             CallParams::Positional(values) => {
@@ -461,7 +573,12 @@ impl QueryBuilder {
                     if i > 0 {
                         frag.push(", ");
                     }
-                    frag.push_param(SqlParam::Text(value.clone()));
+                    match plan.param_types.get(i) {
+                        Some((_, pg_type)) => {
+                            frag.push_typed_param(SqlParam::Text(value.clone()), pg_type)
+                        }
+                        None => frag.push_param(SqlParam::Text(value.clone())),
+                    };
                 }
             }
             CallParams::SingleObject(body) => {
@@ -484,6 +601,53 @@ impl QueryBuilder {
 /// `character varying(255)`, or the `ARRAY`/`USER-DEFINED` placeholders that
 /// `information_schema` reports) yields `None` and the value is bound
 /// uncast, preserving the previous behaviour.
+/// Append a JSON path to a column reference: `"data" -> 'a' ->> 'b'`.
+///
+/// Keys are emitted as string literals and indices as bare integers, which is
+/// what distinguishes `data->'1'` from `data->1` in PostgreSQL. Operands reach
+/// us already restricted to alphanumerics and underscores by the parser; the
+/// quote doubling is belt-and-braces so this stays safe if that ever loosens.
+fn push_json_path(frag: &mut SqlFragment, path: &crate::api_request::JsonPath) {
+    use crate::api_request::{JsonOperand, JsonOperation};
+
+    for operation in path {
+        let (arrow, operand) = match operation {
+            JsonOperation::Arrow(operand) => ("->", operand),
+            JsonOperation::DoubleArrow(operand) => ("->>", operand),
+        };
+
+        frag.push(" ");
+        frag.push(arrow);
+        frag.push(" ");
+
+        match operand {
+            JsonOperand::Key(key) => {
+                frag.push(&format!("'{}'", key.replace('\'', "''")));
+            }
+            JsonOperand::Idx(index) => {
+                frag.push(&index.to_string());
+            }
+        }
+    }
+}
+
+/// The name PostgREST gives an unaliased JSON path expression.
+///
+/// The last key in the path wins -- `data->a->>b` is reported as `b`. A path
+/// that ends in an array index has no name to take, so it keeps the column's.
+fn json_path_alias(column: &str, path: &crate::api_request::JsonPath) -> String {
+    use crate::api_request::{JsonOperand, JsonOperation};
+
+    path.iter()
+        .rev()
+        .find_map(|operation| match operation {
+            JsonOperation::Arrow(JsonOperand::Key(key))
+            | JsonOperation::DoubleArrow(JsonOperand::Key(key)) => Some(key.clone()),
+            _ => None,
+        })
+        .unwrap_or_else(|| column.to_string())
+}
+
 fn castable_type(pg_type: &str) -> Option<&str> {
     if pg_type.is_empty() {
         return None;

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -58,7 +58,10 @@ impl QueryBuilder {
         }
 
         // ORDER BY
-        for term in &plan.order {
+        //
+        // A term naming an embedded resource is left for the caller: it orders
+        // by a column of another table, which this query has no way to reach.
+        for term in plan.order.iter().filter(|t| t.relation.is_none()) {
             let order = Self::build_order_term(term);
             builder = builder.order_by(order);
         }
@@ -219,6 +222,17 @@ impl QueryBuilder {
                 Ok(frag)
             }
         }
+    }
+
+    /// A column reference with its JSON path, as it appears in SQL.
+    ///
+    /// Exposed for ordering by an embedded resource's column, which is
+    /// assembled outside the read plan.
+    pub fn column_sql(field: &crate::plan::CoercibleField) -> String {
+        let mut frag = SqlFragment::new();
+        frag.push(&escape_ident(&field.name));
+        push_json_path(&mut frag, &field.json_path);
+        frag.sql().to_string()
     }
 
     /// Build the SQL for a single filter against a column of `pg_type`.

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -554,6 +554,7 @@ impl QueryBuilder {
                 on_conflict,
                 where_clauses,
                 returning,
+                reports_inserted,
                 ..
             } => {
                 let qi = postrust_sql::identifier::QualifiedIdentifier::new(
@@ -657,7 +658,7 @@ impl QueryBuilder {
                 // one, which is the difference between 201 and 200 and is
                 // knowable only here: `xmax` is zero on a row this statement
                 // created and non-zero on one it updated.
-                if on_conflict.is_some() && !returning.is_empty() {
+                if on_conflict.is_some() && *reports_inserted && !returning.is_empty() {
                     frag.push(", (xmax = 0) AS ");
                     frag.push(&escape_ident(INSERTED_COLUMN));
                 }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -923,7 +923,9 @@ fn push_json_body(
         frag.push(" ");
         frag.push(castable_type(&column.ir_type).unwrap_or("text"));
     }
-    frag.push(") pgrst_body");
+    // Two parentheses: one closes the column definition list, one the lateral
+    // subquery the alias names.
+    frag.push(")) pgrst_body");
 }
 
 /// The `RETURNING` list, or nothing when there is none.

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -603,16 +603,18 @@ impl QueryBuilder {
                         push_json_body(&mut frag, columns, body, false, *apply_defaults);
 
                         // PUT names the row in the URL as well as in the body,
-                        // and the two have to agree -- the conditions are
-                        // written against the body so that a mismatch inserts
-                        // nothing rather than the wrong row.
+                        // and the two have to agree. The conditions are
+                        // written against the body, so a row naming another
+                        // key is left unwritten rather than writing the wrong
+                        // one -- and the count that comes back then says
+                        // whether the request meant exactly one row.
                         if !where_clauses.is_empty() {
                             frag.push(" WHERE ");
                             for (i, clause) in where_clauses.iter().enumerate() {
                                 if i > 0 {
                                     frag.push(" AND ");
                                 }
-                                frag.append(Self::build_logic_tree(clause)?);
+                                frag.append(Self::build_logic_tree_in(Some("pgrst_body"), clause)?);
                             }
                         }
                     }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -257,8 +257,20 @@ impl QueryBuilder {
     /// Exposed for ordering by an embedded resource's column, which is
     /// assembled outside the read plan.
     pub fn column_sql(field: &crate::plan::CoercibleField) -> String {
+        Self::qualified_column_sql(None, field)
+    }
+
+    /// The same, with the column qualified by a relation alias.
+    ///
+    /// The alias belongs to the column, not to the expression around it:
+    /// `to_jsonb(e2."settings")->'a'`, never `e2.to_jsonb(...)`, which reads
+    /// as a function in a schema called `e2`.
+    pub fn qualified_column_sql(
+        qualifier: Option<&str>,
+        field: &crate::plan::CoercibleField,
+    ) -> String {
         let mut frag = SqlFragment::new();
-        push_field_ref(&mut frag, field);
+        push_qualified_field_ref(&mut frag, qualifier, field);
         frag.sql().to_string()
     }
 
@@ -930,6 +942,15 @@ fn push_returning(frag: &mut SqlFragment, returning: &[String]) {
 
 /// A column reference, converted to JSON first where the path requires it.
 fn push_field_ref(frag: &mut SqlFragment, field: &crate::plan::CoercibleField) {
+    push_qualified_field_ref(frag, None, field)
+}
+
+/// The same, with the column qualified by a relation alias.
+fn push_qualified_field_ref(
+    frag: &mut SqlFragment,
+    qualifier: Option<&str>,
+    field: &crate::plan::CoercibleField,
+) {
     // A computed field is a function of the whole row. PostgreSQL would also
     // accept `items.always_true` and resolve it to the same call, but only
     // where the reference is qualified by the relation -- which a bare column
@@ -941,7 +962,10 @@ fn push_field_ref(frag: &mut SqlFragment, field: &crate::plan::CoercibleField) {
             escape_ident(&computed.function.name),
             escape_ident(&computed.relation),
         ),
-        None => escape_ident(&field.name),
+        None => match qualifier {
+            Some(alias) => format!("{}.{}", escape_ident(alias), escape_ident(&field.name)),
+            None => escape_ident(&field.name),
+        },
     };
 
     if field.to_json {

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -771,20 +771,28 @@ impl QueryBuilder {
         // A composite return -- OUT parameters, `RETURNS TABLE`, a row type --
         // already expands to its own columns, and wrapping it would bury them
         // under the function's name.
+        // A bare `record` is the other case: PostgreSQL will not put one in a
+        // `FROM` clause without being told its columns, but it will hand the
+        // value straight to `to_jsonb`, which reads the names off the record
+        // itself. That is where `returns_record()` gets `{"id": 1, ...}` from
+        // without anyone having declared what its columns are.
         let render_as_json = read.is_none()
             && !plan.returns_composite
             && plan
                 .return_type
                 .as_deref()
-                .map(|t| !decodable_type(t) && t != "record")
+                .map(|t| !decodable_type(t) || t == "record")
                 .unwrap_or(false);
 
         let mut frag = SqlFragment::new();
         frag.push("SELECT ");
         if render_as_json {
-            frag.push("to_jsonb(pgrst_scalar) AS ");
+            // Called in the select list rather than the `FROM`: a
+            // set-returning function there still yields a row per result, and
+            // a `record` needs no column list to be called this way.
+            frag.push("to_jsonb(pgrst_call.pgrst_scalar) AS ");
             frag.push(&escape_ident(&plan.function.name));
-            frag.push(" FROM ");
+            frag.push(" FROM (SELECT ");
             frag.push(&from_qi(&qi));
             frag.push("(");
         }
@@ -828,8 +836,17 @@ impl QueryBuilder {
                     if i > 0 {
                         frag.push(", ");
                     }
-                    frag.push(&escape_ident(name));
-                    frag.push(" => ");
+                    // A variadic parameter is passed as the whole tail, which
+                    // is what `VARIADIC` says; `v => array[...]` finds no
+                    // function, since no signature takes an array there.
+                    if plan.variadic_params.iter().any(|v| v == name) {
+                        frag.push("VARIADIC ");
+                        frag.push(&escape_ident(name));
+                        frag.push(" := ");
+                    } else {
+                        frag.push(&escape_ident(name));
+                        frag.push(" => ");
+                    }
                     match declared_type(name) {
                         Some(pg_type) => {
                             frag.push_typed_param(SqlParam::Text(value.clone()), &pg_type)
@@ -860,7 +877,7 @@ impl QueryBuilder {
 
         frag.push(")");
         if render_as_json {
-            frag.push(" AS pgrst_scalar");
+            frag.push(" AS pgrst_scalar) pgrst_call");
         }
 
         // Filters, ordering and paging over the returned rows.

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -1058,13 +1058,25 @@ fn push_json_body(
     });
 }
 
+/// The column a mutation returns when the response reads none of its own.
+///
+/// It exists to be counted, never to be read: the body is empty in every case
+/// that produces it.
+pub const AFFECTED_COLUMN: &str = "pgrst_affected";
+
 /// The `RETURNING` list, qualified by the relation being written.
 ///
 /// `RETURNING` sees everything in the statement's scope, which for an
 /// `UPDATE ... FROM` includes the body -- and a bare column name there is
 /// ambiguous for every column the update writes.
 fn push_returning(frag: &mut SqlFragment, relation: &str, returning: &[String]) {
+    // A statement whose result nothing reads still has to say how many rows it
+    // touched, and the count is the number of rows it returns. A constant is
+    // what says "one row per row affected" without naming a column the caller
+    // may not be allowed to read.
     if returning.is_empty() {
+        frag.push(" RETURNING 1 AS ");
+        frag.push(&escape_ident(AFFECTED_COLUMN));
         return;
     }
     frag.push(" RETURNING ");

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -96,6 +96,28 @@ impl QueryBuilder {
             return Ok(frag);
         }
 
+        // A type this process cannot decode is rendered by PostgreSQL instead.
+        //
+        // The row converter maps a fixed set of built-in types and falls back
+        // to reading a column as text, which fails outright for a type like a
+        // PostGIS geometry -- the column came back as null. `to_jsonb` gives
+        // the database's own rendering, which for a geometry is the GeoJSON
+        // PostgREST returns. PostgREST gets it for free by building its whole
+        // response in SQL; this is the same rendering, asked for by name.
+        let render_as_json = field.aggregate.is_none()
+            && field.cast.is_none()
+            && field.field.json_path.is_empty()
+            && field.field.ir_type == "USER-DEFINED";
+        if render_as_json {
+            frag.push("to_jsonb(");
+            frag.push(&escape_ident(&field.field.name));
+            frag.push(") AS ");
+            frag.push(&escape_ident(
+                field.alias.as_deref().unwrap_or(&field.field.name),
+            ));
+            return Ok(frag);
+        }
+
         // Column name with JSON path.
         //
         // `::` binds tighter than `->>`, so a cast over a JSON path has to be

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -993,12 +993,12 @@ fn push_json_body(
                 column.default.as_deref().unwrap_or("NULL")
             ));
         }
-        frag.push(match single || object {
+        frag.push(match object {
             true => "LATERAL (SELECT jsonb_build_object(",
             false => "LATERAL (SELECT jsonb_agg(jsonb_build_object(",
         });
         frag.push(&pairs);
-        frag.push(match single || object {
+        frag.push(match object {
             true => ") || pgrst_payload.json_data AS val) pgrst_defaults, ",
             false => {
                 ") || pgrst_element) AS val \
@@ -1026,11 +1026,13 @@ fn push_json_body(
             }
         }
     }
-    // `json_to_record` takes one object and `json_to_recordset` an array. An
-    // update writes one set of values whatever it matches, so its body is one
-    // object -- and a body that is not is an error PostgreSQL words better
-    // than this could. An insert may be either, and the body says which.
-    frag.push(match (merged, single || object) {
+    // `json_to_record` takes one object and `json_to_recordset` an array, and
+    // which one the body is is the body's own business -- an update written
+    // with a one-element array is still an update. What makes it single is the
+    // `LIMIT 1` below, not a claim about the body's shape: reading an array
+    // with `json_to_record` is an error about `populate_composite` that says
+    // nothing to the client that sent it.
+    frag.push(match (merged, object) {
         (false, true) => " FROM json_to_record(pgrst_payload.json_data) AS _(",
         (false, false) => " FROM json_to_recordset(pgrst_payload.json_data) AS _(",
         (true, true) => " FROM jsonb_to_record(pgrst_defaults.val) AS _(",
@@ -1044,9 +1046,16 @@ fn push_json_body(
         frag.push(" ");
         frag.push(castable_type(&column.ir_type).unwrap_or("text"));
     }
-    // Two parentheses: one closes the column definition list, one the lateral
-    // subquery the alias names.
-    frag.push(")) pgrst_body");
+    // One paren closes the column definition list; the `LIMIT 1` then applies
+    // to the lateral subquery, whose own paren closes after it.
+    //
+    // An update writes one set of values however many the body offers, so it
+    // takes the first. Without this an array body of two objects would update
+    // every matching row twice over.
+    frag.push(match single {
+        true => ") LIMIT 1) pgrst_body",
+        false => ")) pgrst_body",
+    });
 }
 
 /// The `RETURNING` list, qualified by the relation being written.

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -1103,6 +1103,17 @@ fn push_json_body(
 /// that produces it.
 pub const AFFECTED_COLUMN: &str = "pgrst_affected";
 
+/// Column carrying the written row whole, for a computed relationship.
+///
+/// A computed relationship is a function of the parent row, and after a
+/// mutation the parent is a CTE whose row type is anonymous -- `record`, which
+/// PostgreSQL will not cast to the table's composite type. Inside the
+/// statement the real table is still in scope, so the row is taken there,
+/// where a bare reference to it yields the composite, and travels out through
+/// `RETURNING` as an ordinary column. It is stripped from the response like
+/// any other column added for embedding.
+pub const PARENT_ROW_COLUMN: &str = "pgrst_parent_row";
+
 /// The `RETURNING` list, qualified by the relation being written.
 ///
 /// `RETURNING` sees everything in the statement's scope, which for an
@@ -1122,6 +1133,17 @@ fn push_returning(frag: &mut SqlFragment, relation: &str, returning: &[String]) 
     for (i, column) in returning.iter().enumerate() {
         if i > 0 {
             frag.push(", ");
+        }
+        // The row itself, not a column of it. A bare reference to the relation
+        // is the whole row typed as the table's composite, which is the one
+        // thing a computed relationship can be called with -- and this is the
+        // only place it can be taken, because one level up the CTE has turned
+        // it into a `record`.
+        if column == PARENT_ROW_COLUMN {
+            frag.push(&escape_ident(relation));
+            frag.push(" AS ");
+            frag.push(&escape_ident(PARENT_ROW_COLUMN));
+            continue;
         }
         frag.push(&escape_ident(relation));
         frag.push(".");

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -519,7 +519,11 @@ impl QueryBuilder {
 
     /// Build an ORDER BY term.
     fn build_order_term(term: &CoercibleOrderTerm) -> OrderExpr {
-        let mut order = if term.field.json_path.is_empty() {
+        // A computed field is a call, not a column, and ordering by its name
+        // asks for a column the table does not have. Everything that reads a
+        // field reference has to go through the same place, or the ones that
+        // do not silently mean something else.
+        let mut order = if term.field.json_path.is_empty() && term.field.computed.is_none() {
             OrderExpr::new(&term.field.name)
         } else {
             let mut frag = SqlFragment::new();
@@ -1253,6 +1257,21 @@ fn castable_type(pg_type: &str) -> Option<&str> {
         return None;
     }
 
+    // `character` and `bit` name themselves without their length, and casting
+    // to either truncates to one -- `'10101'::bit` is `bit(1)`. A value on its
+    // way into a `bit(5)` column has to arrive whole; the column enforces its
+    // own length when the row is written, which is where that belongs.
+    let unbounded = match pg_type {
+        "character" | "bpchar" => Some("varchar"),
+        "bit" => Some("varbit"),
+        "character[]" | "bpchar[]" | "_bpchar" => Some("_varchar"),
+        "bit[]" | "_bit" => Some("_varbit"),
+        _ => None,
+    };
+    if unbounded.is_some() {
+        return unbounded;
+    }
+
     let is_bare_name = pg_type
         .chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '_');
@@ -1273,6 +1292,14 @@ mod tests {
         assert_eq!(castable_type("int4"), Some("int4"));
         assert_eq!(castable_type("timestamptz"), Some("timestamptz"));
         assert_eq!(castable_type("_text"), Some("_text"));
+    }
+
+    /// A length these types do not carry, and would truncate to if cast.
+    #[test]
+    fn castable_type_gives_the_unbounded_spelling_of_a_measured_type() {
+        assert_eq!(castable_type("character"), Some("varchar"));
+        assert_eq!(castable_type("bit"), Some("varbit"));
+        assert_eq!(castable_type("_bpchar"), Some("_varchar"));
     }
 
     #[test]

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -535,6 +535,16 @@ impl QueryBuilder {
         } else {
             let mut frag = SqlFragment::new();
             push_field_ref(&mut frag, &term.field);
+            // `OrderExpr` carries SQL and no parameters, so anything bound
+            // here would be dropped and every `$n` after it would be reading
+            // the wrong value -- silently, and only for the requests that take
+            // this branch. Nothing on this path binds today; this is what says
+            // so when something starts to.
+            debug_assert!(
+                frag.params().is_empty(),
+                "an ORDER BY term bound a parameter, which this discards: {}",
+                frag.sql()
+            );
             OrderExpr::raw(frag.sql())
         };
 

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -81,6 +81,14 @@ impl QueryBuilder {
     fn build_select_field(field: &CoercibleSelectField) -> Result<SqlFragment> {
         let mut frag = SqlFragment::new();
 
+        // `*` reaches here only where the columns are not known ahead of time
+        // -- a function's result, where the plan has no table to expand it
+        // against. Quoting it would ask for a column literally named `*`.
+        if field.field.name == "*" && field.aggregate.is_none() && field.cast.is_none() {
+            frag.push("*");
+            return Ok(frag);
+        }
+
         // Aggregate function
         if let Some(agg) = &field.aggregate {
             frag.push(agg.to_sql());
@@ -112,8 +120,10 @@ impl QueryBuilder {
             && field.field.json_path.is_empty()
             && !decodable_type(&field.field.ir_type);
         if render_as_json {
+            let mut inner = SqlFragment::new();
+            push_field_ref(&mut inner, &field.field);
             frag.push("to_jsonb(");
-            frag.push(&escape_ident(&field.field.name));
+            frag.push(inner.sql());
             frag.push(") AS ");
             frag.push(&escape_ident(
                 field.alias.as_deref().unwrap_or(&field.field.name),
@@ -130,8 +140,19 @@ impl QueryBuilder {
         if needs_parens {
             frag.push("(");
         }
-        frag.push(&escape_ident(&field.field.name));
-        push_json_path(&mut frag, &field.field.json_path);
+        // A transformer renders the column instead of this process: PostgREST
+        // uses it for a schema's declared data representations, and it is also
+        // how a value whose spelling depends on the session -- a `timestamptz`
+        // under `Prefer: timezone` -- gets rendered where the session is.
+        match &field.field.transform {
+            Some(function) => {
+                frag.push(function);
+                frag.push("(");
+                push_field_ref(&mut frag, &field.field);
+                frag.push(")");
+            }
+            None => push_field_ref(&mut frag, &field.field),
+        }
         if needs_parens {
             frag.push(")");
         }
@@ -167,8 +188,18 @@ impl QueryBuilder {
         // and PostgreSQL would label the column `?column?`. PostgREST names it
         // after the last key in the path, falling back to the column itself
         // when the path ends in an array index.
-        let implicit_alias = if field.alias.is_none() && !field.field.json_path.is_empty() {
+        let implicit_alias = if field.alias.is_some() {
+            None
+        } else if field.field.transform.is_some() {
+            Some(field.field.name.clone())
+        } else if !field.field.json_path.is_empty() {
             Some(json_path_alias(&field.field.name, &field.field.json_path))
+        } else if field.field.computed.is_some() {
+            // A call is an expression, and PostgreSQL would label it after the
+            // function -- which is the right name, but only by coincidence of
+            // the two agreeing. Naming it outright keeps a schema-qualified
+            // call from arriving under some other label.
+            Some(field.field.name.clone())
         } else {
             None
         };
@@ -230,8 +261,7 @@ impl QueryBuilder {
     /// assembled outside the read plan.
     pub fn column_sql(field: &crate::plan::CoercibleField) -> String {
         let mut frag = SqlFragment::new();
-        frag.push(&escape_ident(&field.name));
-        push_json_path(&mut frag, &field.json_path);
+        push_field_ref(&mut frag, field);
         frag.sql().to_string()
     }
 
@@ -245,6 +275,22 @@ impl QueryBuilder {
     /// name would resolve outward to the correlated parent instead.
     pub fn filter_sql(filter: &crate::api_request::Filter, pg_type: &str) -> Result<SqlFragment> {
         Self::build_filter(&CoercibleFilter::from_filter(filter, pg_type))
+    }
+
+    /// Build the SQL for a logic tree against a table whose column types
+    /// `type_resolver` supplies.
+    ///
+    /// Exposed for the same reason as `filter_sql`: an embedded resource's
+    /// `and=`/`or=` is applied inside a subquery the embedding path assembles
+    /// itself, without going through a full plan.
+    pub fn logic_sql<F>(
+        tree: &crate::api_request::LogicTree,
+        type_resolver: F,
+    ) -> Result<SqlFragment>
+    where
+        F: Fn(&str) -> String + Copy,
+    {
+        Self::build_logic_tree(&CoercibleLogicTree::from_logic_tree(tree, type_resolver))
     }
 
     fn build_filter(filter: &CoercibleFilter) -> Result<SqlFragment> {
@@ -264,16 +310,28 @@ impl QueryBuilder {
         // is not already one is wrapped, so `text_search=fts.x` searches the
         // text instead of failing to find an operator. A domain over tsvector
         // is already one, hence the prefix test rather than an equality.
-        let to_tsvector = matches!(
-            filter.op_expr.operation,
-            crate::api_request::Operation::Fts { .. }
-        ) && !filter.field.ir_type.starts_with("tsvector");
-        if to_tsvector {
+        //
+        // The language belongs on both sides: `to_tsvector('french', col) @@
+        // to_tsquery('french', $1)`. Left off the left-hand side the column is
+        // lexed with the default configuration -- English -- and a French
+        // query then matches nothing, quietly and with a 200.
+        let to_tsvector = match &filter.op_expr.operation {
+            crate::api_request::Operation::Fts { language, .. }
+                if !filter.field.ir_type.starts_with("tsvector") =>
+            {
+                Some(language.clone())
+            }
+            _ => None,
+        };
+        if let Some(language) = &to_tsvector {
             frag.push("to_tsvector(");
+            if let Some(language) = language {
+                frag.push_typed_param(language.clone(), "regconfig");
+                frag.push(", ");
+            }
         }
-        frag.push(&escape_ident(&filter.field.name));
-        push_json_path(&mut frag, &filter.field.json_path);
-        if to_tsvector {
+        push_field_ref(&mut frag, &filter.field);
+        if to_tsvector.is_some() {
             frag.push(")");
         }
 
@@ -284,14 +342,49 @@ impl QueryBuilder {
         let cast = if filter.field.json_path.is_empty() {
             castable_type(&filter.field.ir_type)
         } else {
-            None
+            // A JSON path leaves either `jsonb` (`->`) or `text` (`->>`) on the
+            // left. Text needs no cast, but `jsonb = $1` with the placeholder
+            // bound as text finds no operator, so the value is cast to match.
+            json_path_result_cast(&filter.field.json_path)
         };
-        let push_value = |frag: &mut SqlFragment, value: String| match cast {
-            Some(pg_type) => {
-                frag.push_typed_param(value, pg_type);
-            }
-            None => {
+
+        // `match` is `~`, and on an `ltree` the right-hand side of `~` is an
+        // `lquery` rather than another `ltree`: `path=match.*.Science` is a
+        // pattern, not a path. Casting it to the column's own type -- which is
+        // what every other operator wants -- finds no operator at all.
+        let cast = match (&filter.op_expr.operation, filter.field.ir_type.as_str()) {
+            (
+                crate::api_request::Operation::Quant {
+                    op:
+                        crate::api_request::QuantOperator::Match
+                        | crate::api_request::QuantOperator::IMatch,
+                    quantifier: None,
+                    ..
+                },
+                "ltree",
+            ) => Some("lquery"),
+            _ => cast,
+        };
+        // A schema that declared how one of its domains is written also
+        // declared how it is read: the cast parses the value the client sent,
+        // in its own spelling, rather than PostgreSQL's input function for the
+        // type underneath.
+        let parser = filter.field.transform.as_deref();
+        let push_value = |frag: &mut SqlFragment, value: String| {
+            if let Some(parser) = parser {
+                frag.push(parser);
+                frag.push("(");
                 frag.push_param(value);
+                frag.push(")");
+                return;
+            }
+            match cast {
+                Some(pg_type) => {
+                    frag.push_typed_param(value, pg_type);
+                }
+                None => {
+                    frag.push_param(value);
+                }
             }
         };
 
@@ -340,6 +433,14 @@ impl QueryBuilder {
                 } else {
                     push_value(&mut frag, value.clone());
                 }
+            }
+            crate::api_request::Operation::In(values) if values.is_empty() => {
+                // `IN ()` is a syntax error. The empty array says the same
+                // thing and is a single expression, so it needs no parentheses
+                // of its own wherever the filter ends up. It is false for
+                // every value, nulls included, which is what makes `not.in.()`
+                // match everything.
+                frag.push(" = ANY('{}')");
             }
             crate::api_request::Operation::In(values) => {
                 frag.push(" IN (");
@@ -395,8 +496,7 @@ impl QueryBuilder {
             OrderExpr::new(&term.field.name)
         } else {
             let mut frag = SqlFragment::new();
-            frag.push(&escape_ident(&term.field.name));
-            push_json_path(&mut frag, &term.field.json_path);
+            push_field_ref(&mut frag, &term.field);
             OrderExpr::raw(frag.sql())
         };
 
@@ -735,6 +835,44 @@ impl QueryBuilder {
 /// what distinguishes `data->'1'` from `data->1` in PostgreSQL. Operands reach
 /// us already restricted to alphanumerics and underscores by the parser; the
 /// quote doubling is belt-and-braces so this stays safe if that ever loosens.
+/// A column reference, converted to JSON first where the path requires it.
+fn push_field_ref(frag: &mut SqlFragment, field: &crate::plan::CoercibleField) {
+    // A computed field is a function of the whole row. PostgreSQL would also
+    // accept `items.always_true` and resolve it to the same call, but only
+    // where the reference is qualified by the relation -- which a bare column
+    // name here is not -- so the call is written out.
+    let column = match &field.computed {
+        Some(computed) => format!(
+            "{}.{}({})",
+            escape_ident(&computed.function.schema),
+            escape_ident(&computed.function.name),
+            escape_ident(&computed.relation),
+        ),
+        None => escape_ident(&field.name),
+    };
+
+    if field.to_json {
+        frag.push("to_jsonb(");
+        frag.push(&column);
+        frag.push(")");
+    } else {
+        frag.push(&column);
+    }
+    push_json_path(frag, &field.json_path);
+}
+
+/// The type a JSON path leaves on the left of a comparison.
+///
+/// `None` for a path ending in `->>`, which is already text -- the type filter
+/// values are bound as, so no cast is wanted.
+fn json_path_result_cast(path: &crate::api_request::JsonPath) -> Option<&'static str> {
+    use crate::api_request::JsonOperation;
+    match path.last()? {
+        JsonOperation::Arrow(_) => Some("jsonb"),
+        JsonOperation::DoubleArrow(_) => None,
+    }
+}
+
 fn push_json_path(frag: &mut SqlFragment, path: &crate::api_request::JsonPath) {
     use crate::api_request::{JsonOperand, JsonOperation};
 

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -554,7 +554,7 @@ impl QueryBuilder {
                             frag.push(&escape_ident(&column.name));
                         }
                         frag.push(" ");
-                        push_json_body(&mut frag, &qi, columns, body, false);
+                        push_json_body(&mut frag, columns, body, false);
 
                         // PUT names the row in the URL as well as in the body,
                         // and the two have to agree -- the conditions are
@@ -651,7 +651,7 @@ impl QueryBuilder {
                     frag.push(&escape_ident(&column.name));
                 }
                 frag.push(" ");
-                push_json_body(&mut frag, &qi, columns, body, true);
+                push_json_body(&mut frag, columns, body, true);
 
                 if !where_clauses.is_empty() {
                     frag.push(" WHERE ");
@@ -868,12 +868,10 @@ fn push_column_list(frag: &mut SqlFragment, columns: &[crate::plan::CoercibleFie
 /// body is.
 fn push_json_body(
     frag: &mut SqlFragment,
-    qi: &postrust_sql::identifier::QualifiedIdentifier,
     columns: &[crate::plan::CoercibleField],
     body: &bytes::Bytes,
     single: bool,
 ) {
-    let _ = qi;
     let body = String::from_utf8_lossy(body).into_owned();
     let object = body.trim_start().starts_with('{');
 
@@ -897,9 +895,10 @@ fn push_json_body(
             }
         }
     }
-    // `json_to_record` takes one object and `json_to_recordset` an array. A
-    // `PATCH` body is one object either way; an insert may be either, and the
-    // body itself says which.
+    // `json_to_record` takes one object and `json_to_recordset` an array. An
+    // update writes one set of values whatever it matches, so its body is one
+    // object -- and a body that is not is an error PostgreSQL words better
+    // than this could. An insert may be either, and the body says which.
     frag.push(match single || object {
         true => " FROM json_to_record(pgrst_payload.json_data) AS _(",
         false => " FROM json_to_recordset(pgrst_payload.json_data) AS _(",
@@ -911,10 +910,6 @@ fn push_json_body(
         frag.push(&escape_ident(&column.name));
         frag.push(" ");
         frag.push(castable_type(&column.ir_type).unwrap_or("text"));
-    }
-    frag.push(")");
-    if single && !object {
-        frag.push(" LIMIT 1");
     }
     frag.push(") pgrst_body");
 }

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -872,6 +872,18 @@ impl QueryBuilder {
                 let body_str = String::from_utf8_lossy(body);
                 frag.push_param(SqlParam::Text(body_str.to_string()));
             }
+            CallParams::SingleUnnamed { body, pg_type } => {
+                match body {
+                    Some(body) => frag.push_typed_param(
+                        SqlParam::Text(String::from_utf8_lossy(body).into_owned()),
+                        pg_type,
+                    ),
+                    // No body is that parameter's null. Casting it is what
+                    // tells PostgreSQL which signature is meant, where the
+                    // name carries more than one.
+                    None => frag.push(&format!("NULL::{}", pg_type)),
+                };
+            }
             CallParams::None => {}
         }
 

--- a/crates/postrust-core/src/query/builder.rs
+++ b/crates/postrust-core/src/query/builder.rs
@@ -211,6 +211,18 @@ impl QueryBuilder {
 
     /// Build a logic tree.
     fn build_logic_tree(tree: &CoercibleLogicTree) -> Result<SqlFragment> {
+        Self::build_logic_tree_in(None, tree)
+    }
+
+    /// The same, with every column qualified by a relation.
+    ///
+    /// An `UPDATE ... FROM` has the body's columns in scope alongside the
+    /// table's, so a bare column name in the `WHERE` is ambiguous exactly
+    /// when the request filters on a column it is also writing.
+    fn build_logic_tree_in(
+        qualifier: Option<&str>,
+        tree: &CoercibleLogicTree,
+    ) -> Result<SqlFragment> {
         match tree {
             CoercibleLogicTree::Expr {
                 negated,
@@ -222,8 +234,10 @@ impl QueryBuilder {
                     crate::api_request::LogicOperator::Or => " OR ",
                 };
 
-                let child_frags: Result<Vec<_>> =
-                    children.iter().map(Self::build_logic_tree).collect();
+                let child_frags: Result<Vec<_>> = children
+                    .iter()
+                    .map(|child| Self::build_logic_tree_in(qualifier, child))
+                    .collect();
 
                 let mut combined = SqlFragment::join(sep, child_frags?).parens();
 
@@ -235,7 +249,7 @@ impl QueryBuilder {
 
                 Ok(combined)
             }
-            CoercibleLogicTree::Stmt(filter) => Self::build_filter(filter),
+            CoercibleLogicTree::Stmt(filter) => Self::build_filter_in(qualifier, filter),
             CoercibleLogicTree::NullEmbed {
                 negated,
                 field_name,
@@ -303,6 +317,10 @@ impl QueryBuilder {
     }
 
     fn build_filter(filter: &CoercibleFilter) -> Result<SqlFragment> {
+        Self::build_filter_in(None, filter)
+    }
+
+    fn build_filter_in(qualifier: Option<&str>, filter: &CoercibleFilter) -> Result<SqlFragment> {
         let mut frag = SqlFragment::new();
 
         // Negation wraps the whole comparison. Placing `NOT` between the column
@@ -339,7 +357,7 @@ impl QueryBuilder {
                 frag.push(", ");
             }
         }
-        push_field_ref(&mut frag, &filter.field);
+        push_qualified_field_ref(&mut frag, qualifier, &filter.field);
         if to_tsvector.is_some() {
             frag.push(")");
         }
@@ -547,10 +565,24 @@ impl QueryBuilder {
                 frag.push("INSERT INTO ");
                 frag.push(&from_qi(&qi));
 
+                let object = body
+                    .as_ref()
+                    .map(|body| String::from_utf8_lossy(body).trim_start().starts_with('{'))
+                    .unwrap_or(true);
+
                 match (body, columns.is_empty()) {
-                    // A body naming no columns -- `{}` -- inserts a row of
-                    // defaults. There is no column list to write and no values
-                    // to read out of the body.
+                    // A body naming no columns inserts rows of defaults -- one
+                    // for `{}`, and one per element for an array, which is
+                    // none at all for `[]`. `SELECT` with no columns is what
+                    // says "a row, whatever the table's defaults are".
+                    (Some(body), true) if !object => {
+                        frag.push(" SELECT FROM (SELECT ");
+                        frag.push_param(String::from_utf8_lossy(body).into_owned());
+                        frag.push(
+                            "::json AS json_data) pgrst_payload, LATERAL \
+                             (SELECT FROM json_array_elements(pgrst_payload.json_data)) pgrst_body",
+                        );
+                    }
                     (_, true) => {
                         frag.push(" DEFAULT VALUES");
                     }
@@ -619,7 +651,17 @@ impl QueryBuilder {
                     }
                 }
 
-                push_returning(&mut frag, returning);
+                push_returning(&mut frag, &target.name, returning);
+
+                // Whether each row was inserted or merged into an existing
+                // one, which is the difference between 201 and 200 and is
+                // knowable only here: `xmax` is zero on a row this statement
+                // created and non-zero on one it updated.
+                if on_conflict.is_some() && !returning.is_empty() {
+                    frag.push(", (xmax = 0) AS ");
+                    frag.push(&escape_ident(INSERTED_COLUMN));
+                }
+
                 Ok(frag)
             }
 
@@ -671,11 +713,11 @@ impl QueryBuilder {
                         if i > 0 {
                             frag.push(" AND ");
                         }
-                        frag.append(Self::build_logic_tree(clause)?);
+                        frag.append(Self::build_logic_tree_in(Some(&target.name), clause)?);
                     }
                 }
 
-                push_returning(&mut frag, returning);
+                push_returning(&mut frag, &target.name, returning);
                 Ok(frag)
             }
 
@@ -703,7 +745,7 @@ impl QueryBuilder {
                     }
                 }
 
-                push_returning(&mut frag, returning);
+                push_returning(&mut frag, &target.name, returning);
                 Ok(frag)
             }
         }
@@ -859,6 +901,9 @@ impl QueryBuilder {
 /// what distinguishes `data->'1'` from `data->1` in PostgreSQL. Operands reach
 /// us already restricted to alphanumerics and underscores by the parser; the
 /// quote doubling is belt-and-braces so this stays safe if that ever loosens.
+/// The column that says whether a row was created or merged into.
+pub const INSERTED_COLUMN: &str = "pgrst_inserted";
+
 /// The columns a mutation writes, as a comma-separated identifier list.
 fn push_column_list(frag: &mut SqlFragment, columns: &[crate::plan::CoercibleField]) {
     for (i, column) in columns.iter().enumerate() {
@@ -928,8 +973,12 @@ fn push_json_body(
     frag.push(")) pgrst_body");
 }
 
-/// The `RETURNING` list, or nothing when there is none.
-fn push_returning(frag: &mut SqlFragment, returning: &[String]) {
+/// The `RETURNING` list, qualified by the relation being written.
+///
+/// `RETURNING` sees everything in the statement's scope, which for an
+/// `UPDATE ... FROM` includes the body -- and a bare column name there is
+/// ambiguous for every column the update writes.
+fn push_returning(frag: &mut SqlFragment, relation: &str, returning: &[String]) {
     if returning.is_empty() {
         return;
     }
@@ -938,6 +987,8 @@ fn push_returning(frag: &mut SqlFragment, returning: &[String]) {
         if i > 0 {
             frag.push(", ");
         }
+        frag.push(&escape_ident(relation));
+        frag.push(".");
         frag.push(&escape_ident(column));
     }
 }

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -41,10 +41,7 @@ fn build_db_query(plan: &DbActionPlan, role: Option<&str>) -> Result<MainQuery> 
             }
         }
         DbActionPlan::Call { call, read } => {
-            query.main = QueryBuilder::build_call(call)?;
-            if let Some(read_tree) = read {
-                query.read = Some(QueryBuilder::build_read(read_tree)?);
-            }
+            query.main = QueryBuilder::build_call(call, read.as_ref())?;
         }
     }
 

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -18,6 +18,9 @@ pub fn build_query(plan: &ActionPlan, role: Option<&str>) -> Result<MainQuery> {
     }
 }
 
+/// The name the rows a mutation affected are read from.
+pub const MUTATION_RESULT: &str = "pgrst_mutation_result";
+
 /// Build SQL from a database action plan.
 fn build_db_query(plan: &DbActionPlan, role: Option<&str>) -> Result<MainQuery> {
     let mut query = MainQuery::new();
@@ -35,10 +38,27 @@ fn build_db_query(plan: &DbActionPlan, role: Option<&str>) -> Result<MainQuery> 
             query.main = QueryBuilder::build_read(read_tree)?;
         }
         DbActionPlan::MutateRead { mutate, read } => {
-            query.main = QueryBuilder::build_mutate(mutate)?;
-            if let Some(read_tree) = read {
-                query.read = Some(QueryBuilder::build_read(read_tree)?);
-            }
+            let mutation = QueryBuilder::build_mutate(mutate)?;
+
+            // The rows a mutation affected are a relation like any other, so
+            // `?select=` is answered by reading from them -- which is also
+            // what lets a mutation embed, alias, cast and compute exactly as a
+            // read does. Without the wrapper the `RETURNING` list was the
+            // whole answer, and none of that reached it.
+            query.main = match read {
+                Some(read_tree) => {
+                    let read_sql = QueryBuilder::build_read(read_tree)?;
+                    let mut frag = SqlFragment::new();
+                    frag.push("WITH ");
+                    frag.push(MUTATION_RESULT);
+                    frag.push(" AS (");
+                    frag.append(mutation);
+                    frag.push(") ");
+                    frag.append(read_sql);
+                    frag
+                }
+                None => mutation,
+            };
         }
         DbActionPlan::Call { call, read } => {
             query.main = QueryBuilder::build_call(call, read.as_ref())?;

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -102,3 +102,61 @@ impl MainQuery {
         self.main.build()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api_request::{QualifiedIdentifier, Range};
+    use crate::plan::{CoercibleField, CoercibleSelectField, MutatePlan, ReadPlan, ReadPlanTree};
+
+    /// The whole statement, parentheses included.
+    ///
+    /// A missing one here is a syntax error on every write with a body, and
+    /// nothing short of executing it against PostgreSQL -- or reading it --
+    /// will say so, since the fragments that build it are each well-formed.
+    #[test]
+    fn a_write_reads_its_body_and_is_read_from() {
+        let mutate = MutatePlan::Insert {
+            target: QualifiedIdentifier::new("test", "items"),
+            columns: vec![CoercibleField::simple("id", "int8")],
+            body: Some(bytes::Bytes::from(r#"{"id":9001}"#)),
+            on_conflict: None,
+            where_clauses: vec![],
+            returning: vec!["id".into()],
+            pk_cols: vec!["id".into()],
+            apply_defaults: true,
+        };
+        let read = ReadPlan {
+            select: vec![CoercibleSelectField::simple("id", "bigint")],
+            from: QualifiedIdentifier::unqualified(MUTATION_RESULT),
+            from_alias: None,
+            where_clauses: vec![],
+            order: vec![],
+            range: Range::default(),
+            rel_name: String::new(),
+            rel_to_parent: None,
+            rel_join_conds: vec![],
+            rel_join_type: None,
+            rel_select: vec![],
+            depth: 0,
+        };
+
+        let plan = ActionPlan::Db(DbActionPlan::MutateRead {
+            mutate,
+            read: Some(ReadPlanTree::leaf(read)),
+        });
+        let (sql, _) = build_query(&plan, None).unwrap().build_main();
+
+        assert_eq!(
+            sql,
+            "WITH pgrst_mutation_result AS (\
+             INSERT INTO \"test\".\"items\" (\"id\") \
+             SELECT pgrst_body.\"id\" \
+             FROM (SELECT $1::json AS json_data) pgrst_payload, \
+             LATERAL (SELECT \"id\" FROM json_to_record(pgrst_payload.json_data) \
+             AS _(\"id\" int8)) pgrst_body \
+             RETURNING \"id\") \
+             SELECT \"id\" FROM \"pgrst_mutation_result\""
+        );
+    }
+}

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -4,7 +4,7 @@
 
 mod builder;
 
-pub use builder::{QueryBuilder, INSERTED_COLUMN};
+pub use builder::{QueryBuilder, INSERTED_COLUMN, PARENT_ROW_COLUMN};
 
 use crate::error::Result;
 use crate::plan::{ActionPlan, DbActionPlan};

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -4,7 +4,7 @@
 
 mod builder;
 
-pub use builder::QueryBuilder;
+pub use builder::{QueryBuilder, INSERTED_COLUMN};
 
 use crate::error::Result;
 use crate::plan::{ActionPlan, DbActionPlan};
@@ -155,7 +155,7 @@ mod tests {
              FROM (SELECT $1::json AS json_data) pgrst_payload, \
              LATERAL (SELECT \"id\" FROM json_to_record(pgrst_payload.json_data) \
              AS _(\"id\" int8)) pgrst_body \
-             RETURNING \"id\") \
+             RETURNING \"items\".\"id\") \
              SELECT \"id\" FROM \"pgrst_mutation_result\""
         );
     }

--- a/crates/postrust-core/src/query/mod.rs
+++ b/crates/postrust-core/src/query/mod.rs
@@ -125,6 +125,7 @@ mod tests {
             returning: vec!["id".into()],
             pk_cols: vec!["id".into()],
             apply_defaults: true,
+            reports_inserted: false,
         };
         let read = ReadPlan {
             select: vec![CoercibleSelectField::simple("id", "bigint")],

--- a/crates/postrust-core/src/row_json.rs
+++ b/crates/postrust-core/src/row_json.rs
@@ -75,10 +75,14 @@ pub fn row_to_json(row: &sqlx::postgres::PgRow) -> serde_json::Value {
                 .try_get::<chrono::DateTime<chrono::Utc>, _>(name)
                 .ok()
                 .map(|v| serde_json::Value::String(v.to_rfc3339())),
+            // ISO 8601, with `T` between the date and the time. `to_string`
+            // puts a space there, which is PostgreSQL's *display* format but
+            // not what it writes in JSON -- and a client parsing the result
+            // as a timestamp is parsing JSON.
             "TIMESTAMP" | "TIMESTAMP WITHOUT TIME ZONE" => row
                 .try_get::<chrono::NaiveDateTime, _>(name)
                 .ok()
-                .map(|v| serde_json::Value::String(v.to_string())),
+                .map(|v| serde_json::Value::String(v.format("%Y-%m-%dT%H:%M:%S%.f").to_string())),
             "DATE" => row
                 .try_get::<chrono::NaiveDate, _>(name)
                 .ok()
@@ -97,4 +101,32 @@ pub fn row_to_json(row: &sqlx::postgres::PgRow) -> serde_json::Value {
     }
 
     serde_json::Value::Object(map)
+}
+
+#[cfg(test)]
+mod tests {
+    /// The `T` is not decoration: `to_string` writes a space, which is
+    /// PostgreSQL's display format and not what it puts in JSON.
+    #[test]
+    fn a_timestamp_without_a_zone_is_written_in_iso_8601() {
+        let format = "%Y-%m-%dT%H:%M:%S%.f";
+
+        let with_fraction = chrono::NaiveDateTime::parse_from_str(
+            "2015-12-08 04:22:57.472738",
+            "%Y-%m-%d %H:%M:%S%.f",
+        )
+        .unwrap();
+        assert_eq!(
+            with_fraction.format(format).to_string(),
+            "2015-12-08T04:22:57.472738"
+        );
+
+        let whole_second =
+            chrono::NaiveDateTime::parse_from_str("2018-01-02 00:00:00", "%Y-%m-%d %H:%M:%S")
+                .unwrap();
+        assert_eq!(
+            whole_second.format(format).to_string(),
+            "2018-01-02T00:00:00"
+        );
+    }
 }

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -76,9 +76,14 @@ impl SchemaCache {
         let timezones = queries::load_timezones(pool).await?;
         info!("Loaded {} timezones", timezones.len());
 
+        // Junctions first, then views: a many-to-many derived from a
+        // junction is itself a relationship a view can carry, and the
+        // junction may live in a schema that is not exposed.
+        let primary_keys = queries::load_primary_keys(pool, &relationship_schemas).await?;
+
         let mut relationships = relationships;
-        add_view_relationships(&view_columns, &mut relationships);
-        add_junction_relationships(&tables, &mut relationships);
+        add_junction_relationships(&primary_keys, &mut relationships);
+        add_view_relationships(&tables, &view_columns, &mut relationships);
 
         let media_handlers = queries::load_media_handlers(pool, schemas).await?;
         info!("Loaded {} media type handlers", media_handlers.len());
@@ -266,6 +271,7 @@ impl SchemaCache {
 /// relationship of a base table is offered to each view over it that keeps
 /// those columns, on both sides -- a view can be embedded, and can embed.
 fn add_view_relationships(
+    tables: &TablesMap,
     view_columns: &[(QualifiedIdentifier, QualifiedIdentifier, String)],
     relationships: &mut RelationshipsMap,
 ) {
@@ -302,23 +308,45 @@ fn add_view_relationships(
         else {
             continue;
         };
-        // A many-to-many is derived from two others; projecting it as well
-        // would double up on whatever those produce.
-        if matches!(cardinality, Cardinality::M2M(_)) {
-            continue;
-        }
-
-        let columns = cardinality.columns();
-        let carries = |view_cols: &Vec<&str>, wanted: &dyn Fn(&(String, String)) -> String| {
-            columns
+        // Which columns each end has to carry for the view to stand in for
+        // it. A many-to-many joins through a junction, so the two ends are
+        // described by different halves of it -- the near side by the columns
+        // going into the junction, the far side by the ones coming out.
+        let (near_needs, far_needs): (Vec<String>, Vec<String>) = match cardinality {
+            Cardinality::M2M(junction) => (
+                junction
+                    .source_columns
+                    .iter()
+                    .map(|(near, _)| near.clone())
+                    .collect(),
+                junction
+                    .target_columns
+                    .iter()
+                    .map(|(_, far)| far.clone())
+                    .collect(),
+            ),
+            _ => {
+                let columns = cardinality.columns();
+                (
+                    columns.iter().map(|(near, _)| near.clone()).collect(),
+                    columns.iter().map(|(_, far)| far.clone()).collect(),
+                )
+            }
+        };
+        let carries = |view_cols: &Vec<&str>, needed: &[String]| {
+            needed
                 .iter()
-                .all(|pair| view_cols.iter().any(|c| *c == wanted(pair)))
+                .all(|name| view_cols.iter().any(|c| c == name))
         };
 
         // The view stands in for the near side.
+        //
+        // Skipped when the far side has views of its own: the both-views case
+        // below covers that pair, and this one would leave the far side as a
+        // table the client may not even be able to name.
         if let Some(views) = views_over.get(source) {
             for (view, view_cols) in views {
-                if !carries(view_cols, &|(local, _)| local.clone()) {
+                if !carries(view_cols, &near_needs) {
                     continue;
                 }
                 derived.push((
@@ -336,10 +364,10 @@ fn add_view_relationships(
             }
         }
 
-        // The view stands in for the far side.
+        // The view stands in for the far side, and likewise.
         if let Some(views) = views_over.get(foreign_table) {
             for (view, view_cols) in views {
-                if !carries(view_cols, &|(_, foreign)| foreign.clone()) {
+                if !carries(view_cols, &far_needs) {
                     continue;
                 }
                 derived.push((
@@ -361,11 +389,11 @@ fn add_view_relationships(
         // replaces one end and leaves the other as the base table.
         if let (Some(near), Some(far)) = (views_over.get(source), views_over.get(foreign_table)) {
             for (near_view, near_cols) in near {
-                if !carries(near_cols, &|(local, _)| local.clone()) {
+                if !carries(near_cols, &near_needs) {
                     continue;
                 }
                 for (far_view, far_cols) in far {
-                    if !carries(far_cols, &|(_, foreign)| foreign.clone()) {
+                    if !carries(far_cols, &far_needs) {
                         continue;
                     }
                     derived.push((
@@ -385,7 +413,14 @@ fn add_view_relationships(
         }
     }
 
+    // A projection is only useful if the client can name both ends. The base
+    // table behind a view is often in a schema that is not exposed, and
+    // offering it as a target would produce a relationship that resolves to a
+    // table the request has no permission to read.
     for (key, rel) in derived {
+        if !tables.contains_key(&key.0) || !tables.contains_key(rel.foreign_table()) {
+            continue;
+        }
         relationships.entry(key).or_default().push(rel);
     }
 }
@@ -400,10 +435,13 @@ fn add_view_relationships(
 ///
 /// Both sides get the relationship, named after the table across the junction,
 /// so `/users?select=name,tasks(name)` works from either end.
-fn add_junction_relationships(tables: &TablesMap, relationships: &mut RelationshipsMap) {
+fn add_junction_relationships(
+    primary_keys: &std::collections::HashMap<QualifiedIdentifier, Vec<String>>,
+    relationships: &mut RelationshipsMap,
+) {
     let mut derived: Vec<((QualifiedIdentifier, String), Relationship)> = Vec::new();
 
-    for (junction_qi, junction) in tables {
+    for (junction_qi, junction_pk) in primary_keys {
         let key = (junction_qi.clone(), junction_qi.schema.clone());
         let Some(rels) = relationships.get(&key) else {
             continue;
@@ -426,7 +464,7 @@ fn add_junction_relationships(tables: &TablesMap, relationships: &mut Relationsh
             })
             .collect();
 
-        let mut pk: Vec<&str> = junction.pk_cols.iter().map(String::as_str).collect();
+        let mut pk: Vec<&str> = junction_pk.iter().map(String::as_str).collect();
         pk.sort_unstable();
         if pk.len() != 2 {
             continue;

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -129,7 +129,13 @@ impl SchemaCache {
         // constraint called `client`.
         candidates
             .iter()
-            .find(|r| r.foreign_table().name == to_name)
+            .find(|r| match r {
+                // A computed relationship is named by its function. Two
+                // functions may return the same table, so the table's name
+                // would not tell them apart.
+                Relationship::Computed { function, .. } => function.name == to_name,
+                Relationship::ForeignKey { foreign_table, .. } => foreign_table.name == to_name,
+            })
             .or_else(|| candidates.iter().find(|r| r.constraint_name() == to_name))
             .or_else(|| {
                 candidates

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -63,6 +63,9 @@ impl SchemaCache {
         let timezones = queries::load_timezones(pool).await?;
         info!("Loaded {} timezones", timezones.len());
 
+        let mut relationships = relationships;
+        add_junction_relationships(&tables, &mut relationships);
+
         let media_handlers = queries::load_media_handlers(pool, schemas).await?;
         info!("Loaded {} media type handlers", media_handlers.len());
 
@@ -188,6 +191,98 @@ impl SchemaCache {
                     .iter()
                     .find(|r| r.join_columns().iter().any(|(local, _)| local == to_name))
             })
+    }
+}
+
+/// Derive many-to-many relationships from junction tables.
+///
+/// A junction is a table that exists only to join two others: it has exactly
+/// two foreign keys, to two different tables, and its primary key is precisely
+/// the columns of those keys. That last condition is what separates a junction
+/// from an ordinary table that happens to reference two others, which would
+/// otherwise sprout a relationship it has no business having.
+///
+/// Both sides get the relationship, named after the table across the junction,
+/// so `/users?select=name,tasks(name)` works from either end.
+fn add_junction_relationships(tables: &TablesMap, relationships: &mut RelationshipsMap) {
+    let mut derived: Vec<((QualifiedIdentifier, String), Relationship)> = Vec::new();
+
+    for (junction_qi, junction) in tables {
+        let key = (junction_qi.clone(), junction_qi.schema.clone());
+        let Some(rels) = relationships.get(&key) else {
+            continue;
+        };
+
+        // The single-column keys out of the junction. A junction joins two
+        // tables by one column each; a composite key to somewhere else is a
+        // different relationship that happens to share the table.
+        let outgoing: Vec<(&Relationship, (String, String))> = rels
+            .iter()
+            .filter(|r| matches!(r, Relationship::ForeignKey { table, .. } if table == junction_qi))
+            .filter(|r| r.is_to_one())
+            .filter_map(|r| {
+                let mut columns = r.join_columns();
+                columns.dedup();
+                match columns.len() {
+                    1 => Some((r, columns.remove(0))),
+                    _ => None,
+                }
+            })
+            .collect();
+
+        let mut pk: Vec<&str> = junction.pk_cols.iter().map(String::as_str).collect();
+        pk.sort_unstable();
+        if pk.len() != 2 {
+            continue;
+        }
+
+        // The pair whose columns are exactly the primary key is the one that
+        // makes this a junction. Requiring the whole key is what separates a
+        // junction from a table that merely references two others.
+        for near in 0..outgoing.len() {
+            for far in 0..outgoing.len() {
+                if near == far {
+                    continue;
+                }
+                let (near_rel, (near_local, near_foreign)) = &outgoing[near];
+                let (far_rel, (far_local, far_foreign)) = &outgoing[far];
+                if near_rel.foreign_table() == far_rel.foreign_table() {
+                    continue;
+                }
+                let mut covered = vec![near_local.as_str(), far_local.as_str()];
+                covered.sort_unstable();
+                if covered != pk {
+                    continue;
+                }
+
+                let source = near_rel.foreign_table().clone();
+                let target = far_rel.foreign_table().clone();
+
+                derived.push((
+                    (source.clone(), source.schema.clone()),
+                    Relationship::ForeignKey {
+                        table: source,
+                        foreign_table: target,
+                        is_self: false,
+                        cardinality: Cardinality::M2M(Junction {
+                            table: junction_qi.clone(),
+                            constraint1: near_rel.constraint_name().to_string(),
+                            constraint2: far_rel.constraint_name().to_string(),
+                            // Source to junction, then junction to target.
+                            source_columns: vec![(near_foreign.clone(), near_local.clone())],
+                            target_columns: vec![(far_local.clone(), far_foreign.clone())],
+                        }),
+                        table_is_view: false,
+                        foreign_table_is_view: false,
+                        constraint_name: String::new(),
+                    },
+                ));
+            }
+        }
+    }
+
+    for (key, rel) in derived {
+        relationships.entry(key).or_default().push(rel);
     }
 }
 

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -309,6 +309,23 @@ impl SchemaCache {
                 // functions may return the same table, so the table's name
                 // would not tell them apart.
                 Relationship::Computed { function, .. } => function.name == to_name,
+                // One foreign key pointing at its own table is two
+                // relationships, and the table's name alone cannot tell them
+                // apart. The convention is PostgREST's: the table's name means
+                // the rows that point here -- the children -- and the key's own
+                // column means the row this one points at. A hint names the
+                // column the children point with, and so always means children.
+                r if r.is_self_referential() => match hint {
+                    None => {
+                        (r.foreign_table().name == to_name && r.is_one_to_many())
+                            || (r.single_local_column() == Some(to_name) && !r.is_one_to_many())
+                    }
+                    Some(hint) => {
+                        r.foreign_table().name == to_name
+                            && r.is_one_to_many()
+                            && r.single_foreign_column() == Some(hint)
+                    }
+                },
                 Relationship::ForeignKey { foreign_table, .. } => foreign_table.name == to_name,
             })
             .collect();
@@ -356,8 +373,11 @@ impl SchemaCache {
             }
         };
 
+        // A self-referential match has already accounted for the hint, and the
+        // general rule would reject it: both directions join on the same pair
+        // of columns, so the hint names them both.
         if let Some(hint) = hint {
-            matches.retain(|r| r.matches_hint(hint));
+            matches.retain(|r| r.is_self_referential() || r.matches_hint(hint));
         }
 
         match matches.len() {

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -159,38 +159,79 @@ impl SchemaCache {
     }
 
     /// Find a relationship between two tables by name.
+    ///
+    /// `hint` is the `!hint` of `person_detail!message_sender_fkey(name)`,
+    /// which names the relationship when the two resources are connected by
+    /// more than one.
+    ///
+    /// Returns `Ok(None)` when nothing matches, and an error when several do
+    /// and no hint told them apart -- picking one arbitrarily would answer a
+    /// question the client did not ask.
     pub fn find_relationship(
         &self,
         from: &QualifiedIdentifier,
         to_name: &str,
+        hint: Option<&str>,
         schema: &str,
-    ) -> Option<&Relationship> {
-        let candidates = self.get_relationships(from, schema)?;
+    ) -> Result<Option<&Relationship>> {
+        let Some(candidates) = self.get_relationships(from, schema) else {
+            return Ok(None);
+        };
 
         // An embedding may be named three ways, and they are tried in the
         // order of how specifically they identify one relationship.
         //
-        // The target table's name is the usual spelling, but it is ambiguous
-        // as soon as two foreign keys point at the same table. The foreign key
-        // constraint names exactly one relationship, and so does the column
-        // that joins them -- `/messages?select=*,sender(*)` embeds through the
-        // `sender` column, and `/projects?select=*,client(*)` through the
-        // constraint called `client`.
-        candidates
+        // The target table's name is the usual spelling, but it stops
+        // identifying anything as soon as two foreign keys point at the same
+        // table. The foreign key constraint names exactly one relationship,
+        // and so does the column that joins them -- `/messages?select=*,
+        // sender(*)` embeds through the `sender` column, and
+        // `/projects?select=*,client(*)` through the constraint called
+        // `client`.
+        let by_target: Vec<&Relationship> = candidates
             .iter()
-            .find(|r| match r {
+            .filter(|r| match r {
                 // A computed relationship is named by its function. Two
                 // functions may return the same table, so the table's name
                 // would not tell them apart.
                 Relationship::Computed { function, .. } => function.name == to_name,
                 Relationship::ForeignKey { foreign_table, .. } => foreign_table.name == to_name,
             })
-            .or_else(|| candidates.iter().find(|r| r.constraint_name() == to_name))
-            .or_else(|| {
-                candidates
+            .collect();
+
+        let mut matches = match by_target.is_empty() {
+            false => by_target,
+            true => {
+                let by_constraint: Vec<&Relationship> = candidates
                     .iter()
-                    .find(|r| r.join_columns().iter().any(|(local, _)| local == to_name))
-            })
+                    .filter(|r| r.constraint_name() == to_name)
+                    .collect();
+                match by_constraint.is_empty() {
+                    false => by_constraint,
+                    true => candidates
+                        .iter()
+                        .filter(|r| r.join_columns().iter().any(|(local, _)| local == to_name))
+                        .collect(),
+                }
+            }
+        };
+
+        if let Some(hint) = hint {
+            matches.retain(|r| r.matches_hint(hint));
+        }
+
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(Some(matches[0])),
+            _ => Err(Error::AmbiguousRelationship {
+                origin: from.name.clone(),
+                target: to_name.to_string(),
+                candidates: matches
+                    .iter()
+                    .map(|r| (r.cardinality_name().to_string(), r.describe()))
+                    .collect(),
+            }),
+        }
     }
 }
 

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -51,8 +51,21 @@ impl SchemaCache {
         let tables = queries::load_tables(pool, schemas).await?;
         info!("Loaded {} tables/views", tables.len());
 
+        // Which base-table columns each view carries. Loaded before the
+        // relationships, because a view's base table may live in a schema
+        // that is not itself exposed -- `private.articles` behind a public
+        // view -- and its foreign keys are needed all the same.
+        let view_columns = queries::load_view_columns(pool, schemas).await?;
+
+        let mut relationship_schemas: Vec<String> = schemas.to_vec();
+        for (_, base, _) in &view_columns {
+            if !relationship_schemas.contains(&base.schema) {
+                relationship_schemas.push(base.schema.clone());
+            }
+        }
+
         // Load relationships
-        let relationships = queries::load_relationships(pool, schemas).await?;
+        let relationships = queries::load_relationships(pool, &relationship_schemas).await?;
         info!("Loaded {} relationship sets", relationships.len());
 
         // Load routines
@@ -64,6 +77,7 @@ impl SchemaCache {
         info!("Loaded {} timezones", timezones.len());
 
         let mut relationships = relationships;
+        add_view_relationships(&view_columns, &mut relationships);
         add_junction_relationships(&tables, &mut relationships);
 
         let media_handlers = queries::load_media_handlers(pool, schemas).await?;
@@ -199,17 +213,27 @@ impl SchemaCache {
             })
             .collect();
 
+        // A relationship projected onto a view carries the constraint and
+        // columns of the base one it came from, so naming either of those
+        // would match both. Only the view's own name selects the projection;
+        // the constraint and the column mean the relationship they belong to.
+        // PostgreSQL cannot point a foreign key at a view, so a view on the
+        // far side is exactly what marks a projection.
+        let declared = |r: &&Relationship| !matches!(r, Relationship::ForeignKey { foreign_table_is_view, .. } if *foreign_table_is_view);
+
         let mut matches = match by_target.is_empty() {
             false => by_target,
             true => {
                 let by_constraint: Vec<&Relationship> = candidates
                     .iter()
+                    .filter(declared)
                     .filter(|r| r.constraint_name() == to_name)
                     .collect();
                 match by_constraint.is_empty() {
                     false => by_constraint,
                     true => candidates
                         .iter()
+                        .filter(declared)
                         .filter(|r| r.join_columns().iter().any(|(local, _)| local == to_name))
                         .collect(),
                 }
@@ -232,6 +256,137 @@ impl SchemaCache {
                     .collect(),
             }),
         }
+    }
+}
+
+/// Project a base table's relationships onto the views that select from it.
+///
+/// A view has no foreign keys, but embedding one is ordinary usage: what makes
+/// it possible is that the view carries the columns the key joins on. So every
+/// relationship of a base table is offered to each view over it that keeps
+/// those columns, on both sides -- a view can be embedded, and can embed.
+fn add_view_relationships(
+    view_columns: &[(QualifiedIdentifier, QualifiedIdentifier, String)],
+    relationships: &mut RelationshipsMap,
+) {
+    use std::collections::HashMap;
+
+    // base table -> the views over it, each with the columns it carries
+    let mut views_over: HashMap<&QualifiedIdentifier, HashMap<&QualifiedIdentifier, Vec<&str>>> =
+        HashMap::new();
+    for (view, base, column) in view_columns {
+        views_over
+            .entry(base)
+            .or_default()
+            .entry(view)
+            .or_default()
+            .push(column);
+    }
+
+    let existing: Vec<((QualifiedIdentifier, String), Relationship)> = relationships
+        .iter()
+        .flat_map(|(key, rels)| rels.iter().map(move |rel| (key.clone(), rel.clone())))
+        .collect();
+
+    let mut derived: Vec<((QualifiedIdentifier, String), Relationship)> = Vec::new();
+
+    for ((source, _), rel) in &existing {
+        let Relationship::ForeignKey {
+            foreign_table,
+            cardinality,
+            table_is_view,
+            foreign_table_is_view,
+            constraint_name,
+            ..
+        } = rel
+        else {
+            continue;
+        };
+        // A many-to-many is derived from two others; projecting it as well
+        // would double up on whatever those produce.
+        if matches!(cardinality, Cardinality::M2M(_)) {
+            continue;
+        }
+
+        let columns = cardinality.columns();
+        let carries = |view_cols: &Vec<&str>, wanted: &dyn Fn(&(String, String)) -> String| {
+            columns
+                .iter()
+                .all(|pair| view_cols.iter().any(|c| *c == wanted(pair)))
+        };
+
+        // The view stands in for the near side.
+        if let Some(views) = views_over.get(source) {
+            for (view, view_cols) in views {
+                if !carries(view_cols, &|(local, _)| local.clone()) {
+                    continue;
+                }
+                derived.push((
+                    ((*view).clone(), view.schema.clone()),
+                    Relationship::ForeignKey {
+                        table: (*view).clone(),
+                        foreign_table: foreign_table.clone(),
+                        is_self: *view == foreign_table,
+                        cardinality: cardinality.clone(),
+                        table_is_view: true,
+                        foreign_table_is_view: *foreign_table_is_view,
+                        constraint_name: constraint_name.clone(),
+                    },
+                ));
+            }
+        }
+
+        // The view stands in for the far side.
+        if let Some(views) = views_over.get(foreign_table) {
+            for (view, view_cols) in views {
+                if !carries(view_cols, &|(_, foreign)| foreign.clone()) {
+                    continue;
+                }
+                derived.push((
+                    (source.clone(), source.schema.clone()),
+                    Relationship::ForeignKey {
+                        table: source.clone(),
+                        foreign_table: (*view).clone(),
+                        is_self: source == *view,
+                        cardinality: cardinality.clone(),
+                        table_is_view: *table_is_view,
+                        foreign_table_is_view: true,
+                        constraint_name: constraint_name.clone(),
+                    },
+                ));
+            }
+        }
+
+        // Both sides are views. Neither of the cases above covers it: each
+        // replaces one end and leaves the other as the base table.
+        if let (Some(near), Some(far)) = (views_over.get(source), views_over.get(foreign_table)) {
+            for (near_view, near_cols) in near {
+                if !carries(near_cols, &|(local, _)| local.clone()) {
+                    continue;
+                }
+                for (far_view, far_cols) in far {
+                    if !carries(far_cols, &|(_, foreign)| foreign.clone()) {
+                        continue;
+                    }
+                    derived.push((
+                        ((*near_view).clone(), near_view.schema.clone()),
+                        Relationship::ForeignKey {
+                            table: (*near_view).clone(),
+                            foreign_table: (*far_view).clone(),
+                            is_self: near_view == far_view,
+                            cardinality: cardinality.clone(),
+                            table_is_view: true,
+                            foreign_table_is_view: true,
+                            constraint_name: constraint_name.clone(),
+                        },
+                    ));
+                }
+            }
+        }
+    }
+
+    for (key, rel) in derived {
+        relationships.entry(key).or_default().push(rel);
     }
 }
 

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -12,7 +12,7 @@ pub use relationship::{
     Cardinality, Junction, MediaHandler, MediaHandlerMap, Relationship, RelationshipsMap,
 };
 pub use routine::{FuncVolatility, RetType, Routine, RoutineMap, RoutineParam};
-pub use table::{Column, ColumnMap, Table, TablesMap};
+pub use table::{Column, ColumnMap, ComputedColumn, Table, TablesMap};
 
 use crate::api_request::QualifiedIdentifier;
 use crate::error::{Error, Result};
@@ -36,6 +36,11 @@ pub struct SchemaCache {
     pub pg_version: i32,
     /// User-defined renderers for media types, by (schema, media type).
     pub media_handlers: MediaHandlerMap,
+    /// Casts between a domain and `json`/`text`, by (source, target) type.
+    ///
+    /// A schema uses these to decide how a value of one of its domains is
+    /// written on the wire and how one written by a client is read back.
+    pub representations: std::collections::HashMap<(String, String), String>,
 }
 
 impl SchemaCache {
@@ -57,10 +62,27 @@ impl SchemaCache {
         // view -- and its foreign keys are needed all the same.
         let view_columns = queries::load_view_columns(pool, schemas).await?;
 
+        // Functions that read as columns. Attached to the tables they belong
+        // to, so resolving a field name has one place to look.
+        let mut tables = tables;
+        for (table, name, function, data_type) in
+            queries::load_computed_columns(pool, schemas).await?
+        {
+            if let Some(table) = tables.get_mut(&table) {
+                table.computed_columns.insert(
+                    name,
+                    ComputedColumn {
+                        function,
+                        data_type,
+                    },
+                );
+            }
+        }
+
         let mut relationship_schemas: Vec<String> = schemas.to_vec();
-        for (_, base, _) in &view_columns {
-            if !relationship_schemas.contains(&base.schema) {
-                relationship_schemas.push(base.schema.clone());
+        for column in &view_columns {
+            if !relationship_schemas.contains(&column.base.schema) {
+                relationship_schemas.push(column.base.schema.clone());
             }
         }
 
@@ -83,10 +105,14 @@ impl SchemaCache {
 
         let mut relationships = relationships;
         add_junction_relationships(&primary_keys, &mut relationships);
+        substitute_hidden_junctions(&tables, &view_columns, &mut relationships);
         add_view_relationships(&tables, &view_columns, &mut relationships);
 
         let media_handlers = queries::load_media_handlers(pool, schemas).await?;
         info!("Loaded {} media type handlers", media_handlers.len());
+
+        let representations = queries::load_representations(pool).await?;
+        info!("Loaded {} data representations", representations.len());
 
         Ok(Self {
             tables,
@@ -95,6 +121,7 @@ impl SchemaCache {
             timezones,
             pg_version,
             media_handlers,
+            representations,
         })
     }
 
@@ -105,8 +132,29 @@ impl SchemaCache {
 
     /// Get a table, returning an error if not found.
     pub fn require_table(&self, qi: &QualifiedIdentifier) -> Result<&Table> {
-        self.get_table(qi)
-            .ok_or_else(|| Error::TableNotFound(qi.to_string()))
+        self.get_table(qi).ok_or_else(|| Error::TableNotFound {
+            name: qi.to_string(),
+            suggestion: self.similar_table(qi),
+        })
+    }
+
+    /// The exposed table whose name is closest to one that does not exist.
+    ///
+    /// PostgREST answers a schema-cache miss with a suggestion where there is
+    /// an obviously intended table -- `projectx` for `projects` -- and with
+    /// nothing where there is not, which is what the similarity floor decides.
+    /// Below it the "suggestion" would be noise, and would also say more about
+    /// the schema than the client asked.
+    fn similar_table(&self, qi: &QualifiedIdentifier) -> Option<String> {
+        const MIN_SIMILARITY: f64 = 0.75;
+
+        self.tables
+            .keys()
+            .filter(|candidate| candidate.schema == qi.schema)
+            .map(|candidate| (similarity(&candidate.name, &qi.name), candidate))
+            .filter(|(score, _)| *score >= MIN_SIMILARITY)
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .map(|(_, candidate)| candidate.to_string())
     }
 
     /// Get relationships for a table.
@@ -158,6 +206,14 @@ impl SchemaCache {
         self.get_table(&candidate)
     }
 
+    /// The function that renders a value of `pg_type` as `target`, if the
+    /// schema declared one.
+    pub fn representation(&self, pg_type: &str, target: &str) -> Option<&str> {
+        self.representations
+            .get(&(pg_type.to_string(), target.to_string()))
+            .map(String::as_str)
+    }
+
     /// Find a user-defined renderer for a media type on a given table.
     ///
     /// A handler declared for the table itself wins over one taking
@@ -175,6 +231,45 @@ impl SchemaCache {
             .iter()
             .find(|h| h.table.as_ref() == Some(table))
             .or_else(|| candidates.iter().find(|h| h.table.is_none()))
+    }
+
+    /// The error to report when no relationship connects two resources.
+    ///
+    /// Built here rather than at the call site because the suggestion needs
+    /// the relationships the origin actually has, which is what the client
+    /// most likely meant to name.
+    pub fn relationship_not_found(
+        &self,
+        from: &QualifiedIdentifier,
+        to_name: &str,
+        hint: Option<&str>,
+        schema: &str,
+    ) -> Error {
+        // Looser than the table suggestion: a relationship is named by the far
+        // table, and a client that got it wrong tends to have got it wrong by
+        // a whole word -- `car_model_sales_202101` for `car_model_sales`.
+        const MIN_SIMILARITY: f64 = 0.4;
+
+        let suggestion = self
+            .get_relationships(from, schema)
+            .into_iter()
+            .flatten()
+            .map(|rel| rel.foreign_table().name.as_str())
+            // A relationship of exactly that name exists, so the name is not
+            // what went wrong -- the hint is.
+            .filter(|name| *name != to_name)
+            .map(|name| (similarity(name, to_name), name))
+            .filter(|(score, _)| *score >= MIN_SIMILARITY)
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .map(|(_, name)| name.to_string());
+
+        Error::RelationshipNotFound {
+            origin: from.name.clone(),
+            target: to_name.to_string(),
+            hint: hint.map(str::to_string),
+            schema: schema.to_string(),
+            suggestion,
+        }
     }
 
     /// Find a relationship between two tables by name.
@@ -226,6 +321,22 @@ impl SchemaCache {
         // far side is exactly what marks a projection.
         let declared = |r: &&Relationship| !matches!(r, Relationship::ForeignKey { foreign_table_is_view, .. } if *foreign_table_is_view);
 
+        // A computed relationship declared under a name overrides whatever the
+        // catalogue found under it. That is deliberate on the schema author's
+        // part -- naming the function after the table is how a schema replaces
+        // the derived relationship with one of its own -- so the two are not
+        // an ambiguity to report back.
+        let by_target = match by_target
+            .iter()
+            .any(|r| matches!(r, Relationship::Computed { .. }))
+        {
+            true => by_target
+                .into_iter()
+                .filter(|r| matches!(r, Relationship::Computed { .. }))
+                .collect(),
+            false => by_target,
+        };
+
         let mut matches = match by_target.is_empty() {
             false => by_target,
             true => {
@@ -264,29 +375,172 @@ impl SchemaCache {
     }
 }
 
-/// Project a base table's relationships onto the views that select from it.
+/// How alike two names are, from 0 (nothing in common) to 1 (identical).
 ///
-/// A view has no foreign keys, but embedding one is ordinary usage: what makes
-/// it possible is that the view carries the columns the key joins on. So every
-/// relationship of a base table is offered to each view over it that keeps
-/// those columns, on both sides -- a view can be embedded, and can embed.
-fn add_view_relationships(
+/// Edit distance over the longer of the two, which is enough to tell a typo
+/// from a different word.
+fn similarity(a: &str, b: &str) -> f64 {
+    let longest = a.chars().count().max(b.chars().count());
+    if longest == 0 {
+        return 1.0;
+    }
+    1.0 - edit_distance(a, b) as f64 / longest as f64
+}
+
+/// Levenshtein distance, computed one row at a time.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    let mut current = vec![0; b.len() + 1];
+
+    for (i, a_char) in a.chars().enumerate() {
+        current[0] = i + 1;
+        for (j, b_char) in b.iter().enumerate() {
+            let substitution = previous[j] + usize::from(a_char != *b_char);
+            current[j + 1] = substitution.min(previous[j + 1] + 1).min(current[j] + 1);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[b.len()]
+}
+
+/// Route a many-to-many through the exposed view of its junction.
+///
+/// The junction is often the one table of the three that the API does not
+/// expose -- `private.personnages` behind `test.personnages` -- and joining
+/// through the base table is a `permission denied for schema private` at
+/// request time even though the relationship itself is real. Where a view over
+/// it is exposed and carries both keys, that view is joined through instead.
+fn substitute_hidden_junctions(
     tables: &TablesMap,
-    view_columns: &[(QualifiedIdentifier, QualifiedIdentifier, String)],
+    view_columns: &[queries::ViewColumn],
     relationships: &mut RelationshipsMap,
 ) {
     use std::collections::HashMap;
 
-    // base table -> the views over it, each with the columns it carries
-    let mut views_over: HashMap<&QualifiedIdentifier, HashMap<&QualifiedIdentifier, Vec<&str>>> =
+    // Which name an exposed view gives each of a base table's columns.
+    type ColumnRenames<'a> = HashMap<&'a str, &'a str>;
+    /// The exposed views over one base table, each with its renames.
+    type ExposedViews<'a> = Vec<(&'a QualifiedIdentifier, ColumnRenames<'a>)>;
+
+    let mut views_over: HashMap<&QualifiedIdentifier, ExposedViews<'_>> = HashMap::new();
+    for column in view_columns {
+        if !tables.contains_key(&column.view) {
+            continue;
+        }
+        let entry = views_over.entry(&column.base).or_default();
+        match entry.iter_mut().find(|(view, _)| *view == &column.view) {
+            Some((_, mapping)) => {
+                mapping.insert(&column.base_column, &column.view_column);
+            }
+            None => {
+                let mut mapping = HashMap::new();
+                mapping.insert(column.base_column.as_str(), column.view_column.as_str());
+                entry.push((&column.view, mapping));
+            }
+        }
+    }
+
+    for rel in relationships.values_mut().flatten() {
+        let Relationship::ForeignKey {
+            cardinality: Cardinality::M2M(junction),
+            ..
+        } = rel
+        else {
+            continue;
+        };
+        if tables.contains_key(&junction.table) {
+            continue;
+        }
+
+        let needed: Vec<&str> = junction
+            .source_columns
+            .iter()
+            .map(|(_, through)| through.as_str())
+            .chain(
+                junction
+                    .target_columns
+                    .iter()
+                    .map(|(through, _)| through.as_str()),
+            )
+            .collect();
+
+        let Some((view, mapping)) = views_over.get(&junction.table).and_then(|views| {
+            views
+                .iter()
+                .find(|(_, mapping)| needed.iter().all(|name| mapping.contains_key(name)))
+        }) else {
+            // Nothing exposes the junction, so nothing can join through it.
+            // Marked rather than removed here, since the relationship is being
+            // iterated; the sweep below drops them.
+            junction.table = QualifiedIdentifier::new("", "");
+            continue;
+        };
+
+        junction.table = (*view).clone();
+        for (_, through) in junction.source_columns.iter_mut() {
+            if let Some(renamed) = mapping.get(through.as_str()) {
+                *through = (*renamed).to_string();
+            }
+        }
+        for (through, _) in junction.target_columns.iter_mut() {
+            if let Some(renamed) = mapping.get(through.as_str()) {
+                *through = (*renamed).to_string();
+            }
+        }
+    }
+
+    // Offering an unreachable relationship would answer `permission denied for
+    // schema private` where PostgREST answers that no relationship was found,
+    // which is both the truer answer and the one that says nothing about a
+    // schema the client was never shown.
+    for rels in relationships.values_mut() {
+        rels.retain(|rel| {
+            !matches!(
+                rel,
+                Relationship::ForeignKey {
+                    cardinality: Cardinality::M2M(junction),
+                    ..
+                } if junction.table.name.is_empty()
+            )
+        });
+    }
+    relationships.retain(|_, rels| !rels.is_empty());
+}
+
+/// Project relationships from base tables onto the views that select them.
+///
+/// A view carrying both ends of a foreign key can stand in for either side of
+/// it, so `/articleStars?select=*,articles(*)` embeds through the key on
+/// `private.article_stars` without the client ever naming the private table.
+///
+/// The join columns are rewritten to the names the view gives them: a view is
+/// free to rename what it selects, and the projected relationship has to join
+/// on the names the client can actually see. Where a view selects one base
+/// column twice under different names, each spelling is a relationship of its
+/// own -- they are genuinely different joins, and `!t1_id1` is how a client
+/// tells them apart.
+fn add_view_relationships(
+    tables: &TablesMap,
+    view_columns: &[queries::ViewColumn],
+    relationships: &mut RelationshipsMap,
+) {
+    use std::collections::HashMap;
+
+    // base table -> view -> base column -> the names that view gives it
+    type ColumnNames = HashMap<String, Vec<String>>;
+    let mut views_over: HashMap<&QualifiedIdentifier, HashMap<&QualifiedIdentifier, ColumnNames>> =
         HashMap::new();
-    for (view, base, column) in view_columns {
+    for column in view_columns {
         views_over
-            .entry(base)
+            .entry(&column.base)
             .or_default()
-            .entry(view)
+            .entry(&column.view)
             .or_default()
-            .push(column);
+            .entry(column.base_column.clone())
+            .or_default()
+            .push(column.view_column.clone());
     }
 
     let existing: Vec<((QualifiedIdentifier, String), Relationship)> = relationships
@@ -308,6 +562,7 @@ fn add_view_relationships(
         else {
             continue;
         };
+
         // Which columns each end has to carry for the view to stand in for
         // it. A many-to-many joins through a junction, so the two ends are
         // described by different halves of it -- the near side by the columns
@@ -333,81 +588,97 @@ fn add_view_relationships(
                 )
             }
         };
-        let carries = |view_cols: &Vec<&str>, needed: &[String]| {
-            needed
-                .iter()
-                .all(|name| view_cols.iter().any(|c| c == name))
+
+        // Every way the view can spell the columns this end joins on. Empty
+        // when it does not carry all of them, which is what disqualifies it
+        // from standing in at all.
+        let spellings = |view_cols: &ColumnNames, needed: &[String]| -> Vec<Vec<String>> {
+            let mut combinations: Vec<Vec<String>> = vec![vec![]];
+            for name in needed {
+                let Some(candidates) = view_cols.get(name) else {
+                    return vec![];
+                };
+                combinations = combinations
+                    .into_iter()
+                    .flat_map(|prefix| {
+                        candidates.iter().map(move |candidate| {
+                            let mut extended = prefix.clone();
+                            extended.push(candidate.clone());
+                            extended
+                        })
+                    })
+                    .collect();
+            }
+            combinations
         };
 
         // The view stands in for the near side.
-        //
-        // Skipped when the far side has views of its own: the both-views case
-        // below covers that pair, and this one would leave the far side as a
-        // table the client may not even be able to name.
         if let Some(views) = views_over.get(source) {
             for (view, view_cols) in views {
-                if !carries(view_cols, &near_needs) {
-                    continue;
+                for near in spellings(view_cols, &near_needs) {
+                    derived.push((
+                        ((*view).clone(), view.schema.clone()),
+                        Relationship::ForeignKey {
+                            table: (*view).clone(),
+                            foreign_table: foreign_table.clone(),
+                            is_self: *view == foreign_table,
+                            cardinality: rename_cardinality(cardinality, Some(&near), None),
+                            table_is_view: true,
+                            foreign_table_is_view: *foreign_table_is_view,
+                            constraint_name: constraint_name.clone(),
+                        },
+                    ));
                 }
-                derived.push((
-                    ((*view).clone(), view.schema.clone()),
-                    Relationship::ForeignKey {
-                        table: (*view).clone(),
-                        foreign_table: foreign_table.clone(),
-                        is_self: *view == foreign_table,
-                        cardinality: cardinality.clone(),
-                        table_is_view: true,
-                        foreign_table_is_view: *foreign_table_is_view,
-                        constraint_name: constraint_name.clone(),
-                    },
-                ));
             }
         }
 
         // The view stands in for the far side, and likewise.
         if let Some(views) = views_over.get(foreign_table) {
             for (view, view_cols) in views {
-                if !carries(view_cols, &far_needs) {
-                    continue;
+                for far in spellings(view_cols, &far_needs) {
+                    derived.push((
+                        (source.clone(), source.schema.clone()),
+                        Relationship::ForeignKey {
+                            table: source.clone(),
+                            foreign_table: (*view).clone(),
+                            is_self: source == *view,
+                            cardinality: rename_cardinality(cardinality, None, Some(&far)),
+                            table_is_view: *table_is_view,
+                            foreign_table_is_view: true,
+                            constraint_name: constraint_name.clone(),
+                        },
+                    ));
                 }
-                derived.push((
-                    (source.clone(), source.schema.clone()),
-                    Relationship::ForeignKey {
-                        table: source.clone(),
-                        foreign_table: (*view).clone(),
-                        is_self: source == *view,
-                        cardinality: cardinality.clone(),
-                        table_is_view: *table_is_view,
-                        foreign_table_is_view: true,
-                        constraint_name: constraint_name.clone(),
-                    },
-                ));
             }
         }
 
         // Both sides are views. Neither of the cases above covers it: each
         // replaces one end and leaves the other as the base table.
-        if let (Some(near), Some(far)) = (views_over.get(source), views_over.get(foreign_table)) {
-            for (near_view, near_cols) in near {
-                if !carries(near_cols, &near_needs) {
-                    continue;
-                }
-                for (far_view, far_cols) in far {
-                    if !carries(far_cols, &far_needs) {
-                        continue;
+        if let (Some(near_views), Some(far_views)) =
+            (views_over.get(source), views_over.get(foreign_table))
+        {
+            for (near_view, near_cols) in near_views {
+                for near in spellings(near_cols, &near_needs) {
+                    for (far_view, far_cols) in far_views {
+                        for far in spellings(far_cols, &far_needs) {
+                            derived.push((
+                                ((*near_view).clone(), near_view.schema.clone()),
+                                Relationship::ForeignKey {
+                                    table: (*near_view).clone(),
+                                    foreign_table: (*far_view).clone(),
+                                    is_self: near_view == far_view,
+                                    cardinality: rename_cardinality(
+                                        cardinality,
+                                        Some(&near),
+                                        Some(&far),
+                                    ),
+                                    table_is_view: true,
+                                    foreign_table_is_view: true,
+                                    constraint_name: constraint_name.clone(),
+                                },
+                            ));
+                        }
                     }
-                    derived.push((
-                        ((*near_view).clone(), near_view.schema.clone()),
-                        Relationship::ForeignKey {
-                            table: (*near_view).clone(),
-                            foreign_table: (*far_view).clone(),
-                            is_self: near_view == far_view,
-                            cardinality: cardinality.clone(),
-                            table_is_view: true,
-                            foreign_table_is_view: true,
-                            constraint_name: constraint_name.clone(),
-                        },
-                    ));
                 }
             }
         }
@@ -422,6 +693,78 @@ fn add_view_relationships(
             continue;
         }
         relationships.entry(key).or_default().push(rel);
+    }
+}
+
+/// A cardinality with one or both ends' columns renamed.
+///
+/// `near` and `far` are given in the order the cardinality lists them, so the
+/// nth name replaces the nth column. `None` leaves that end alone.
+fn rename_cardinality(
+    cardinality: &Cardinality,
+    near: Option<&[String]>,
+    far: Option<&[String]>,
+) -> Cardinality {
+    let rename_pairs = |columns: &[(String, String)]| -> Vec<(String, String)> {
+        columns
+            .iter()
+            .enumerate()
+            .map(|(i, (local, foreign))| {
+                (
+                    near.and_then(|names| names.get(i)).unwrap_or(local).clone(),
+                    far.and_then(|names| names.get(i))
+                        .unwrap_or(foreign)
+                        .clone(),
+                )
+            })
+            .collect()
+    };
+
+    match cardinality {
+        Cardinality::O2M {
+            constraint,
+            columns,
+        } => Cardinality::O2M {
+            constraint: constraint.clone(),
+            columns: rename_pairs(columns),
+        },
+        Cardinality::M2O {
+            constraint,
+            columns,
+        } => Cardinality::M2O {
+            constraint: constraint.clone(),
+            columns: rename_pairs(columns),
+        },
+        Cardinality::O2O {
+            constraint,
+            columns,
+            is_parent,
+        } => Cardinality::O2O {
+            constraint: constraint.clone(),
+            columns: rename_pairs(columns),
+            is_parent: *is_parent,
+        },
+        // Only the outer ends move: the junction keeps its own column names,
+        // since the view stands in for a side of the join and not for the
+        // table doing the joining.
+        Cardinality::M2M(junction) => {
+            let mut junction = junction.clone();
+            if let Some(names) = near {
+                for (i, (source, _)) in junction.source_columns.iter_mut().enumerate() {
+                    if let Some(name) = names.get(i) {
+                        *source = name.clone();
+                    }
+                }
+            }
+            if let Some(names) = far {
+                for (i, (_, target)) in junction.target_columns.iter_mut().enumerate() {
+                    if let Some(name) = names.get(i) {
+                        *target = name.clone();
+                    }
+                }
+            }
+            Cardinality::M2M(junction)
+        }
     }
 }
 

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -272,6 +272,22 @@ impl SchemaCache {
         }
     }
 
+    /// The exposed function whose name is closest to one that does not exist.
+    ///
+    /// Only when the name itself is wrong: an existing name whose arguments do
+    /// not match is a different mistake, and the overloads answer it better.
+    pub fn similar_routine(&self, qi: &QualifiedIdentifier) -> Option<String> {
+        const MIN_SIMILARITY: f64 = 0.75;
+
+        self.routines
+            .keys()
+            .filter(|candidate| candidate.schema == qi.schema)
+            .map(|candidate| (similarity(&candidate.name, &qi.name), candidate))
+            .filter(|(score, _)| *score >= MIN_SIMILARITY)
+            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            .map(|(_, candidate)| candidate.to_string())
+    }
+
     /// Find a relationship between two tables by name.
     ///
     /// `hint` is the `!hint` of `person_detail!message_sender_fkey(name)`,
@@ -399,7 +415,7 @@ impl SchemaCache {
 ///
 /// Edit distance over the longer of the two, which is enough to tell a typo
 /// from a different word.
-fn similarity(a: &str, b: &str) -> f64 {
+pub(crate) fn similarity(a: &str, b: &str) -> f64 {
     let longest = a.chars().count().max(b.chars().count());
     if longest == 0 {
         return 1.0;

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -8,7 +8,9 @@ mod relationship;
 mod routine;
 mod table;
 
-pub use relationship::{Cardinality, Junction, Relationship, RelationshipsMap};
+pub use relationship::{
+    Cardinality, Junction, MediaHandler, MediaHandlerMap, Relationship, RelationshipsMap,
+};
 pub use routine::{FuncVolatility, RetType, Routine, RoutineMap, RoutineParam};
 pub use table::{Column, ColumnMap, Table, TablesMap};
 
@@ -32,6 +34,8 @@ pub struct SchemaCache {
     pub timezones: HashSet<String>,
     /// PostgreSQL version.
     pub pg_version: i32,
+    /// User-defined renderers for media types, by (schema, media type).
+    pub media_handlers: MediaHandlerMap,
 }
 
 impl SchemaCache {
@@ -59,12 +63,16 @@ impl SchemaCache {
         let timezones = queries::load_timezones(pool).await?;
         info!("Loaded {} timezones", timezones.len());
 
+        let media_handlers = queries::load_media_handlers(pool, schemas).await?;
+        info!("Loaded {} media type handlers", media_handlers.len());
+
         Ok(Self {
             tables,
             relationships,
             routines,
             timezones,
             pg_version,
+            media_handlers,
         })
     }
 
@@ -107,6 +115,25 @@ impl SchemaCache {
             self.routines.len(),
             self.pg_version
         )
+    }
+
+    /// Find a user-defined renderer for a media type on a given table.
+    ///
+    /// A handler declared for the table itself wins over one taking
+    /// `anyelement`, which is the schema-wide fallback.
+    pub fn media_handler(
+        &self,
+        schema: &str,
+        media_type: &str,
+        table: &QualifiedIdentifier,
+    ) -> Option<&MediaHandler> {
+        let candidates = self
+            .media_handlers
+            .get(&(schema.to_string(), media_type.to_string()))?;
+        candidates
+            .iter()
+            .find(|h| h.table.as_ref() == Some(table))
+            .or_else(|| candidates.iter().find(|h| h.table.is_none()))
     }
 
     /// Find a relationship between two tables by name.

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -197,11 +197,19 @@ impl SchemaCache {
     /// path it was rendered against, so both spellings are tried -- and an
     /// unqualified one is looked for in the function's own schema.
     pub fn routine_returned_table(&self, qi: &QualifiedIdentifier) -> Option<&Table> {
-        let routine = self.get_routines(qi)?.first()?;
+        self.returned_table(self.get_routines(qi)?.first()?)
+    }
+
+    /// The same, for a routine already chosen.
+    ///
+    /// A name may carry several signatures returning different things, so
+    /// which overload was selected decides which table the result is shaped
+    /// by -- and only the caller knows that.
+    pub fn returned_table(&self, routine: &Routine) -> Option<&Table> {
         let type_name = routine.return_type.type_name()?;
         let candidate = match type_name.split_once('.') {
             Some((schema, name)) => QualifiedIdentifier::new(schema, name),
-            None => QualifiedIdentifier::new(&qi.schema, type_name),
+            None => QualifiedIdentifier::new(&routine.schema, type_name),
         };
         self.get_table(&candidate)
     }

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -129,6 +129,12 @@ impl SchemaCache {
         substitute_hidden_junctions(&tables, &view_columns, &mut relationships);
         add_view_relationships(&tables, &view_columns, &mut relationships);
 
+        // A view over a junction is a junction. It has no key of its own, so
+        // this runs only once the view's own relationships exist -- which is
+        // why the pass is here and not with the first one.
+        let view_keys = view_primary_keys(&primary_keys, &view_columns);
+        add_junction_relationships(&view_keys, &mut relationships);
+
         let media_handlers = queries::load_media_handlers(pool, schemas).await?;
         info!("Loaded {} media type handlers", media_handlers.len());
 
@@ -980,6 +986,57 @@ fn rename_cardinality(
             Cardinality::M2M(junction)
         }
     }
+}
+
+/// The key a view inherits from the table it selects from.
+///
+/// A view over a junction is a junction: `main_jobs` selects the columns of
+/// `jobs` that make it one, and PostgREST embeds `sites` through it and
+/// through `jobs` alike -- reporting both as candidates when the two cannot be
+/// told apart. A view has no key of its own, so the base table's is mapped
+/// through the names the view gives those columns.
+///
+/// Only where the view exposes every one of them: a key missing a column is
+/// not that key, and a junction is exactly the relation whose key *is* the
+/// pairing.
+fn view_primary_keys(
+    primary_keys: &std::collections::HashMap<QualifiedIdentifier, Vec<String>>,
+    view_columns: &[queries::ViewColumn],
+) -> std::collections::HashMap<QualifiedIdentifier, Vec<String>> {
+    use std::collections::HashMap;
+
+    // view -> base table -> base column -> the name the view gives it
+    let mut by_view: HashMap<
+        &QualifiedIdentifier,
+        HashMap<&QualifiedIdentifier, HashMap<&str, &str>>,
+    > = HashMap::new();
+    for column in view_columns {
+        by_view
+            .entry(&column.view)
+            .or_default()
+            .entry(&column.base)
+            .or_default()
+            .entry(column.base_column.as_str())
+            .or_insert(column.view_column.as_str());
+    }
+
+    let mut keys = HashMap::new();
+    for (view, bases) in by_view {
+        for (base, columns) in bases {
+            let Some(key) = primary_keys.get(base).filter(|key| !key.is_empty()) else {
+                continue;
+            };
+            let mapped: Option<Vec<String>> = key
+                .iter()
+                .map(|column| columns.get(column.as_str()).map(|name| name.to_string()))
+                .collect();
+            if let Some(mapped) = mapped {
+                keys.insert(view.clone(), mapped);
+            }
+        }
+    }
+
+    keys
 }
 
 /// Derive many-to-many relationships from junction tables.

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -1004,23 +1004,14 @@ fn add_junction_relationships(
             continue;
         };
 
-        // The single-column keys out of the junction.
-        //
-        // This is not the right rule. `touched_files` joins
-        // `files(project_id, filename)` to `users_tasks(user_id, task_id)` and
-        // is as much a junction as any other; PostgREST embeds through both it
-        // and `car_models_car_dealers`, and this answers "no relationship" for
-        // a relationship that is plainly there. The primary-key test below is
-        // what actually separates a junction from a table that merely
-        // references two others, and it does not need this.
-        //
-        // It stays because the embed layer cannot yet express the join it
-        // would produce: `EmbedPlan` carries one `local_column` and one
-        // `foreign_column`, `EmbedJunction` one column per side, and
-        // `parent_keys` matches children to parents on a single scalar. Deriving
-        // the relationship without widening those would join a composite
-        // junction on the first column of each key and return rows that are
-        // wrong rather than absent -- and be much harder to notice.
+        // The keys out of the junction, however many columns each is written
+        // over. Requiring one column apiece looked like what separates a
+        // junction from a table that merely references two others, but it is
+        // not: `touched_files` joins `files(project_id, filename)` to
+        // `users_tasks(user_id, task_id)` and is as much a junction as any
+        // other. What separates them is the primary-key test below, which this
+        // duplicated and then over-applied -- so a composite junction was
+        // answered "no relationship" for a relationship that is plainly there.
         let outgoing: Vec<(&Relationship, Vec<(String, String)>)> = rels
             .iter()
             .filter(|r| matches!(r, Relationship::ForeignKey { table, .. } if table == junction_qi))
@@ -1028,9 +1019,9 @@ fn add_junction_relationships(
             .filter_map(|r| {
                 let mut columns = r.join_columns();
                 columns.dedup();
-                match columns.len() {
-                    1 => Some((r, columns)),
-                    _ => None,
+                match columns.is_empty() {
+                    true => None,
+                    false => Some((r, columns)),
                 }
             })
             .collect();

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -232,19 +232,43 @@ impl SchemaCache {
     ///
     /// A handler declared for the table itself wins over one taking
     /// `anyelement`, which is the schema-wide fallback.
-    pub fn media_handler(
-        &self,
+    /// A schema may also declare a handler for `*/*`, which renders whatever
+    /// was asked for. What comes back is the handler and the media type the
+    /// response should be labelled with -- not always the one requested, since
+    /// `*/*` is not a type a response can claim to be. PostgREST resolves it
+    /// to `application/octet-stream`, which is what a body of unnamed bytes
+    /// is, and this follows it.
+    /// A handler declared for one table renders that table as it is, so it
+    /// only applies to a request that asked for the table as it is:
+    /// `?select=id` is a different shape from the one the handler was written
+    /// against, and running it over that shape produces either nonsense or an
+    /// error. PostgREST guards both table-specific lookups on the selection
+    /// being the default one, and `default_select` is that guard.
+    pub fn media_handler<'a>(
+        &'a self,
         schema: &str,
-        media_type: &str,
+        media_type: &'a str,
         table: &QualifiedIdentifier,
-    ) -> Option<&MediaHandler> {
-        let candidates = self
-            .media_handlers
-            .get(&(schema.to_string(), media_type.to_string()))?;
-        candidates
-            .iter()
-            .find(|h| h.table.as_ref() == Some(table))
-            .or_else(|| candidates.iter().find(|h| h.table.is_none()))
+        default_select: bool,
+    ) -> Option<(&'a MediaHandler, &'a str)> {
+        let named = |media: &str| {
+            let candidates = self
+                .media_handlers
+                .get(&(schema.to_string(), media.to_string()))?;
+            candidates
+                .iter()
+                .find(|h| default_select && h.table.as_ref() == Some(table))
+                .or_else(|| candidates.iter().find(|h| h.table.is_none()))
+        };
+
+        match named(media_type) {
+            Some(handler) => Some((handler, media_type)),
+            // `*/*` is declared on a table, so it is a table lookup too.
+            None if default_select => {
+                named("*/*").map(|handler| (handler, "application/octet-stream"))
+            }
+            None => None,
+        }
     }
 
     /// The error to report when no relationship connects two resources.

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -206,6 +206,12 @@ impl SchemaCache {
     /// which overload was selected decides which table the result is shaped
     /// by -- and only the caller knows that.
     pub fn returned_table(&self, routine: &Routine) -> Option<&Table> {
+        // Only a row type names a table. Without this, a function returning
+        // `xml` is shaped by whatever relation happens to be called `xml` --
+        // and the fixtures have one, so this is not hypothetical.
+        if !routine.returns_composite {
+            return None;
+        }
         let type_name = routine.return_type.type_name()?;
         let candidate = match type_name.split_once('.') {
             Some((schema, name)) => QualifiedIdentifier::new(schema, name),

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -17,7 +17,7 @@ pub use table::{Column, ColumnMap, ComputedColumn, Table, TablesMap};
 use crate::api_request::QualifiedIdentifier;
 use crate::error::{Error, Result};
 use sqlx::PgPool;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::info;
 
@@ -429,6 +429,91 @@ pub(crate) fn similarity(a: &str, b: &str) -> f64 {
         return 1.0;
     }
     1.0 - edit_distance(a, b) as f64 / longest as f64
+}
+
+/// The closest of `candidates` to `query`, or `None` if none is close enough.
+///
+/// Scored the way PostgREST scores its hints: cosine similarity over the
+/// character n-grams of both strings, three at a time and falling back to two
+/// where three finds nothing, with the ends marked so that a shared prefix
+/// counts for something. A Levenshtein ratio, which is the obvious thing to
+/// reach for, answers differently on the cases that matter -- it calls
+/// `(any_arg)` and `(name)` a third alike, because they are both short, where
+/// sharing no letter sequence at all is what a client needs to be told.
+///
+/// The floor applies to the similarity; among what clears it, the nearest by
+/// edit distance wins.
+pub(crate) fn closest<'a>(
+    candidates: impl IntoIterator<Item = &'a str> + Clone,
+    query: &str,
+    min_score: f64,
+) -> Option<&'a str> {
+    for size in [3usize, 2] {
+        let asked = grams(query, size);
+        let mut fitting: Vec<&str> = candidates
+            .clone()
+            .into_iter()
+            .filter(|candidate| cosine(&asked, &grams(candidate, size)) >= min_score)
+            .collect();
+
+        // Ranked by edit distance only among those the similarity admitted,
+        // which is why a short unrelated name never surfaces: it never got
+        // this far.
+        fitting.sort_by(|a, b| {
+            similarity(&normalize(b), &normalize(query))
+                .total_cmp(&similarity(&normalize(a), &normalize(query)))
+        });
+        if let Some(best) = fitting.first() {
+            return Some(best);
+        }
+    }
+    None
+}
+
+/// A string reduced to what a comparison should see.
+///
+/// Punctuation is dropped, so `(name)` and `name` are the same word; commas
+/// and spaces are kept, because a parameter list is compared as the list it
+/// is written as.
+fn normalize(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .filter(|c| c.is_alphanumeric() || *c == ',' || *c == ' ')
+        .collect()
+}
+
+/// How many times each run of `size` characters occurs, ends marked.
+fn grams(value: &str, size: usize) -> HashMap<String, usize> {
+    let mut padded: Vec<char> = std::iter::once('-')
+        .chain(normalize(value).chars())
+        .chain(std::iter::once('-'))
+        .collect();
+    while padded.len() < size {
+        padded.push('-');
+    }
+
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for window in padded.windows(size) {
+        *counts.entry(window.iter().collect()).or_insert(0) += 1;
+    }
+    counts
+}
+
+/// The cosine of the angle between two gram counts.
+fn cosine(a: &HashMap<String, usize>, b: &HashMap<String, usize>) -> f64 {
+    let magnitude = |counts: &HashMap<String, usize>| -> f64 {
+        counts.values().map(|n| (n * n) as f64).sum::<f64>().sqrt()
+    };
+    let (a_size, b_size) = (magnitude(a), magnitude(b));
+    if a_size == 0.0 || b_size == 0.0 {
+        return 0.0;
+    }
+    let shared: f64 = a
+        .iter()
+        .map(|(gram, count)| (count * b.get(gram).copied().unwrap_or(0)) as f64)
+        .sum();
+    shared / (a_size * b_size)
 }
 
 /// Levenshtein distance, computed one row at a time.

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -116,11 +116,25 @@ impl SchemaCache {
         to_name: &str,
         schema: &str,
     ) -> Option<&Relationship> {
-        self.get_relationships(from, schema)?
+        let candidates = self.get_relationships(from, schema)?;
+
+        // An embedding may be named three ways, and they are tried in the
+        // order of how specifically they identify one relationship.
+        //
+        // The target table's name is the usual spelling, but it is ambiguous
+        // as soon as two foreign keys point at the same table. The foreign key
+        // constraint names exactly one relationship, and so does the column
+        // that joins them -- `/messages?select=*,sender(*)` embeds through the
+        // `sender` column, and `/projects?select=*,client(*)` through the
+        // constraint called `client`.
+        candidates
             .iter()
-            .find(|r| match r {
-                Relationship::ForeignKey { foreign_table, .. } => foreign_table.name == to_name,
-                Relationship::Computed { foreign_table, .. } => foreign_table.name == to_name,
+            .find(|r| r.foreign_table().name == to_name)
+            .or_else(|| candidates.iter().find(|r| r.constraint_name() == to_name))
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .find(|r| r.join_columns().iter().any(|(local, _)| local == to_name))
             })
     }
 }

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -447,8 +447,11 @@ pub(crate) fn similarity(a: &str, b: &str) -> f64 {
 /// `(any_arg)` and `(name)` a third alike, because they are both short, where
 /// sharing no letter sequence at all is what a client needs to be told.
 ///
-/// The floor applies to the similarity; among what clears it, the nearest by
-/// edit distance wins.
+/// The floor is strict, and applies to the similarity; among what clears it,
+/// the nearest by edit distance wins. A floor of zero therefore means "shares
+/// any sequence of characters at all", which is a real filter -- two strings
+/// with no run of two characters in common score nothing and never reach the
+/// ranking.
 pub(crate) fn closest<'a>(
     candidates: impl IntoIterator<Item = &'a str> + Clone,
     query: &str,
@@ -459,7 +462,7 @@ pub(crate) fn closest<'a>(
         let mut fitting: Vec<&str> = candidates
             .clone()
             .into_iter()
-            .filter(|candidate| cosine(&asked, &grams(candidate, size)) >= min_score)
+            .filter(|candidate| cosine(&asked, &grams(candidate, size)) > min_score)
             .collect();
 
         // Ranked by edit distance only among those the similarity admitted,

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -936,15 +936,13 @@ fn add_junction_relationships(
             })
             .collect();
 
-        let mut pk: Vec<&str> = junction_pk.iter().map(String::as_str).collect();
-        pk.sort_unstable();
-        if pk.len() != 2 {
-            continue;
-        }
+        let pk: Vec<&str> = junction_pk.iter().map(String::as_str).collect();
 
-        // The pair whose columns are exactly the primary key is the one that
-        // makes this a junction. Requiring the whole key is what separates a
-        // junction from a table that merely references two others.
+        // The pair whose columns are part of the primary key is what makes
+        // this a junction: keying on both of them is what says a row of it is
+        // one pairing. A junction may carry more in its key than the pair --
+        // `group_yard` keys on `(id, group_id, yard_id)` -- and requiring the
+        // key to be exactly the two columns missed those.
         for near in 0..outgoing.len() {
             for far in 0..outgoing.len() {
                 if near == far {
@@ -955,9 +953,8 @@ fn add_junction_relationships(
                 if near_rel.foreign_table() == far_rel.foreign_table() {
                     continue;
                 }
-                let mut covered = vec![near_local.as_str(), far_local.as_str()];
-                covered.sort_unstable();
-                if covered != pk {
+                let covered = [near_local.as_str(), far_local.as_str()];
+                if !covered.iter().all(|column| pk.contains(column)) {
                     continue;
                 }
 

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -117,6 +117,25 @@ impl SchemaCache {
         )
     }
 
+    /// The table whose rows a function returns, if it returns rows of one.
+    ///
+    /// This is what makes a function behave like a table for everything after
+    /// the call: its result can be selected from, filtered, ordered, paged and
+    /// embedded on, all of which need a table to resolve columns against.
+    ///
+    /// `format_type` may or may not qualify the name, depending on the search
+    /// path it was rendered against, so both spellings are tried -- and an
+    /// unqualified one is looked for in the function's own schema.
+    pub fn routine_returned_table(&self, qi: &QualifiedIdentifier) -> Option<&Table> {
+        let routine = self.get_routines(qi)?.first()?;
+        let type_name = routine.return_type.type_name()?;
+        let candidate = match type_name.split_once('.') {
+            Some((schema, name)) => QualifiedIdentifier::new(schema, name),
+            None => QualifiedIdentifier::new(&qi.schema, type_name),
+        };
+        self.get_table(&candidate)
+    }
+
     /// Find a user-defined renderer for a media type on a given table.
     ///
     /// A handler declared for the table itself wins over one taking

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -420,6 +420,13 @@ impl SchemaCache {
                     .iter()
                     .map(|r| (r.cardinality_name().to_string(), r.describe()))
                     .collect(),
+                // What the client would have to write instead. The details
+                // say which relationships were found; this says how to ask for
+                // one of them, which is the part it can act on.
+                disambiguated: matches
+                    .iter()
+                    .map(|r| format!("{}!{}", to_name, r.disambiguator()))
+                    .collect(),
             }),
         }
     }

--- a/crates/postrust-core/src/schema_cache/mod.rs
+++ b/crates/postrust-core/src/schema_cache/mod.rs
@@ -46,7 +46,28 @@ pub struct SchemaCache {
 impl SchemaCache {
     /// Load schema cache from the database.
     pub async fn load(pool: &PgPool, schemas: &[String]) -> Result<Self> {
+        Self::load_with_search_path(pool, schemas, &[]).await
+    }
+
+    /// Load the cache, resolving functions along `extra_search_path` as well.
+    ///
+    /// A computed column's function is reached the way the database reaches
+    /// it, which is along the search path -- so it may live in a schema the
+    /// API does not expose. The table it reads must still be exposed.
+    pub async fn load_with_search_path(
+        pool: &PgPool,
+        schemas: &[String],
+        extra_search_path: &[String],
+    ) -> Result<Self> {
         info!("Loading schema cache for schemas: {:?}", schemas);
+
+        let function_schemas: Vec<String> = schemas
+            .iter()
+            .chain(extra_search_path)
+            .cloned()
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
 
         // Get PostgreSQL version
         let pg_version = queries::get_pg_version(pool).await?;
@@ -66,7 +87,7 @@ impl SchemaCache {
         // to, so resolving a field name has one place to look.
         let mut tables = tables;
         for (table, name, function, data_type) in
-            queries::load_computed_columns(pool, schemas).await?
+            queries::load_computed_columns(pool, schemas, &function_schemas).await?
         {
             if let Some(table) = tables.get_mut(&table) {
                 table.computed_columns.insert(
@@ -146,14 +167,29 @@ impl SchemaCache {
     /// Below it the "suggestion" would be noise, and would also say more about
     /// the schema than the client asked.
     fn similar_table(&self, qi: &QualifiedIdentifier) -> Option<String> {
-        const MIN_SIMILARITY: f64 = 0.75;
+        const MIN_SIMILARITY: f64 = 0.5;
+
+        // Scored by shared character n-grams rather than by edit distance.
+        // A Levenshtein ratio cannot tell `items` from `items3` as the table
+        // `itemsx` was meant to be -- both are one edit away, so both score
+        // 0.833 and the winner is whichever the map happened to yield last.
+        // Counting 3-grams separates them, because it notices that one
+        // candidate is the query's own length and the other is not: `items`
+        // scores 0.73 against `itemsx` and `items3` scores 0.67.
+        let asked = grams(&qi.name, 3);
 
         self.tables
             .keys()
             .filter(|candidate| candidate.schema == qi.schema)
-            .map(|candidate| (similarity(&candidate.name, &qi.name), candidate))
+            .map(|candidate| (cosine(&asked, &grams(&candidate.name, 3)), candidate))
             .filter(|(score, _)| *score >= MIN_SIMILARITY)
-            .max_by(|(a, _), (b, _)| a.total_cmp(b))
+            // Ties go to the shorter name, and then to the earlier one, so
+            // that the suggestion does not depend on iteration order.
+            .max_by(|(a, left), (b, right)| {
+                a.total_cmp(b)
+                    .then_with(|| right.name.len().cmp(&left.name.len()))
+                    .then_with(|| right.name.cmp(&left.name))
+            })
             .map(|(_, candidate)| candidate.to_string())
     }
 
@@ -288,18 +324,27 @@ impl SchemaCache {
         // a whole word -- `car_model_sales_202101` for `car_model_sales`.
         const MIN_SIMILARITY: f64 = 0.4;
 
-        let suggestion = self
+        let related: Vec<&str> = self
             .get_relationships(from, schema)
             .into_iter()
             .flatten()
             .map(|rel| rel.foreign_table().name.as_str())
-            // A relationship of exactly that name exists, so the name is not
-            // what went wrong -- the hint is.
-            .filter(|name| *name != to_name)
-            .map(|name| (similarity(name, to_name), name))
-            .filter(|(score, _)| *score >= MIN_SIMILARITY)
-            .max_by(|(a, _), (b, _)| a.total_cmp(b))
-            .map(|(_, name)| name.to_string());
+            .collect();
+
+        // A relationship of exactly that name exists, so the name is not what
+        // went wrong -- the hint is, and there is nothing to suggest. Dropping
+        // only the exact match and then offering the next-nearest name told a
+        // client that asked for `person!space` that it had perhaps meant
+        // `person_detail`, when what it had meant was `person` all along.
+        let suggestion = match related.contains(&to_name) {
+            true => None,
+            false => related
+                .iter()
+                .map(|name| (similarity(name, to_name), *name))
+                .filter(|(score, _)| *score >= MIN_SIMILARITY)
+                .max_by(|(a, _), (b, _)| a.total_cmp(b))
+                .map(|(_, name)| name.to_string()),
+        };
 
         Error::RelationshipNotFound {
             origin: from.name.clone(),
@@ -959,10 +1004,24 @@ fn add_junction_relationships(
             continue;
         };
 
-        // The single-column keys out of the junction. A junction joins two
-        // tables by one column each; a composite key to somewhere else is a
-        // different relationship that happens to share the table.
-        let outgoing: Vec<(&Relationship, (String, String))> = rels
+        // The single-column keys out of the junction.
+        //
+        // This is not the right rule. `touched_files` joins
+        // `files(project_id, filename)` to `users_tasks(user_id, task_id)` and
+        // is as much a junction as any other; PostgREST embeds through both it
+        // and `car_models_car_dealers`, and this answers "no relationship" for
+        // a relationship that is plainly there. The primary-key test below is
+        // what actually separates a junction from a table that merely
+        // references two others, and it does not need this.
+        //
+        // It stays because the embed layer cannot yet express the join it
+        // would produce: `EmbedPlan` carries one `local_column` and one
+        // `foreign_column`, `EmbedJunction` one column per side, and
+        // `parent_keys` matches children to parents on a single scalar. Deriving
+        // the relationship without widening those would join a composite
+        // junction on the first column of each key and return rows that are
+        // wrong rather than absent -- and be much harder to notice.
+        let outgoing: Vec<(&Relationship, Vec<(String, String)>)> = rels
             .iter()
             .filter(|r| matches!(r, Relationship::ForeignKey { table, .. } if table == junction_qi))
             .filter(|r| r.is_to_one())
@@ -970,7 +1029,7 @@ fn add_junction_relationships(
                 let mut columns = r.join_columns();
                 columns.dedup();
                 match columns.len() {
-                    1 => Some((r, columns.remove(0))),
+                    1 => Some((r, columns)),
                     _ => None,
                 }
             })
@@ -988,13 +1047,19 @@ fn add_junction_relationships(
                 if near == far {
                     continue;
                 }
-                let (near_rel, (near_local, near_foreign)) = &outgoing[near];
-                let (far_rel, (far_local, far_foreign)) = &outgoing[far];
+                let (near_rel, near_columns) = &outgoing[near];
+                let (far_rel, far_columns) = &outgoing[far];
                 if near_rel.foreign_table() == far_rel.foreign_table() {
                     continue;
                 }
-                let covered = [near_local.as_str(), far_local.as_str()];
-                if !covered.iter().all(|column| pk.contains(column)) {
+                // Every column either key is written over has to be part of
+                // the junction's own key: that is what says a row of it is one
+                // pairing and nothing more.
+                if !near_columns
+                    .iter()
+                    .chain(far_columns)
+                    .all(|(local, _)| pk.contains(&local.as_str()))
+                {
                     continue;
                 }
 
@@ -1011,9 +1076,17 @@ fn add_junction_relationships(
                             table: junction_qi.clone(),
                             constraint1: near_rel.constraint_name().to_string(),
                             constraint2: far_rel.constraint_name().to_string(),
-                            // Source to junction, then junction to target.
-                            source_columns: vec![(near_foreign.clone(), near_local.clone())],
-                            target_columns: vec![(far_local.clone(), far_foreign.clone())],
+                            // Source to junction, then junction to target,
+                            // each in the order the constraint declares so a
+                            // composite key joins column for column.
+                            source_columns: near_columns
+                                .iter()
+                                .map(|(local, foreign)| (foreign.clone(), local.clone()))
+                                .collect(),
+                            target_columns: far_columns
+                                .iter()
+                                .map(|(local, foreign)| (local.clone(), foreign.clone()))
+                                .collect(),
                         }),
                         table_is_view: false,
                         foreign_table_is_view: false,

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -496,6 +496,10 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
             pg_catalog.obj_description(p.oid) as description,
             p.provolatile::text as volatility,
             p.provariadic <> 0 as has_variadic,
+            EXISTS (
+                SELECT 1 FROM unnest(COALESCE(p.proargmodes, '{}'::"char"[])) AS mode
+                 WHERE mode IN ('o', 't', 'b')
+            ) as has_out_params,
             p.prokind = 'p' as is_procedure,
             pg_get_function_identity_arguments(p.oid) as args,
             -- Input parameters, in declaration order. Built from the catalog
@@ -558,8 +562,14 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
         // is pseudo too but renders as a function-named null column, so it
         // counts as non-composite.
         let ret_typtype: Option<String> = row.get("ret_typtype");
+        // A named row type always expands. `record` expands only when the
+        // function declares its columns as `OUT` parameters or a `RETURNS
+        // TABLE` -- a bare `RETURNS record` has none, and PostgreSQL refuses
+        // to put one in a `FROM` clause without being told what they are.
+        let has_out_params: bool = row.get("has_out_params");
         let returns_composite = !matches!(return_type, RetType::Void)
-            && matches!(ret_typtype.as_deref(), Some("c") | Some("p"));
+            && (ret_typtype.as_deref() == Some("c")
+                || (ret_typtype.as_deref() == Some("p") && has_out_params));
 
         let routine = Routine {
             schema,

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -557,13 +557,39 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
                 )
                 FROM generate_series(1, p.pronargs) AS i
             ), '[]'::json) as params,
+            -- The columns the function's rows have, where it names them:
+            -- `RETURNS TABLE(a text, b colour)` declares them as OUT
+            -- parameters, and they are the only account of the result's shape
+            -- -- there is no table to read it off. `proallargtypes` is a
+            -- plain 1-indexed array and lines up with `proargnames`.
+            COALESCE((
+                SELECT json_agg(
+                    json_build_object(
+                        'name', COALESCE(p.proargnames[i], ''),
+                        'type', pg_catalog.format_type(p.proallargtypes[i], NULL)
+                    ) ORDER BY i
+                )
+                FROM generate_series(
+                    1, COALESCE(array_length(p.proallargtypes, 1), 0)) AS i
+                WHERE p.proargmodes[i] IN ('o', 't', 'b')
+            ), '[]'::json) as out_params,
             CASE
                 WHEN p.proretset THEN 'SETOF ' || pg_catalog.format_type(rt.base_type, NULL)
                 ELSE pg_catalog.format_type(rt.base_type, NULL)
             END as return_type,
             p.proretset as returns_set,
             (SELECT t.typtype::text FROM pg_catalog.pg_type t WHERE t.oid = rt.base_type)
-                as ret_typtype
+                as ret_typtype,
+            -- A domain named after a media type says the value already is
+            -- that media type: `returns "image/png"` is a PNG, not a row to
+            -- serialise. Only a single value can be one, so a set-returning
+            -- function is not it.
+            (SELECT lower(dt.typname) FROM pg_catalog.pg_type dt
+              WHERE dt.oid = p.prorettype
+                AND dt.typbasetype <> 0
+                AND NOT p.proretset
+                AND (dt.typname ~ '^[A-Za-z0-9.-]+/[A-Za-z0-9.+-]+$'
+                     OR dt.typname = '*/*')) as media_type
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
         JOIN resolved rt ON rt.oid = p.prorettype
@@ -640,6 +666,12 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
             isolation_level: None,
             settings: vec![],
             is_procedure: row.get("is_procedure"),
+            media_type: row.get("media_type"),
+            output_columns: parse_routine_params(row.get("out_params"))
+                .into_iter()
+                .filter(|param| !param.name.is_empty())
+                .map(|param| (param.name, param.param_type))
+                .collect(),
         };
 
         routines.entry(qi).or_default().push(routine);

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -469,7 +469,16 @@ fn parse_routine_params(value: serde_json::Value) -> Vec<RoutineParam> {
                     .and_then(|n| n.as_str())
                     .unwrap_or_default()
                     .to_string(),
-                type_max_length: param_type.clone(),
+                // A parameter declared `char(4)` is stored as bare
+                // `character`, whose length is 1, so casting an argument to
+                // the declared type truncates it. PostgreSQL does not enforce
+                // a length on a function parameter at all, so the unbounded
+                // spelling is the honest one to cast to.
+                type_max_length: item
+                    .get("cast_type")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or(&param_type)
+                    .to_string(),
                 param_type,
                 required: item
                     .get("required")
@@ -490,6 +499,22 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
 
     let rows = sqlx::query(
         r#"
+        -- What a type is once every domain over it is stripped away.
+        --
+        -- `RETURNS SETOF projects_domain` returns rows of `projects`, and a
+        -- domain is transparent to everything that matters here: whether the
+        -- result is composite, and which table's columns it has. Reading the
+        -- declared type alone finds a type name that names no table.
+        WITH RECURSIVE base_types AS (
+            SELECT oid, typbasetype, oid AS base_type FROM pg_catalog.pg_type
+            UNION
+            SELECT t.oid, b.typbasetype, b.oid AS base_type
+              FROM base_types t
+              JOIN pg_catalog.pg_type b ON b.oid = t.typbasetype
+        ),
+        resolved AS (
+            SELECT oid, base_type FROM base_types WHERE typbasetype = 0
+        )
         SELECT
             n.nspname as schema,
             p.proname as name,
@@ -514,6 +539,18 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
                     json_build_object(
                         'name', COALESCE(p.proargnames[i], ''),
                         'type', pg_catalog.format_type(p.proargtypes[i - 1], NULL),
+                        -- What an argument is cast to. `character` and `bit`
+                        -- name themselves without a length, and casting to
+                        -- either truncates to one character; a parameter's
+                        -- length is not enforced anyway, so the varying
+                        -- spelling is what the value should reach.
+                        'cast_type', CASE p.proargtypes[i - 1]
+                            WHEN 'character'::regtype   THEN 'character varying'
+                            WHEN 'character[]'::regtype THEN 'character varying[]'
+                            WHEN 'bit'::regtype         THEN 'bit varying'
+                            WHEN 'bit[]'::regtype       THEN 'bit varying[]'
+                            ELSE pg_catalog.format_type(p.proargtypes[i - 1], NULL)
+                        END,
                         'required', i <= (p.pronargs - p.pronargdefaults),
                         'variadic', p.provariadic <> 0 AND i = p.pronargs
                     ) ORDER BY i
@@ -521,16 +558,36 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
                 FROM generate_series(1, p.pronargs) AS i
             ), '[]'::json) as params,
             CASE
-                WHEN p.proretset THEN 'SETOF ' || pg_catalog.format_type(p.prorettype, NULL)
-                ELSE pg_catalog.format_type(p.prorettype, NULL)
+                WHEN p.proretset THEN 'SETOF ' || pg_catalog.format_type(rt.base_type, NULL)
+                ELSE pg_catalog.format_type(rt.base_type, NULL)
             END as return_type,
             p.proretset as returns_set,
-            (SELECT t.typtype::text FROM pg_catalog.pg_type t WHERE t.oid = p.prorettype)
+            (SELECT t.typtype::text FROM pg_catalog.pg_type t WHERE t.oid = rt.base_type)
                 as ret_typtype
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
+        JOIN resolved rt ON rt.oid = p.prorettype
         WHERE n.nspname = ANY($1)
           AND p.prokind IN ('f', 'p')
+          -- A parameter with no name cannot be given an argument by name, so
+          -- a function that has one is not callable over the API at all --
+          -- and leaving it in the cache makes it a candidate that no request
+          -- can ever match, and a hint that sends the client nowhere.
+          --
+          -- The exception is the single unnamed parameter that takes the
+          -- whole request body, which is how a function is called with one
+          -- json, text, xml or bytea argument and no name for it.
+          AND (
+            (SELECT count(*) FROM generate_series(1, p.pronargs) AS i
+              WHERE COALESCE(p.proargnames[i], '') = '') = 0
+            OR (
+              p.pronargs = 1
+              AND COALESCE(p.proargnames[1], '') = ''
+              AND p.proargtypes[0] IN ('bytea'::regtype, 'json'::regtype,
+                                       'jsonb'::regtype, 'text'::regtype,
+                                       'xml'::regtype)
+            )
+          )
         ORDER BY n.nspname, p.proname
         "#,
     )
@@ -586,6 +643,26 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
         };
 
         routines.entry(qi).or_default().push(routine);
+    }
+
+    // Overloads of one name in a fixed order: fewest parameters first, then by
+    // the parameters themselves. Catalogue order is whatever the planner
+    // happened to return, and it decides which signature a client is offered
+    // first when a call cannot be told apart -- an answer that should not
+    // change between two servers reading the same schema.
+    for overloads in routines.values_mut() {
+        overloads.sort_by(|a, b| {
+            let key = |r: &Routine| {
+                (
+                    r.params.len(),
+                    r.params
+                        .iter()
+                        .map(|p| (p.name.clone(), p.param_type.clone()))
+                        .collect::<Vec<_>>(),
+                )
+            };
+            key(a).cmp(&key(b))
+        });
     }
 
     Ok(routines)

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -60,7 +60,8 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
                 WHERE tp.table_schema = t.table_schema
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'DELETE'
-            ) as deletable
+            ) as deletable,
+            COALESCE(k.is_partitioned, false) as is_partitioned
         FROM (
             -- `information_schema.tables` has no row for a materialized view,
             -- so one is added from the catalogue. Everything downstream keys
@@ -76,6 +77,12 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
               JOIN pg_namespace n ON n.oid = c.relnamespace
              WHERE c.relkind = 'm'
         ) t
+        LEFT JOIN LATERAL (
+            SELECT c.relkind = 'p' AS is_partitioned
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = t.table_schema AND c.relname = t.table_name
+        ) k ON true
         WHERE t.table_schema = ANY($1)
         ORDER BY t.table_schema, t.table_name
         "#,
@@ -98,6 +105,7 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
             name: name.clone(),
             description: row.get("description"),
             is_view: table_type == "VIEW",
+            is_partitioned: row.get("is_partitioned"),
             insertable: row.get("insertable"),
             updatable: row.get("updatable"),
             deletable: row.get("deletable"),

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -594,3 +594,69 @@ pub async fn load_media_handlers(pool: &PgPool, schemas: &[String]) -> Result<Me
 
     Ok(handlers)
 }
+
+/// Which base-table column each of a view's columns comes from.
+///
+/// A view has no foreign keys of its own, but it can still be embedded: the
+/// relationships of the tables it selects from apply to it, through whichever
+/// of their columns it carries.
+///
+/// The mapping is made by name. PostgreSQL records which base columns a view
+/// depends on, but not which of the view's own columns each one became -- that
+/// lives in the parsed rule tree. Matching by name covers a view that selects
+/// its columns through unchanged, and misses one that renames them, which is
+/// the honest limit of doing this without parsing the rule.
+pub async fn load_view_columns(
+    pool: &PgPool,
+    schemas: &[String],
+) -> Result<Vec<(QualifiedIdentifier, QualifiedIdentifier, String)>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT
+            vn.nspname AS view_schema,
+            v.relname  AS view_name,
+            tn.nspname AS base_schema,
+            t.relname  AS base_name,
+            va.attname AS column_name
+        FROM pg_depend d
+        JOIN pg_rewrite r    ON r.oid = d.objid AND r.rulename = '_RETURN'
+        JOIN pg_class v      ON v.oid = r.ev_class AND v.relkind = ANY (ARRAY['v','m'])
+        JOIN pg_namespace vn ON vn.oid = v.relnamespace
+        JOIN pg_class t      ON t.oid = d.refobjid
+                            AND t.relkind = ANY (ARRAY['r','v','m','p','f'])
+        JOIN pg_namespace tn ON tn.oid = t.relnamespace
+        JOIN pg_attribute ta ON ta.attrelid = t.oid
+                            AND ta.attnum = d.refobjsubid
+                            AND NOT ta.attisdropped
+        JOIN pg_attribute va ON va.attrelid = v.oid
+                            AND va.attname = ta.attname
+                            AND NOT va.attisdropped
+        WHERE d.classid = 'pg_rewrite'::regclass
+          AND d.refclassid = 'pg_class'::regclass
+          AND d.refobjsubid > 0
+          AND v.oid <> t.oid
+          AND vn.nspname = ANY($1)
+        "#,
+    )
+    .bind(schemas)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                QualifiedIdentifier::new(
+                    row.get::<String, _>("view_schema"),
+                    row.get::<String, _>("view_name"),
+                ),
+                QualifiedIdentifier::new(
+                    row.get::<String, _>("base_schema"),
+                    row.get::<String, _>("base_name"),
+                ),
+                row.get::<String, _>("column_name"),
+            )
+        })
+        .collect())
+}

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -137,6 +137,11 @@ async fn load_columns(
             c.is_nullable,
             c.data_type,
             c.udt_name,
+            -- A domain's own name. `information_schema` reports the type
+            -- underneath it in `data_type` and `udt_name`, so this is the only
+            -- column that says a value is a `color` rather than an integer --
+            -- and the domain is what a data representation is declared on.
+            c.domain_name,
             c.character_maximum_length,
             c.column_default,
             pg_catalog.col_description(
@@ -152,7 +157,7 @@ async fn load_columns(
         LEFT JOIN pg_enum e ON e.enumtypid = t.oid
         WHERE c.table_schema = $1 AND c.table_name = $2
         GROUP BY c.table_schema, c.table_name, c.column_name, c.ordinal_position, c.is_nullable,
-                 c.data_type, c.udt_name, c.character_maximum_length,
+                 c.data_type, c.udt_name, c.domain_name, c.character_maximum_length,
                  c.column_default, t.oid, e.enumtypid
         ORDER BY c.ordinal_position
         "#,
@@ -185,6 +190,7 @@ async fn load_columns(
             nullable: is_nullable == "YES",
             data_type,
             nominal_type: udt_name,
+            domain_type: row.get("domain_name"),
             max_len,
             default: row.get("column_default"),
             enum_values,
@@ -652,6 +658,7 @@ async fn load_catalog_columns(
             CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
             pg_catalog.format_type(a.atttypid, NULL) AS data_type,
             t.typname AS udt_name,
+            CASE WHEN t.typtype = 'd' THEN t.typname END AS domain_name,
             NULL::int AS character_maximum_length,
             pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS column_default,
             pg_catalog.col_description(c.oid, a.attnum) AS description,

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -660,3 +660,49 @@ pub async fn load_view_columns(
         })
         .collect())
 }
+
+/// Primary key columns for every table in the given schemas.
+///
+/// Junction detection needs the key of the table doing the joining, and that
+/// table may sit in a schema which is not exposed -- the junction behind two
+/// public views. Loading the key alone keeps it out of the API surface while
+/// still letting the relationship be derived.
+pub async fn load_primary_keys(
+    pool: &PgPool,
+    schemas: &[String],
+) -> Result<HashMap<QualifiedIdentifier, Vec<String>>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            n.nspname AS table_schema,
+            c.relname AS table_name,
+            (SELECT array_agg(a.attname ORDER BY k.ord)
+               FROM unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord)
+               JOIN pg_attribute a
+                 ON a.attrelid = c.oid AND a.attnum = k.attnum) AS pk_cols
+        FROM pg_index i
+        JOIN pg_class c      ON c.oid = i.indrelid
+        JOIN pg_namespace n  ON n.oid = c.relnamespace
+        WHERE i.indisprimary
+          AND n.nspname = ANY($1)
+        "#,
+    )
+    .bind(schemas)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let columns: Option<Vec<String>> = row.get("pk_cols");
+            Some((
+                QualifiedIdentifier::new(
+                    row.get::<String, _>("table_schema"),
+                    row.get::<String, _>("table_name"),
+                ),
+                columns?,
+            ))
+        })
+        .collect())
+}

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -43,23 +43,39 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
                   AND i.indisprimary),
                 ARRAY[]::text[]
             ) as pk_cols,
+            -- Being granted INSERT on a view does not make the view
+            -- insertable. A view is written through only where it is simple
+            -- enough for PostgreSQL to write through automatically, or where
+            -- an INSTEAD OF trigger says how -- `projects_view_without_triggers`
+            -- carries every grant and accepts nothing. Both halves have to
+            -- hold. A table has no row in `information_schema.views`, so the
+            -- grant is the whole answer there.
             EXISTS (
                 SELECT 1 FROM information_schema.table_privileges tp
                 WHERE tp.table_schema = t.table_schema
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'INSERT'
+            ) AND COALESCE(
+                v.is_insertable_into = 'YES' OR v.is_trigger_insertable_into = 'YES',
+                true
             ) as insertable,
             EXISTS (
                 SELECT 1 FROM information_schema.table_privileges tp
                 WHERE tp.table_schema = t.table_schema
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'UPDATE'
+            ) AND COALESCE(
+                v.is_updatable = 'YES' OR v.is_trigger_updatable = 'YES',
+                true
             ) as updatable,
             EXISTS (
                 SELECT 1 FROM information_schema.table_privileges tp
                 WHERE tp.table_schema = t.table_schema
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'DELETE'
+            ) AND COALESCE(
+                v.is_updatable = 'YES' OR v.is_trigger_deletable = 'YES',
+                true
             ) as deletable,
             COALESCE(k.is_partitioned, false) as is_partitioned
         FROM (
@@ -88,6 +104,8 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
               JOIN pg_namespace n ON n.oid = c.relnamespace
              WHERE n.nspname = t.table_schema AND c.relname = t.table_name
         ) k ON true
+        LEFT JOIN information_schema.views v
+               ON v.table_schema = t.table_schema AND v.table_name = t.table_name
         WHERE t.table_schema = ANY($1)
           -- A partition is reached through the table it partitions, not on its
           -- own. `information_schema.tables` lists every one of them, so a

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -82,12 +82,21 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
              WHERE c.relkind = 'm'
         ) t
         LEFT JOIN LATERAL (
-            SELECT c.relkind = 'p' AS is_partitioned
+            SELECT c.relkind = 'p' AS is_partitioned,
+                   c.relispartition AS is_partition
               FROM pg_class c
               JOIN pg_namespace n ON n.oid = c.relnamespace
              WHERE n.nspname = t.table_schema AND c.relname = t.table_name
         ) k ON true
         WHERE t.table_schema = ANY($1)
+          -- A partition is reached through the table it partitions, not on its
+          -- own. `information_schema.tables` lists every one of them, so a
+          -- schema with a year of monthly partitions exposed twelve endpoints
+          -- PostgREST does not have -- and a request naming one was answered
+          -- as though the table were real, which made a missing relationship
+          -- read as a missing column. The partitioned parent itself
+          -- (`relkind = 'p'`) is not a partition and stays.
+          AND NOT COALESCE(k.is_partition, false)
         ORDER BY t.table_schema, t.table_name
         "#,
     )
@@ -896,9 +905,17 @@ pub async fn load_representations(
 /// exposes that. Only single-argument functions returning a single value
 /// qualify -- one returning `setof` another table is a computed *relationship*,
 /// which is embedded rather than selected.
+/// `function_schemas` is where the function itself may live: the exposed
+/// schemas plus whatever `db-extra-search-path` adds. The table has to be
+/// exposed -- it is the thing being read -- but the function need not be, and
+/// PostgREST resolves it along the search path. `always_false(test.items)`
+/// lives in `public`, so requiring the function to be in an exposed schema
+/// left `?always_false=is.false` answered "column does not exist" for a field
+/// PostgREST reads as a column.
 pub async fn load_computed_columns(
     pool: &PgPool,
     schemas: &[String],
+    function_schemas: &[String],
 ) -> Result<Vec<(QualifiedIdentifier, String, QualifiedIdentifier, String)>> {
     let rows = sqlx::query(
         r#"
@@ -916,11 +933,12 @@ pub async fn load_computed_columns(
            AND p.prokind = 'f'
            AND p.prorettype <> 'pg_catalog.trigger'::pg_catalog.regtype
            AND t.relkind = ANY (ARRAY['r', 'v', 'm', 'p', 'f'])
-           AND fn.nspname = ANY($1)
+           AND fn.nspname = ANY($2)
            AND tn.nspname = ANY($1)
         "#,
     )
     .bind(schemas)
+    .bind(function_schemas)
     .fetch_all(pool)
     .await
     .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -593,7 +593,18 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
                 AND dt.typbasetype <> 0
                 AND NOT p.proretset
                 AND (dt.typname ~ '^[A-Za-z0-9.-]+/[A-Za-z0-9.+-]+$'
-                     OR dt.typname = '*/*')) as media_type
+                     OR dt.typname = '*/*')) as media_type,
+            -- What that domain is a domain *over*. A value whose type this
+            -- side does not recognise arrives as PostgreSQL's text rendering
+            -- of it, and a `bytea` renders as `\x` and hex -- which is a
+            -- description of the bytes, not the bytes. Knowing the base type
+            -- is what tells the two apart.
+            (SELECT lower(bt.typname) FROM pg_catalog.pg_type dt
+               JOIN pg_catalog.pg_type bt ON bt.oid = dt.typbasetype
+              WHERE dt.oid = p.prorettype
+                AND NOT p.proretset
+                AND (dt.typname ~ '^[A-Za-z0-9.-]+/[A-Za-z0-9.+-]+$'
+                     OR dt.typname = '*/*')) as media_base_type
         FROM pg_proc p
         JOIN pg_namespace n ON n.oid = p.pronamespace
         JOIN resolved rt ON rt.oid = p.prorettype
@@ -671,6 +682,7 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
             settings: vec![],
             is_procedure: row.get("is_procedure"),
             media_type: row.get("media_type"),
+            media_base_type: row.get("media_base_type"),
             output_columns: parse_routine_params(row.get("out_params"))
                 .into_iter()
                 .filter(|param| !param.name.is_empty())
@@ -730,12 +742,14 @@ pub async fn load_media_handlers(pool: &PgPool, schemas: &[String]) -> Result<Me
             n.nspname    AS agg_schema,
             p.proname    AS agg_name,
             t.typname    AS media_type,
+            bt.typname   AS media_base_type,
             argn.nspname AS arg_schema,
             argc.relname AS arg_table
         FROM pg_aggregate a
         JOIN pg_proc p       ON p.oid = a.aggfnoid
         JOIN pg_namespace n  ON n.oid = p.pronamespace
         JOIN pg_type t       ON t.oid = a.aggtranstype
+        JOIN pg_type bt      ON bt.oid = t.typbasetype
         LEFT JOIN pg_type argt      ON argt.oid = p.proargtypes[0]
         LEFT JOIN pg_class argc     ON argc.oid = argt.typrelid
         LEFT JOIN pg_namespace argn ON argn.oid = argc.relnamespace
@@ -767,6 +781,7 @@ pub async fn load_media_handlers(pool: &PgPool, schemas: &[String]) -> Result<Me
             .push(MediaHandler {
                 aggregate: QualifiedIdentifier::new(agg_schema, row.get::<String, _>("agg_name")),
                 table,
+                base_type: row.get("media_base_type"),
             });
     }
 

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -143,7 +143,27 @@ async fn load_columns(
             -- and the domain is what a data representation is declared on.
             c.domain_name,
             c.character_maximum_length,
-            c.column_default,
+            -- An identity column has no `column_default`: `information_schema`
+            -- describes it as generated rather than defaulted. What it would
+            -- take if a row left it out is the next value of the sequence the
+            -- column owns, which is the answer `Prefer: missing=default`
+            -- needs.
+            COALESCE(
+                c.column_default,
+                (SELECT format('nextval(%L)', s.oid::regclass)
+                   FROM pg_class rel
+                   JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+                   JOIN pg_attribute att ON att.attrelid = rel.oid
+                                        AND att.attname = c.column_name
+                                        AND att.attidentity = 'd'
+                   JOIN pg_depend dep ON dep.refobjid = rel.oid
+                                     AND dep.refobjsubid = att.attnum
+                                     AND dep.deptype = 'i'
+                   JOIN pg_class s ON s.oid = dep.objid AND s.relkind = 'S'
+                  WHERE ns.nspname = c.table_schema
+                    AND rel.relname = c.table_name
+                  LIMIT 1)
+            ) AS column_default,
             pg_catalog.col_description(
                 (quote_ident(c.table_schema) || '.' || quote_ident(c.table_name))::regclass,
                 c.ordinal_position

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -61,9 +61,22 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'DELETE'
             ) as deletable
-        FROM information_schema.tables t
+        FROM (
+            -- `information_schema.tables` has no row for a materialized view,
+            -- so one is added from the catalogue. Everything downstream keys
+            -- off `table_type`, and a materialized view is a view that cannot
+            -- be written to -- which is what the privilege lookups above
+            -- already report, since it has no INSERT/UPDATE/DELETE grants.
+            SELECT table_schema, table_name, table_type
+              FROM information_schema.tables
+             WHERE table_type IN ('BASE TABLE', 'VIEW')
+            UNION ALL
+            SELECT n.nspname, c.relname, 'VIEW'
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE c.relkind = 'm'
+        ) t
         WHERE t.table_schema = ANY($1)
-          AND t.table_type IN ('BASE TABLE', 'VIEW')
         ORDER BY t.table_schema, t.table_name
         "#,
     )
@@ -90,6 +103,7 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
             deletable: row.get("deletable"),
             pk_cols: pk_cols.clone(),
             columns: load_columns(pool, &schema, &name, &pk_cols).await?,
+            computed_columns: Default::default(),
         };
 
         tables.insert(qi, table);
@@ -140,6 +154,13 @@ async fn load_columns(
     .fetch_all(pool)
     .await
     .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    // A materialized view has no rows in `information_schema.columns`; its
+    // columns come from the catalogue instead.
+    let rows = match rows.is_empty() {
+        true => load_catalog_columns(pool, schema, table).await?,
+        false => rows,
+    };
 
     for row in rows {
         let name: String = row.get("column_name");
@@ -605,37 +626,125 @@ pub async fn load_media_handlers(pool: &PgPool, schemas: &[String]) -> Result<Me
 /// depends on, but not which of the view's own columns each one became -- that
 /// lives in the parsed rule tree. Matching by name covers a view that selects
 /// its columns through unchanged, and misses one that renames them, which is
-/// the honest limit of doing this without parsing the rule.
-pub async fn load_view_columns(
+/// Columns read straight from the catalogue, for a relation
+/// `information_schema` does not describe.
+///
+/// The columns are shaped to match what the `information_schema` query
+/// returns, so the caller cannot tell which of the two answered.
+async fn load_catalog_columns(
     pool: &PgPool,
-    schemas: &[String],
-) -> Result<Vec<(QualifiedIdentifier, QualifiedIdentifier, String)>> {
+    schema: &str,
+    table: &str,
+) -> Result<Vec<sqlx::postgres::PgRow>> {
+    sqlx::query(
+        r#"
+        SELECT
+            a.attname AS column_name,
+            a.attnum::int AS ordinal_position,
+            CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+            pg_catalog.format_type(a.atttypid, NULL) AS data_type,
+            t.typname AS udt_name,
+            NULL::int AS character_maximum_length,
+            pg_catalog.pg_get_expr(d.adbin, d.adrelid) AS column_default,
+            pg_catalog.col_description(c.oid, a.attnum) AS description,
+            COALESCE(
+                (SELECT array_agg(e.enumlabel ORDER BY e.enumsortorder)
+                   FROM pg_enum e WHERE e.enumtypid = t.oid),
+                ARRAY[]::text[]
+            ) AS enum_values
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
+        JOIN pg_type t ON t.oid = a.atttypid
+        LEFT JOIN pg_attrdef d ON d.adrelid = c.oid AND d.adnum = a.attnum
+        WHERE n.nspname = $1 AND c.relname = $2
+        ORDER BY a.attnum
+        "#,
+    )
+    .bind(schema)
+    .bind(table)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))
+}
+
+/// Casts a schema declares between one of its domains and `json` or `text`.
+///
+/// PostgREST calls these data representations: a domain over `integer` with a
+/// cast to `json` decides how a column of that domain is rendered, and a cast
+/// back from `text` decides how a filter value written against it is read. It
+/// lets a schema say that a colour is `"#01E240"` on the wire and an integer in
+/// storage, with neither the client nor the table having to know about the
+/// other.
+///
+/// Keyed by `(source type, target type)` so both directions come out of one
+/// query: the render is `(domain, json)` and the parse is `(text, domain)`.
+pub async fn load_representations(
+    pool: &PgPool,
+) -> Result<std::collections::HashMap<(String, String), String>> {
     let rows = sqlx::query(
         r#"
-        SELECT DISTINCT
-            vn.nspname AS view_schema,
-            v.relname  AS view_name,
-            tn.nspname AS base_schema,
-            t.relname  AS base_name,
-            va.attname AS column_name
-        FROM pg_depend d
-        JOIN pg_rewrite r    ON r.oid = d.objid AND r.rulename = '_RETURN'
-        JOIN pg_class v      ON v.oid = r.ev_class AND v.relkind = ANY (ARRAY['v','m'])
-        JOIN pg_namespace vn ON vn.oid = v.relnamespace
-        JOIN pg_class t      ON t.oid = d.refobjid
-                            AND t.relkind = ANY (ARRAY['r','v','m','p','f'])
-        JOIN pg_namespace tn ON tn.oid = t.relnamespace
-        JOIN pg_attribute ta ON ta.attrelid = t.oid
-                            AND ta.attnum = d.refobjsubid
-                            AND NOT ta.attisdropped
-        JOIN pg_attribute va ON va.attrelid = v.oid
-                            AND va.attname = ta.attname
-                            AND NOT va.attisdropped
-        WHERE d.classid = 'pg_rewrite'::regclass
-          AND d.refclassid = 'pg_class'::regclass
-          AND d.refobjsubid > 0
-          AND v.oid <> t.oid
-          AND vn.nspname = ANY($1)
+        SELECT c.castsource::regtype::text AS source,
+               c.casttarget::regtype::text AS target,
+               c.castfunc::regproc::text   AS function
+          FROM pg_catalog.pg_cast c
+          JOIN pg_catalog.pg_type src ON src.oid = c.castsource
+          JOIN pg_catalog.pg_type dst ON dst.oid = c.casttarget
+         WHERE c.castcontext = 'i'
+           AND c.castmethod = 'f'
+           AND has_function_privilege(c.castfunc, 'execute')
+           AND ((src.typtype = 'd' AND c.casttarget IN ('json'::regtype, 'text'::regtype))
+             OR (dst.typtype = 'd' AND c.castsource IN ('json'::regtype, 'text'::regtype)))
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                (
+                    row.get::<String, _>("source"),
+                    row.get::<String, _>("target"),
+                ),
+                row.get::<String, _>("function"),
+            )
+        })
+        .collect())
+}
+
+/// Functions of a table's row type, which read as though they were columns.
+///
+/// `create function always_true(items) returns boolean` makes
+/// `?select=id,always_true` and `?always_true=is.true` work on `items`:
+/// PostgreSQL resolves `items.always_true` to the function call, and PostgREST
+/// exposes that. Only single-argument functions returning a single value
+/// qualify -- one returning `setof` another table is a computed *relationship*,
+/// which is embedded rather than selected.
+pub async fn load_computed_columns(
+    pool: &PgPool,
+    schemas: &[String],
+) -> Result<Vec<(QualifiedIdentifier, String, QualifiedIdentifier, String)>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT tn.nspname AS table_schema,
+               t.relname  AS table_name,
+               fn.nspname AS function_schema,
+               p.proname  AS function_name,
+               pg_catalog.format_type(p.prorettype, null) AS return_type
+          FROM pg_proc p
+          JOIN pg_namespace fn ON fn.oid = p.pronamespace
+          JOIN pg_class t ON t.reltype = p.proargtypes[0]
+          JOIN pg_namespace tn ON tn.oid = t.relnamespace
+         WHERE p.pronargs = 1
+           AND NOT p.proretset
+           AND p.prokind = 'f'
+           AND p.prorettype <> 'pg_catalog.trigger'::pg_catalog.regtype
+           AND t.relkind = ANY (ARRAY['r', 'v', 'm', 'p', 'f'])
+           AND fn.nspname = ANY($1)
+           AND tn.nspname = ANY($1)
         "#,
     )
     .bind(schemas)
@@ -648,15 +757,168 @@ pub async fn load_view_columns(
         .map(|row| {
             (
                 QualifiedIdentifier::new(
-                    row.get::<String, _>("view_schema"),
-                    row.get::<String, _>("view_name"),
+                    row.get::<String, _>("table_schema"),
+                    row.get::<String, _>("table_name"),
                 ),
+                row.get::<String, _>("function_name"),
                 QualifiedIdentifier::new(
-                    row.get::<String, _>("base_schema"),
-                    row.get::<String, _>("base_name"),
+                    row.get::<String, _>("function_schema"),
+                    row.get::<String, _>("function_name"),
                 ),
-                row.get::<String, _>("column_name"),
+                row.get::<String, _>("return_type"),
             )
+        })
+        .collect())
+}
+
+/// One view column, and the base-table column it was selected from.
+#[derive(Clone, Debug)]
+pub struct ViewColumn {
+    /// The view.
+    pub view: QualifiedIdentifier,
+    /// The table the column ultimately comes from.
+    pub base: QualifiedIdentifier,
+    /// The column's name on the base table.
+    pub base_column: String,
+    /// The name the view gives it.
+    pub view_column: String,
+}
+
+/// Which base-table column each view column came from.
+///
+/// A view may rename what it selects -- `select article_id as "articleId"` --
+/// so matching by name gets the mapping wrong exactly where it matters, and a
+/// view over another view has to be followed through. PostgreSQL records the
+/// answer in the rewrite rule's target list, where every entry carries the
+/// table and column it originated from, but only as a `pg_node_tree`, which
+/// has no catalogue view and no parser exposed to SQL.
+///
+/// The shape below is PostgREST's: turn the node tree into JSON with a fixed
+/// series of string replacements -- the fields wanted are quoted first so the
+/// one regular expression can strip everything else -- read the target list
+/// out of it, then follow view-on-view chains recursively, stopping on a cycle.
+///
+/// One base column may arrive under several names (`select t1_id as t1_id1,
+/// t1_id as t1_id2`), so a single mapping is a row per name.
+pub async fn load_view_columns(pool: &PgPool, schemas: &[String]) -> Result<Vec<ViewColumn>> {
+    let rows = sqlx::query(
+        r#"
+        WITH RECURSIVE
+        views AS (
+            SELECT c.oid AS view_id, c.relnamespace AS view_schema_id,
+                   n.nspname AS view_schema, c.relname AS view_name,
+                   r.ev_action AS view_definition
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+              JOIN pg_rewrite r ON r.ev_class = c.oid
+             WHERE c.relkind IN ('v', 'm')
+        ),
+        transform_json AS (
+            SELECT view_id, view_schema_id, view_schema, view_name,
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                regexp_replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                replace(
+                    view_definition::text,
+                    '<>', '()'
+                ), ',', ''
+                ), E'\\{', ''
+                ), E'\\}', ''
+                ), ' :targetList ', ',"targetList":'
+                ), ' :resno ', ',"resno":'
+                ), ' :resorigtbl ', ',"resorigtbl":'
+                ), ' :resorigcol ', ',"resorigcol":'
+                ), '{', '{ :'
+                ), '((', '{(('
+                ), '({', '{({'
+                ), ' :[^}{,]+', ',"":', 'g'
+                ), ',"":}', '}'
+                ), ',"":,', ','
+                ), '{(', '('
+                ), '{,', '{'
+                ), '(', '['
+                ), ')', ']'
+                ), ' ', ','
+                )::json AS view_definition
+              FROM views
+        ),
+        results AS (
+            SELECT view_id, view_schema_id, view_schema, view_name,
+                   (entry->>'resno')::int AS view_column,
+                   (entry->>'resorigtbl')::oid AS resorigtbl,
+                   (entry->>'resorigcol')::int AS resorigcol
+              FROM (
+                SELECT view_id, view_schema_id, view_schema, view_name,
+                       json_array_elements(view_definition->0->'targetList') AS entry
+                  FROM transform_json
+              ) target_entries
+        ),
+        -- A view over a view is followed down to the base table. `path`
+        -- carries the tables already visited so a cyclic definition stops
+        -- rather than recursing forever.
+        recursion(view_id, view_schema, view_name, view_column,
+                  resorigtbl, resorigcol, is_cycle, path) AS (
+            SELECT r.view_id, r.view_schema, r.view_name, r.view_column,
+                   r.resorigtbl, r.resorigcol, false, ARRAY[r.resorigtbl]
+              FROM results r
+             WHERE r.view_schema = ANY($1)
+            UNION ALL
+            SELECT v.view_id, v.view_schema, v.view_name, v.view_column,
+                   t.resorigtbl, t.resorigcol,
+                   t.resorigtbl = ANY(v.path), v.path || t.resorigtbl
+              FROM recursion v
+              JOIN results t ON v.resorigtbl = t.view_id AND v.resorigcol = t.view_column
+             WHERE NOT v.is_cycle
+        )
+        SELECT DISTINCT
+               rec.view_schema, rec.view_name,
+               sch.nspname AS base_schema, tbl.relname AS base_name,
+               col.attname AS base_column, vcol.attname AS view_column
+          FROM recursion rec
+          JOIN pg_attribute vcol ON vcol.attrelid = rec.view_id
+                                AND vcol.attnum = rec.view_column
+                                AND NOT vcol.attisdropped
+          JOIN pg_class tbl ON tbl.oid = rec.resorigtbl
+          JOIN pg_namespace sch ON sch.oid = tbl.relnamespace
+          JOIN pg_attribute col ON col.attrelid = tbl.oid
+                               AND col.attnum = rec.resorigcol
+                               AND NOT col.attisdropped
+         WHERE rec.resorigtbl <> 0
+        "#,
+    )
+    .bind(schemas)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ViewColumn {
+            view: QualifiedIdentifier::new(
+                row.get::<String, _>("view_schema"),
+                row.get::<String, _>("view_name"),
+            ),
+            base: QualifiedIdentifier::new(
+                row.get::<String, _>("base_schema"),
+                row.get::<String, _>("base_name"),
+            ),
+            base_column: row.get::<String, _>("base_column"),
+            view_column: row.get::<String, _>("view_column"),
         })
         .collect())
 }

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -1,6 +1,8 @@
 //! SQL queries for schema introspection.
 
-use super::relationship::{Cardinality, Relationship, RelationshipsMap};
+use super::relationship::{
+    Cardinality, MediaHandler, MediaHandlerMap, Relationship, RelationshipsMap,
+};
 use super::routine::{FuncVolatility, RetType, Routine, RoutineMap, RoutineParam};
 use super::table::{Column, ColumnMap, Table, TablesMap};
 use crate::api_request::QualifiedIdentifier;
@@ -519,4 +521,63 @@ pub async fn load_timezones(pool: &PgPool) -> Result<HashSet<String>> {
         .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
 
     Ok(rows.iter().map(|r| r.get("name")).collect())
+}
+
+/// Load user-defined renderers for media types.
+///
+/// A renderer is an aggregate whose state type is a domain named after a media
+/// type. The domain is how the name survives -- `application/geo+json` is not
+/// a legal identifier otherwise -- and the `/` in it is what makes an
+/// ordinary-looking domain recognisable as one.
+///
+/// The aggregate's argument says what it renders: a table's composite type
+/// renders that table, and `anyelement` renders anything in the schema.
+pub async fn load_media_handlers(pool: &PgPool, schemas: &[String]) -> Result<MediaHandlerMap> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            n.nspname    AS agg_schema,
+            p.proname    AS agg_name,
+            t.typname    AS media_type,
+            argn.nspname AS arg_schema,
+            argc.relname AS arg_table
+        FROM pg_aggregate a
+        JOIN pg_proc p       ON p.oid = a.aggfnoid
+        JOIN pg_namespace n  ON n.oid = p.pronamespace
+        JOIN pg_type t       ON t.oid = a.aggtranstype
+        LEFT JOIN pg_type argt      ON argt.oid = p.proargtypes[0]
+        LEFT JOIN pg_class argc     ON argc.oid = argt.typrelid
+        LEFT JOIN pg_namespace argn ON argn.oid = argc.relnamespace
+        WHERE n.nspname = ANY($1)
+          AND t.typtype = 'd'
+          AND t.typname LIKE '%/%'
+        "#,
+    )
+    .bind(schemas)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    let mut handlers: MediaHandlerMap = HashMap::new();
+    for row in rows {
+        let agg_schema: String = row.get("agg_schema");
+        let media_type: String = row.get("media_type");
+        let table = match (
+            row.get::<Option<String>, _>("arg_schema"),
+            row.get::<Option<String>, _>("arg_table"),
+        ) {
+            (Some(schema), Some(name)) => Some(QualifiedIdentifier::new(schema, name)),
+            _ => None,
+        };
+
+        handlers
+            .entry((agg_schema.clone(), media_type))
+            .or_default()
+            .push(MediaHandler {
+                aggregate: QualifiedIdentifier::new(agg_schema, row.get::<String, _>("agg_name")),
+                table,
+            });
+    }
+
+    Ok(handlers)
 }

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -1,7 +1,7 @@
 //! SQL queries for schema introspection.
 
 use super::relationship::{Cardinality, Relationship, RelationshipsMap};
-use super::routine::{FuncVolatility, RetType, Routine, RoutineMap};
+use super::routine::{FuncVolatility, RetType, Routine, RoutineMap, RoutineParam};
 use super::table::{Column, ColumnMap, Table, TablesMap};
 use crate::api_request::QualifiedIdentifier;
 use crate::error::{Error, Result};
@@ -298,6 +298,41 @@ pub async fn load_relationships(pool: &PgPool, schemas: &[String]) -> Result<Rel
     Ok(relationships)
 }
 
+/// Decode the `params` JSON built by [`load_routines`]'s query.
+///
+/// Anything malformed yields no parameters rather than an error: an argument
+/// whose type we don't know is bound untyped, which is how the server behaved
+/// before parameter types were loaded at all.
+fn parse_routine_params(value: serde_json::Value) -> Vec<RoutineParam> {
+    let Some(items) = value.as_array() else {
+        return Vec::new();
+    };
+
+    items
+        .iter()
+        .filter_map(|item| {
+            let param_type = item.get("type")?.as_str()?.to_string();
+            Some(RoutineParam {
+                name: item
+                    .get("name")
+                    .and_then(|n| n.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                type_max_length: param_type.clone(),
+                param_type,
+                required: item
+                    .get("required")
+                    .and_then(|r| r.as_bool())
+                    .unwrap_or(true),
+                variadic: item
+                    .get("variadic")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            })
+        })
+        .collect()
+}
+
 /// Load stored functions.
 pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineMap> {
     let mut routines: RoutineMap = HashMap::new();
@@ -312,6 +347,24 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
             p.provariadic <> 0 as has_variadic,
             p.prokind = 'p' as is_procedure,
             pg_get_function_identity_arguments(p.oid) as args,
+            -- Input parameters, in declaration order. Built from the catalog
+            -- rather than parsed out of the identity-arguments string, whose
+            -- types can themselves contain commas (`numeric(10,2)`).
+            -- `proargtypes` covers the IN parameters only and is 0-indexed;
+            -- `proargnames` is 1-indexed and lists IN names first, so the two
+            -- line up over 1..pronargs. A parameter is optional when it falls
+            -- inside the trailing run that has defaults.
+            COALESCE((
+                SELECT json_agg(
+                    json_build_object(
+                        'name', COALESCE(p.proargnames[i], ''),
+                        'type', pg_catalog.format_type(p.proargtypes[i - 1], NULL),
+                        'required', i <= (p.pronargs - p.pronargdefaults),
+                        'variadic', p.provariadic <> 0 AND i = p.pronargs
+                    ) ORDER BY i
+                )
+                FROM generate_series(1, p.pronargs) AS i
+            ), '[]'::json) as params,
             CASE
                 WHEN p.proretset THEN 'SETOF ' || pg_catalog.format_type(p.prorettype, NULL)
                 ELSE pg_catalog.format_type(p.prorettype, NULL)
@@ -361,7 +414,7 @@ pub async fn load_routines(pool: &PgPool, schemas: &[String]) -> Result<RoutineM
             schema,
             name,
             description: row.get("description"),
-            params: vec![], // Simplified - full implementation would parse args
+            params: parse_routine_params(row.get("params")),
             return_type,
             returns_composite,
             volatility: FuncVolatility::from_char(volatility.chars().next().unwrap_or('v')),

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -181,27 +181,40 @@ pub async fn load_relationships(pool: &PgPool, schemas: &[String]) -> Result<Rel
             t1.relname as table_name,
             ns2.nspname as foreign_table_schema,
             t2.relname as foreign_table_name,
-            array_agg(a1.attname ORDER BY array_position(c.conkey, a1.attnum)) as columns,
-            array_agg(a2.attname ORDER BY array_position(c.confkey, a2.attnum)) as foreign_columns,
+            -- Each key's columns are read in their own subquery, by ordinal
+            -- position. Joining pg_attribute twice in the outer query instead
+            -- would multiply the two keys together: a two-column foreign key
+            -- came back as four pairs, of which two paired a column with the
+            -- wrong one on the other side.
+            (SELECT array_agg(a.attname ORDER BY k.ord)
+               FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord)
+               JOIN pg_attribute a
+                 ON a.attrelid = c.conrelid AND a.attnum = k.attnum) as columns,
+            (SELECT array_agg(a.attname ORDER BY k.ord)
+               FROM unnest(c.confkey) WITH ORDINALITY AS k(attnum, ord)
+               JOIN pg_attribute a
+                 ON a.attrelid = c.confrelid AND a.attnum = k.attnum) as foreign_columns,
             t1.relkind = 'v' as table_is_view,
             t2.relkind = 'v' as foreign_table_is_view,
+            -- The key is unique when a unique index is *covered by* it, not
+            -- when the index merely contains it. Asked the other way round,
+            -- any key that is part of a wider unique index looked unique --
+            -- so a foreign key on two of a three-column primary key became a
+            -- one-to-one, and the far side embedded a single object where it
+            -- should have embedded an array.
             EXISTS (
                 SELECT 1 FROM pg_index i
                 WHERE i.indrelid = c.conrelid
                   AND i.indisunique
-                  AND i.indkey::int[] @> c.conkey::int[]
+                  AND c.conkey::int[] @> i.indkey::int[]
             ) as is_unique
         FROM pg_constraint c
         JOIN pg_class t1 ON t1.oid = c.conrelid
         JOIN pg_namespace ns1 ON ns1.oid = t1.relnamespace
         JOIN pg_class t2 ON t2.oid = c.confrelid
         JOIN pg_namespace ns2 ON ns2.oid = t2.relnamespace
-        JOIN pg_attribute a1 ON a1.attrelid = c.conrelid AND a1.attnum = ANY(c.conkey)
-        JOIN pg_attribute a2 ON a2.attrelid = c.confrelid AND a2.attnum = ANY(c.confkey)
         WHERE c.contype = 'f'
           AND ns1.nspname = ANY($1)
-        GROUP BY c.conname, ns1.nspname, t1.relname, ns2.nspname, t2.relname,
-                 t1.relkind, t2.relkind, c.conrelid, c.conkey
         "#,
     )
     .bind(schemas)

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -68,9 +68,13 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
             -- off `table_type`, and a materialized view is a view that cannot
             -- be written to -- which is what the privilege lookups above
             -- already report, since it has no INSERT/UPDATE/DELETE grants.
+            -- A foreign table is a table: it has columns, it can be selected
+            -- from and written to, and which server stores the rows is not
+            -- the API's business. Leaving it out meant a schema that exposes
+            -- one answered "no such table".
             SELECT table_schema, table_name, table_type
               FROM information_schema.tables
-             WHERE table_type IN ('BASE TABLE', 'VIEW')
+             WHERE table_type IN ('BASE TABLE', 'VIEW', 'FOREIGN')
             UNION ALL
             SELECT n.nspname, c.relname, 'VIEW'
               FROM pg_class c

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -73,6 +73,10 @@ pub async fn load_tables(pool: &PgPool, schemas: &[String]) -> Result<TablesMap>
                 WHERE tp.table_schema = t.table_schema
                   AND tp.table_name = t.table_name
                   AND tp.privilege_type = 'DELETE'
+            -- `is_updatable`, not a typo for a column that does not exist:
+            -- `information_schema.views` has no `is_deletable`, because a view
+            -- PostgreSQL can write through automatically is one it can delete
+            -- through as well. Only the trigger half is asked separately.
             ) AND COALESCE(
                 v.is_updatable = 'YES' OR v.is_trigger_deletable = 'YES',
                 true

--- a/crates/postrust-core/src/schema_cache/queries.rs
+++ b/crates/postrust-core/src/schema_cache/queries.rs
@@ -295,7 +295,88 @@ pub async fn load_relationships(pool: &PgPool, schemas: &[String]) -> Result<Rel
             .push(reverse_rel);
     }
 
+    load_computed_relationships(pool, schemas, &mut relationships).await?;
+
     Ok(relationships)
+}
+
+/// Add relationships that are computed by a function rather than declared by a
+/// foreign key.
+///
+/// A function qualifies when it takes exactly one argument, that argument is
+/// the composite type of an exposed table, and it returns rows of an exposed
+/// table. `SETOF t` yields many rows per parent and a bare `t` yields one;
+/// `ROWS 1` on a set-returning function declares it yields one as well, which
+/// is how a to-one computed relationship is written.
+///
+/// The relationship is named after the function, not after the table it
+/// returns, so that two functions returning the same table stay distinct.
+async fn load_computed_relationships(
+    pool: &PgPool,
+    schemas: &[String],
+    relationships: &mut RelationshipsMap,
+) -> Result<()> {
+    let rows = sqlx::query(
+        r#"
+        SELECT
+            pn.nspname  AS function_schema,
+            p.proname   AS function_name,
+            tn.nspname  AS table_schema,
+            t.relname   AS table_name,
+            fn.nspname  AS foreign_table_schema,
+            f.relname   AS foreign_table_name,
+            (NOT p.proretset) OR p.prorows = 1 AS to_one
+        FROM pg_proc p
+        JOIN pg_namespace pn ON pn.oid = p.pronamespace
+        -- the single argument is a table's composite type
+        JOIN pg_type argt ON argt.oid = p.proargtypes[0]
+        JOIN pg_class t   ON t.oid = argt.typrelid
+        JOIN pg_namespace tn ON tn.oid = t.relnamespace
+        -- and the return type is a table as well
+        JOIN pg_type rett ON rett.oid = p.prorettype
+        JOIN pg_class f   ON f.oid = rett.typrelid
+        JOIN pg_namespace fn ON fn.oid = f.relnamespace
+        WHERE p.pronargs = 1
+          AND pn.nspname = ANY($1)
+          AND tn.nspname = ANY($1)
+          AND fn.nspname = ANY($1)
+          -- relkind 'c' would be a standalone composite type, not a relation
+          AND t.relkind = ANY (ARRAY['r','v','m','f','p'])
+          AND f.relkind = ANY (ARRAY['r','v','m','f','p'])
+        "#,
+    )
+    .bind(schemas)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| Error::SchemaCacheLoadFailed(e.to_string()))?;
+
+    for row in rows {
+        let function = QualifiedIdentifier::new(
+            row.get::<String, _>("function_schema"),
+            row.get::<String, _>("function_name"),
+        );
+        let table_schema: String = row.get("table_schema");
+        let table = QualifiedIdentifier::new(&table_schema, row.get::<String, _>("table_name"));
+        let foreign_table = QualifiedIdentifier::new(
+            row.get::<String, _>("foreign_table_schema"),
+            row.get::<String, _>("foreign_table_name"),
+        );
+        let is_self = table == foreign_table;
+
+        relationships
+            .entry((table.clone(), table_schema))
+            .or_default()
+            .push(Relationship::Computed {
+                function,
+                table: table.clone(),
+                foreign_table: foreign_table.clone(),
+                table_alias: table,
+                to_one: row.get("to_one"),
+                is_self,
+            });
+    }
+
+    Ok(())
 }
 
 /// Decode the `params` JSON built by [`load_routines`]'s query.

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -108,20 +108,36 @@ impl Relationship {
                 cardinality: Cardinality::M2M(junction),
                 ..
             } => {
-                let side = |columns: &[(String, String)]| -> String {
-                    columns
-                        .iter()
-                        .map(|(_, far)| far.clone())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                };
+                // Both constraints belong to the junction table, so both are
+                // named with the junction's own columns. The two lists are
+                // oriented in opposite directions -- `source_columns` runs
+                // (source, through) and `target_columns` runs (through,
+                // target) -- so the junction's side is the second element of
+                // one and the first of the other. Taking the second of both
+                // described the far constraint with the column it points at
+                // rather than the column it is on:
+                // `whatev_jobs_project_id_1_fkey(id)` for a constraint that is
+                // on `project_id_1`.
+                let joined = |columns: Vec<String>| columns.join(", ");
                 format!(
                     "{} using {}({}) and {}({})",
                     junction.table.name,
                     junction.constraint1,
-                    side(&junction.source_columns),
+                    joined(
+                        junction
+                            .source_columns
+                            .iter()
+                            .map(|(_, through)| through.clone())
+                            .collect()
+                    ),
                     junction.constraint2,
-                    side(&junction.target_columns),
+                    joined(
+                        junction
+                            .target_columns
+                            .iter()
+                            .map(|(through, _)| through.clone())
+                            .collect()
+                    ),
                 )
             }
             Self::ForeignKey {

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -100,6 +100,30 @@ impl Relationship {
     /// what a client needs to write the hint that disambiguates it.
     pub fn describe(&self) -> String {
         match self {
+            // A junction is described by the table it joins through and the
+            // two constraints that make it one -- there is no single
+            // constraint to name, and the empty string that came out instead
+            // told a client nothing about which relationship it had found.
+            Self::ForeignKey {
+                cardinality: Cardinality::M2M(junction),
+                ..
+            } => {
+                let side = |columns: &[(String, String)]| -> String {
+                    columns
+                        .iter()
+                        .map(|(_, far)| far.clone())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                };
+                format!(
+                    "{} using {}({}) and {}({})",
+                    junction.table.name,
+                    junction.constraint1,
+                    side(&junction.source_columns),
+                    junction.constraint2,
+                    side(&junction.target_columns),
+                )
+            }
             Self::ForeignKey {
                 table,
                 foreign_table,
@@ -126,6 +150,24 @@ impl Relationship {
                     foreign
                 )
             }
+            Self::Computed { function, .. } => function.name.clone(),
+        }
+    }
+
+    /// The `!hint` that picks this relationship out from its rivals.
+    ///
+    /// The constraint for a foreign key, the junction table for a
+    /// many-to-many: whichever name is the one a client would have to write to
+    /// mean this relationship and no other.
+    pub fn disambiguator(&self) -> String {
+        match self {
+            Self::ForeignKey {
+                cardinality: Cardinality::M2M(junction),
+                ..
+            } => junction.table.name.clone(),
+            Self::ForeignKey {
+                constraint_name, ..
+            } => constraint_name.clone(),
             Self::Computed { function, .. } => function.name.clone(),
         }
     }

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -405,6 +405,9 @@ pub struct MediaHandler {
     /// The table it renders, or `None` when it takes `anyelement` and so
     /// renders any of them.
     pub table: Option<QualifiedIdentifier>,
+    /// The type the handler's media-type domain is a domain over, which is
+    /// what says whether its output is bytes or text.
+    pub base_type: String,
 }
 
 /// Media handlers by (schema, media type).

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -175,6 +175,55 @@ impl Relationship {
             }
     }
 
+    /// Whether this is a self-referential foreign key.
+    pub fn is_self_referential(&self) -> bool {
+        matches!(self, Self::ForeignKey { is_self, .. } if *is_self)
+    }
+
+    /// Whether this relationship yields many rows per row of its own table.
+    pub fn is_one_to_many(&self) -> bool {
+        matches!(
+            self,
+            Self::ForeignKey {
+                cardinality: Cardinality::O2M { .. },
+                ..
+            }
+        )
+    }
+
+    /// The single column this side joins on, where it joins on exactly one.
+    pub fn single_local_column(&self) -> Option<&str> {
+        match self.join_columns().len() {
+            1 => match self {
+                Self::ForeignKey { cardinality, .. } => match cardinality {
+                    Cardinality::O2M { columns, .. }
+                    | Cardinality::M2O { columns, .. }
+                    | Cardinality::O2O { columns, .. } => Some(columns[0].0.as_str()),
+                    Cardinality::M2M(_) => None,
+                },
+                Self::Computed { .. } => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// The single column the other side joins on, where there is exactly one.
+    pub fn single_foreign_column(&self) -> Option<&str> {
+        match self {
+            Self::ForeignKey { cardinality, .. } => match cardinality {
+                Cardinality::O2M { columns, .. }
+                | Cardinality::M2O { columns, .. }
+                | Cardinality::O2O { columns, .. }
+                    if columns.len() == 1 =>
+                {
+                    Some(columns[0].1.as_str())
+                }
+                _ => None,
+            },
+            Self::Computed { .. } => None,
+        }
+    }
+
     /// Get the join columns for this relationship.
     pub fn join_columns(&self) -> Vec<(String, String)> {
         match self {

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -77,6 +77,70 @@ impl Relationship {
         }
     }
 
+    /// How PostgREST names this relationship's cardinality.
+    pub fn cardinality_name(&self) -> &'static str {
+        match self {
+            Self::ForeignKey { cardinality, .. } => match cardinality {
+                Cardinality::O2M { .. } => "one-to-many",
+                Cardinality::M2O { .. } => "many-to-one",
+                Cardinality::O2O { .. } => "one-to-one",
+                Cardinality::M2M(_) => "many-to-many",
+            },
+            Self::Computed { to_one, .. } => match to_one {
+                true => "many-to-one",
+                false => "one-to-many",
+            },
+        }
+    }
+
+    /// How this relationship reads when several of them cannot be told apart.
+    ///
+    /// `message_sender_fkey using message(sender) and person_detail(id)` --
+    /// the constraint, then each side with the columns it joins on, which is
+    /// what a client needs to write the hint that disambiguates it.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::ForeignKey {
+                table,
+                foreign_table,
+                cardinality,
+                ..
+            } => {
+                let columns = cardinality.columns();
+                let local = columns
+                    .iter()
+                    .map(|(local, _)| local.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let foreign = columns
+                    .iter()
+                    .map(|(_, foreign)| foreign.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!(
+                    "{} using {}({}) and {}({})",
+                    self.constraint_name(),
+                    table.name,
+                    local,
+                    foreign_table.name,
+                    foreign
+                )
+            }
+            Self::Computed { function, .. } => function.name.clone(),
+        }
+    }
+
+    /// Whether a hint names this relationship.
+    ///
+    /// A hint may be the constraint, the column that joins them, or the table
+    /// on the far side -- whichever the client found unambiguous.
+    pub fn matches_hint(&self, hint: &str) -> bool {
+        self.constraint_name() == hint
+            || self.foreign_table().name == hint
+            || self.join_columns().iter().any(|(local, _)| local == hint)
+            || matches!(self, Self::Computed { function, .. } if function.name == hint)
+    }
+
     /// Get the join columns for this relationship.
     pub fn join_columns(&self) -> Vec<(String, String)> {
         match self {

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -139,12 +139,21 @@ impl Relationship {
         // telling name depends on the direction: `whatev_jobs!site_id_1` names
         // a column on the jobs, which is the far side when the request starts
         // from the sites.
+        //
+        // A self-referential relationship appears twice, once each way, and
+        // both directions join on the same pair of columns -- so matching
+        // either side would match both and make every hint ambiguous. The far
+        // side is the telling one: `family_tree!parent` asks for the rows
+        // whose `parent` points here.
+        let self_referential = matches!(self, Self::ForeignKey { is_self, .. } if *is_self);
+        let columns_match = self
+            .join_columns()
+            .iter()
+            .any(|(local, foreign)| foreign == hint || (!self_referential && local == hint));
+
         self.constraint_name() == hint
             || self.foreign_table().name == hint
-            || self
-                .join_columns()
-                .iter()
-                .any(|(local, foreign)| local == hint || foreign == hint)
+            || columns_match
             || match self {
                 Self::Computed { function, .. } => function.name == hint,
                 // A junction is named by the table it joins through, or by

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -201,3 +201,22 @@ mod tests {
         assert_eq!(cols[0], ("id".into(), "user_id".into()));
     }
 }
+
+/// A user-defined renderer for a media type.
+///
+/// PostgREST lets a schema override how a media type is produced by declaring
+/// an aggregate whose state type is a domain named after that media type --
+/// `create domain "application/geo+json" as jsonb` and an aggregate over the
+/// table's rows returning it. The aggregate is then applied to the rows the
+/// request selected and its result is the whole response body.
+#[derive(Clone, Debug)]
+pub struct MediaHandler {
+    /// The aggregate to apply.
+    pub aggregate: QualifiedIdentifier,
+    /// The table it renders, or `None` when it takes `anyelement` and so
+    /// renders any of them.
+    pub table: Option<QualifiedIdentifier>,
+}
+
+/// Media handlers by (schema, media type).
+pub type MediaHandlerMap = std::collections::HashMap<(String, String), Vec<MediaHandler>>;

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -135,10 +135,35 @@ impl Relationship {
     /// A hint may be the constraint, the column that joins them, or the table
     /// on the far side -- whichever the client found unambiguous.
     pub fn matches_hint(&self, hint: &str) -> bool {
+        // Both columns of the join count, because which side carries the
+        // telling name depends on the direction: `whatev_jobs!site_id_1` names
+        // a column on the jobs, which is the far side when the request starts
+        // from the sites.
         self.constraint_name() == hint
             || self.foreign_table().name == hint
-            || self.join_columns().iter().any(|(local, _)| local == hint)
-            || matches!(self, Self::Computed { function, .. } if function.name == hint)
+            || self
+                .join_columns()
+                .iter()
+                .any(|(local, foreign)| local == hint || foreign == hint)
+            || match self {
+                Self::Computed { function, .. } => function.name == hint,
+                // A junction is named by the table it joins through, or by
+                // either of the constraints that make it one.
+                Self::ForeignKey {
+                    cardinality: Cardinality::M2M(junction),
+                    ..
+                } => {
+                    junction.table.name == hint
+                        || junction.constraint1 == hint
+                        || junction.constraint2 == hint
+                        || junction
+                            .source_columns
+                            .iter()
+                            .chain(junction.target_columns.iter())
+                            .any(|(a, b)| a == hint || b == hint)
+                }
+                Self::ForeignKey { .. } => false,
+            }
     }
 
     /// Get the join columns for this relationship.

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -61,6 +61,22 @@ impl Relationship {
         }
     }
 
+    /// The name of the foreign key constraint behind this relationship.
+    ///
+    /// Empty for a many-to-many, which is two constraints rather than one, and
+    /// for a computed relationship, which has none.
+    pub fn constraint_name(&self) -> &str {
+        match self {
+            Self::ForeignKey { cardinality, .. } => match cardinality {
+                Cardinality::O2M { constraint, .. }
+                | Cardinality::M2O { constraint, .. }
+                | Cardinality::O2O { constraint, .. } => constraint,
+                Cardinality::M2M(_) => "",
+            },
+            Self::Computed { .. } => "",
+        }
+    }
+
     /// Get the join columns for this relationship.
     pub fn join_columns(&self) -> Vec<(String, String)> {
         match self {

--- a/crates/postrust-core/src/schema_cache/routine.rs
+++ b/crates/postrust-core/src/schema_cache/routine.rs
@@ -32,6 +32,35 @@ pub struct Routine {
     pub settings: Vec<(String, String)>,
     /// Whether this is a procedure (vs function)
     pub is_procedure: bool,
+    /// The media type this function's value already is.
+    ///
+    /// A domain named `image/png` is a declaration about the value, not a type
+    /// the API layer serialises: `returns "text/plain"` returns text, and
+    /// wrapping it in JSON would be answering a question nobody asked. `*/*`
+    /// is spelled that way in the catalogue and reaches a client as
+    /// `application/octet-stream`, which is what "some bytes" is called on the
+    /// wire.
+    #[serde(default)]
+    pub media_type: Option<String>,
+    /// The columns a `RETURNS TABLE` function's rows have, as `(name, type)`.
+    ///
+    /// A function returning rows of a table is shaped by that table, whose
+    /// columns are known. One declaring its own columns is not, and this is
+    /// the only account of them -- without it the result can only be selected
+    /// with `*`, and a column of a type this process cannot decode comes back
+    /// null with nothing to say it should have been rendered by the database.
+    #[serde(default)]
+    pub output_columns: Vec<(String, String)>,
+}
+
+impl Routine {
+    /// The media type this function produces, as a client would name it.
+    pub fn produced_media_type(&self) -> Option<&str> {
+        match self.media_type.as_deref() {
+            Some("*/*") => Some("application/octet-stream"),
+            other => other,
+        }
+    }
 }
 
 impl Routine {
@@ -135,6 +164,8 @@ mod tests {
     #[test]
     fn test_routine_is_safe_for_get() {
         let mut routine = Routine {
+            output_columns: Vec::new(),
+            media_type: None,
             schema: "public".into(),
             name: "get_users".into(),
             description: None,

--- a/crates/postrust-core/src/schema_cache/routine.rs
+++ b/crates/postrust-core/src/schema_cache/routine.rs
@@ -42,6 +42,13 @@ pub struct Routine {
     /// wire.
     #[serde(default)]
     pub media_type: Option<String>,
+    /// The type that media-type domain is a domain over.
+    ///
+    /// A `bytea` renders as `\x` followed by hex when this side cannot name
+    /// its type, and that rendering is a description of the bytes rather than
+    /// the bytes. See [`Self::media_type`].
+    #[serde(default)]
+    pub media_base_type: Option<String>,
     /// The columns a `RETURNS TABLE` function's rows have, as `(name, type)`.
     ///
     /// A function returning rows of a table is shaped by that table, whose
@@ -166,6 +173,7 @@ mod tests {
         let mut routine = Routine {
             output_columns: Vec::new(),
             media_type: None,
+            media_base_type: None,
             schema: "public".into(),
             name: "get_users".into(),
             description: None,

--- a/crates/postrust-core/src/schema_cache/table.rs
+++ b/crates/postrust-core/src/schema_cache/table.rs
@@ -43,6 +43,15 @@ pub struct Table {
     pub computed_columns: HashMap<String, ComputedColumn>,
 }
 
+impl Column {
+    /// The type a data representation would be declared on.
+    ///
+    /// The domain where the column has one, and the type itself otherwise.
+    pub fn representation_type(&self) -> &str {
+        self.domain_type.as_deref().unwrap_or(&self.nominal_type)
+    }
+}
+
 impl Table {
     /// Get a column by name.
     pub fn get_column(&self, name: &str) -> Option<&Column> {
@@ -97,6 +106,14 @@ pub struct Column {
     pub data_type: String,
     /// Base type (for domains)
     pub nominal_type: String,
+    /// The domain this column is declared over, where it is declared over one.
+    ///
+    /// `information_schema` reports the type *underneath* a domain in
+    /// `data_type` and `udt_name`, so nothing else says that a value is a
+    /// `color` rather than an integer -- and a data representation is declared
+    /// on the domain.
+    #[serde(default)]
+    pub domain_type: Option<String>,
     /// Maximum length (for varchar, etc.)
     pub max_len: Option<i32>,
     /// Default value expression
@@ -183,6 +200,7 @@ mod tests {
             enum_values: vec![],
             is_pk: true,
             position: 1,
+            domain_type: None,
         };
         assert!(col1.is_auto());
 
@@ -197,6 +215,7 @@ mod tests {
             enum_values: vec![],
             is_pk: false,
             position: 2,
+            domain_type: None,
         };
         assert!(col2.is_auto());
 
@@ -211,6 +230,7 @@ mod tests {
             enum_values: vec![],
             is_pk: false,
             position: 3,
+            domain_type: None,
         };
         assert!(!col3.is_auto());
     }

--- a/crates/postrust-core/src/schema_cache/table.rs
+++ b/crates/postrust-core/src/schema_cache/table.rs
@@ -26,12 +26,26 @@ pub struct Table {
     pub pk_cols: Vec<String>,
     /// Columns indexed by name
     pub columns: ColumnMap,
+    /// Computed columns, indexed by name.
+    ///
+    /// Not part of the table, and never returned by `select=*`: a function of
+    /// one argument of the table's own row type, which PostgreSQL lets a query
+    /// read as though it were a column. PostgREST exposes them under the name
+    /// the function has, so `?select=id,always_true` and `?always_true=is.true`
+    /// both work on a table that has no such column.
+    #[serde(default)]
+    pub computed_columns: HashMap<String, ComputedColumn>,
 }
 
 impl Table {
     /// Get a column by name.
     pub fn get_column(&self, name: &str) -> Option<&Column> {
         self.columns.get(name)
+    }
+
+    /// Get a computed column by name.
+    pub fn get_computed_column(&self, name: &str) -> Option<&ComputedColumn> {
+        self.computed_columns.get(name)
     }
 
     /// Check if the table has a column.
@@ -53,6 +67,15 @@ impl Table {
     pub fn is_readonly(&self) -> bool {
         !self.insertable && !self.updatable && !self.deletable
     }
+}
+
+/// A function of the table's row type, read as though it were a column.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ComputedColumn {
+    /// The function to call.
+    pub function: QualifiedIdentifier,
+    /// What it returns.
+    pub data_type: String,
 }
 
 /// A table column.
@@ -132,6 +155,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns: IndexMap::new(),
+            computed_columns: Default::default(),
         };
 
         let qi = table.qualified_identifier();

--- a/crates/postrust-core/src/schema_cache/table.rs
+++ b/crates/postrust-core/src/schema_cache/table.rs
@@ -16,6 +16,12 @@ pub struct Table {
     pub description: Option<String>,
     /// Whether this is a view (vs a table)
     pub is_view: bool,
+    /// Whether this is a partitioned table.
+    ///
+    /// It behaves as a table for reading and writing, but not for everything:
+    /// a system column such as `xmax` cannot be read back from one.
+    #[serde(default)]
+    pub is_partitioned: bool,
     /// Whether INSERT is allowed
     pub insertable: bool,
     /// Whether UPDATE is allowed
@@ -156,6 +162,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns: IndexMap::new(),
             computed_columns: Default::default(),
+            is_partitioned: false,
         };
 
         let qi = table.qualified_identifier();

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1857,6 +1857,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1867,6 +1867,7 @@ mod tests {
             relationships: HashMap::new(),
             routines: HashMap::new(),
             timezones: HashSet::new(),
+            media_handlers: HashMap::new(),
             pg_version: 150000,
         }
     }

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1401,6 +1401,9 @@ fn build_embed_expressions(
         let expression = plan
             .embed_expression(
                 parent_alias,
+                // GraphQL does not expose computed relationships, so the row
+                // expression is never read; the alias is the honest value.
+                &postrust_sql::escape_ident(parent_alias),
                 &child_alias,
                 &parts.join(", "),
                 max_rows,

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1407,6 +1407,7 @@ fn build_embed_expressions(
                 &child_alias,
                 &parts.join(", "),
                 max_rows,
+                0,
                 None,
                 None,
             )
@@ -1855,6 +1856,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 
@@ -1870,6 +1872,7 @@ mod tests {
             timezones: HashSet::new(),
             media_handlers: HashMap::new(),
             pg_version: 150000,
+            representations: Default::default(),
         }
     }
 

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1828,6 +1828,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -1843,6 +1844,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1408,6 +1408,7 @@ fn build_embed_expressions(
                 &parts.join(", "),
                 max_rows,
                 None,
+                None,
             )
             .map_err(|e| async_graphql::Error::new(e.to_string()))?;
 

--- a/crates/postrust-graphql/src/handler.rs
+++ b/crates/postrust-graphql/src/handler.rs
@@ -1399,7 +1399,13 @@ fn build_embed_expressions(
         }
 
         let expression = plan
-            .embed_expression(parent_alias, &child_alias, &parts.join(", "), max_rows)
+            .embed_expression(
+                parent_alias,
+                &child_alias,
+                &parts.join(", "),
+                max_rows,
+                None,
+            )
             .map_err(|e| async_graphql::Error::new(e.to_string()))?;
 
         expressions.push((rel.name.clone(), expression));

--- a/crates/postrust-graphql/src/input/mutation.rs
+++ b/crates/postrust-graphql/src/input/mutation.rs
@@ -354,6 +354,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 

--- a/crates/postrust-graphql/src/input/mutation.rs
+++ b/crates/postrust-graphql/src/input/mutation.rs
@@ -353,6 +353,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 

--- a/crates/postrust-graphql/src/input/mutation.rs
+++ b/crates/postrust-graphql/src/input/mutation.rs
@@ -295,6 +295,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -310,6 +311,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -325,6 +327,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 3,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -340,6 +343,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 4,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/resolver/mutation.rs
+++ b/crates/postrust-graphql/src/resolver/mutation.rs
@@ -421,6 +421,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 

--- a/crates/postrust-graphql/src/resolver/mutation.rs
+++ b/crates/postrust-graphql/src/resolver/mutation.rs
@@ -379,6 +379,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -394,6 +395,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -409,6 +411,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 3,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/resolver/mutation.rs
+++ b/crates/postrust-graphql/src/resolver/mutation.rs
@@ -314,6 +314,7 @@ pub fn build_insert_plan(args: &InsertArgs, table: &Table) -> MutatePlan {
         returning,
         pk_cols: table.pk_cols.clone(),
         apply_defaults: true,
+        reports_inserted: false,
     }
 }
 
@@ -422,6 +423,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 

--- a/crates/postrust-graphql/src/resolver/query.rs
+++ b/crates/postrust-graphql/src/resolver/query.rs
@@ -372,6 +372,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -387,6 +388,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -402,6 +404,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 3,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -417,6 +420,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 4,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/resolver/query.rs
+++ b/crates/postrust-graphql/src/resolver/query.rs
@@ -431,6 +431,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 

--- a/crates/postrust-graphql/src/resolver/query.rs
+++ b/crates/postrust-graphql/src/resolver/query.rs
@@ -84,6 +84,10 @@ impl QueryArgs {
         Range {
             offset: self.offset.unwrap_or(0),
             limit: self.limit,
+            // There is no `Range` header for a GraphQL argument to compete
+            // with, so whether the offset was written or defaulted decides
+            // nothing here.
+            offset_explicit: self.offset.is_some(),
         }
     }
 

--- a/crates/postrust-graphql/src/resolver/query.rs
+++ b/crates/postrust-graphql/src/resolver/query.rs
@@ -430,6 +430,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 

--- a/crates/postrust-graphql/src/schema/mod.rs
+++ b/crates/postrust-graphql/src/schema/mod.rs
@@ -656,6 +656,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 
@@ -955,6 +956,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns: indexmap::IndexMap::new(),
             computed_columns: Default::default(),
+            is_partitioned: false,
         };
         cache
             .tables

--- a/crates/postrust-graphql/src/schema/mod.rs
+++ b/crates/postrust-graphql/src/schema/mod.rs
@@ -655,6 +655,7 @@ mod tests {
             deletable,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 
@@ -678,6 +679,7 @@ mod tests {
             timezones: HashSet::new(),
             media_handlers: HashMap::new(),
             pg_version: 150000,
+            representations: Default::default(),
         }
     }
 
@@ -952,6 +954,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns: indexmap::IndexMap::new(),
+            computed_columns: Default::default(),
         };
         cache
             .tables

--- a/crates/postrust-graphql/src/schema/mod.rs
+++ b/crates/postrust-graphql/src/schema/mod.rs
@@ -627,6 +627,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -642,6 +643,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/schema/mod.rs
+++ b/crates/postrust-graphql/src/schema/mod.rs
@@ -676,6 +676,7 @@ mod tests {
             relationships: HashMap::new(),
             routines: HashMap::new(),
             timezones: HashSet::new(),
+            media_handlers: HashMap::new(),
             pg_version: 150000,
         }
     }

--- a/crates/postrust-graphql/src/schema/object.rs
+++ b/crates/postrust-graphql/src/schema/object.rs
@@ -156,6 +156,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: true,
                 position: 1,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -171,6 +172,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 2,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -186,6 +188,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 3,
+                domain_type: None,
             },
         );
         columns.insert(
@@ -201,6 +204,7 @@ mod tests {
                 enum_values: vec![],
                 is_pk: false,
                 position: 4,
+                domain_type: None,
             },
         );
 

--- a/crates/postrust-graphql/src/schema/object.rs
+++ b/crates/postrust-graphql/src/schema/object.rs
@@ -214,6 +214,7 @@ mod tests {
             deletable: true,
             pk_cols: vec!["id".into()],
             columns,
+            computed_columns: Default::default(),
         }
     }
 

--- a/crates/postrust-graphql/src/schema/object.rs
+++ b/crates/postrust-graphql/src/schema/object.rs
@@ -215,6 +215,7 @@ mod tests {
             pk_cols: vec!["id".into()],
             columns,
             computed_columns: Default::default(),
+            is_partitioned: false,
         }
     }
 

--- a/crates/postrust-lambda/src/main.rs
+++ b/crates/postrust-lambda/src/main.rs
@@ -45,7 +45,11 @@ async fn handler(event: Request) -> Result<Response<Body>, Error> {
     let schema_cache = SCHEMA_CACHE
         .get_or_init(|| async {
             info!("Loading schema cache");
-            let cache = postrust_core::SchemaCache::load(pool, &config.db_schemas)
+            let cache = postrust_core::SchemaCache::load_with_search_path(
+                pool,
+                &config.db_schemas,
+                &config.db_extra_search_path,
+            )
                 .await
                 .expect("Failed to load schema cache");
             Arc::new(RwLock::new(cache))

--- a/crates/postrust-lambda/src/main.rs
+++ b/crates/postrust-lambda/src/main.rs
@@ -50,8 +50,8 @@ async fn handler(event: Request) -> Result<Response<Body>, Error> {
                 &config.db_schemas,
                 &config.db_extra_search_path,
             )
-                .await
-                .expect("Failed to load schema cache");
+            .await
+            .expect("Failed to load schema cache");
             Arc::new(RwLock::new(cache))
         })
         .await;

--- a/crates/postrust-lambda/src/main.rs
+++ b/crates/postrust-lambda/src/main.rs
@@ -2,6 +2,11 @@
 //!
 //! Deploys Postrust as an AWS Lambda function.
 
+// As in `postrust-core` and `postrust-server`: `postrust_core::Error` is wide
+// on purpose, and boxing it would put an allocation on the error path of every
+// request to save a return slot on the success path.
+#![allow(clippy::result_large_err)]
+
 use lambda_http::{run, service_fn, Body, Error, Request, Response};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;

--- a/crates/postrust-response/src/headers.rs
+++ b/crates/postrust-response/src/headers.rs
@@ -106,9 +106,10 @@ pub fn build_response_headers(
     }
 
     // Preference-Applied
-    if let Some(applied) =
-        postrust_core::api_request::preferences::preference_applied(&request.preferences)
-    {
+    if let Some(applied) = postrust_core::api_request::preferences::preference_applied(
+        &request.preferences,
+        crate::preference_scope(request),
+    ) {
         if let Ok(v) = HeaderValue::from_str(&applied) {
             headers.insert(
                 http::header::HeaderName::from_static("preference-applied"),

--- a/crates/postrust-response/src/headers.rs
+++ b/crates/postrust-response/src/headers.rs
@@ -5,7 +5,11 @@ use postrust_core::ApiRequest;
 use std::fmt;
 
 /// Content-Range header value.
-#[derive(Clone, Debug)]
+///
+/// Rendered exactly as PostgREST's `contentRangeH`: no unit prefix, `*` for an
+/// unknown total, and `*` in place of the range itself when the response is
+/// empty. See `RangeQuery.hs` in the PostgREST source.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ContentRange {
     /// Start of range (0-based)
     pub start: i64,
@@ -13,42 +17,55 @@ pub struct ContentRange {
     pub end: i64,
     /// Total count (or None if unknown)
     pub total: Option<i64>,
-    /// Unit name
-    pub unit: String,
 }
 
 impl ContentRange {
     /// Create a new content range.
     pub fn new(start: i64, end: i64, total: Option<i64>) -> Self {
-        Self {
-            start,
-            end,
-            total,
-            unit: "items".to_string(),
-        }
+        Self { start, end, total }
     }
 
-    /// Create from offset, limit, and total.
-    pub fn from_pagination(
-        offset: i64,
-        limit: Option<i64>,
-        count: i64,
-        total: Option<i64>,
-    ) -> Self {
-        let end = match limit {
-            Some(l) => (offset + l - 1).min(offset + count - 1).max(offset),
-            None => offset + count - 1,
-        };
+    /// Build the range for a response that returned `count` rows starting at
+    /// `offset`.
+    ///
+    /// `count` is what the query actually returned, so any limit has already
+    /// been applied; an empty result yields `end < start`, which renders as
+    /// `*` rather than a zero-length range.
+    pub fn from_pagination(offset: i64, count: i64, total: Option<i64>) -> Self {
+        Self::new(offset, offset + count - 1, total)
+    }
 
-        Self::new(offset, end, total)
+    /// The HTTP status this range implies, following PostgREST's `rangeStatus`.
+    ///
+    /// Without a total there is nothing to be partial about, so the answer is
+    /// always 200.
+    pub fn status(&self) -> http::StatusCode {
+        match self.total {
+            None => http::StatusCode::OK,
+            Some(total) => {
+                if self.start > total {
+                    http::StatusCode::RANGE_NOT_SATISFIABLE
+                } else if (1 + self.end - self.start) < total {
+                    http::StatusCode::PARTIAL_CONTENT
+                } else {
+                    http::StatusCode::OK
+                }
+            }
+        }
     }
 }
 
 impl fmt::Display for ContentRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // An empty result, or a known-zero total, reports `*` for the range.
+        if self.total == Some(0) || self.start > self.end {
+            write!(f, "*")?;
+        } else {
+            write!(f, "{}-{}", self.start, self.end)?;
+        }
         match self.total {
-            Some(total) => write!(f, "{} {}-{}/{}", self.unit, self.start, self.end, total),
-            None => write!(f, "{} {}-{}/*", self.unit, self.start, self.end),
+            Some(total) => write!(f, "/{total}"),
+            None => write!(f, "/*"),
         }
     }
 }
@@ -124,24 +141,54 @@ mod tests {
 
     #[test]
     fn test_content_range_display() {
-        let range = ContentRange::new(0, 9, Some(100));
-        assert_eq!(range.to_string(), "items 0-9/100");
+        // No unit prefix, and `*` stands in for an unknown total.
+        assert_eq!(ContentRange::new(0, 9, Some(100)).to_string(), "0-9/100");
+        assert_eq!(ContentRange::new(10, 19, None).to_string(), "10-19/*");
+    }
 
-        let range = ContentRange::new(10, 19, None);
-        assert_eq!(range.to_string(), "items 10-19/*");
+    #[test]
+    fn test_content_range_display_empty() {
+        // An empty result reports `*` for the range, not a zero-length one.
+        assert_eq!(ContentRange::from_pagination(0, 0, None).to_string(), "*/*");
+        assert_eq!(
+            ContentRange::from_pagination(0, 0, Some(0)).to_string(),
+            "*/0"
+        );
     }
 
     #[test]
     fn test_content_range_from_pagination() {
-        // First page of 10
-        let range = ContentRange::from_pagination(0, Some(10), 10, Some(100));
-        assert_eq!(range.start, 0);
-        assert_eq!(range.end, 9);
+        // A full page: `count` is what came back, so the limit is already applied.
+        let range = ContentRange::from_pagination(0, 10, Some(100));
+        assert_eq!((range.start, range.end), (0, 9));
 
-        // Partial last page
-        let range = ContentRange::from_pagination(90, Some(10), 5, Some(95));
-        assert_eq!(range.start, 90);
-        assert_eq!(range.end, 94);
+        // Partial last page.
+        let range = ContentRange::from_pagination(90, 5, Some(95));
+        assert_eq!((range.start, range.end), (90, 94));
+    }
+
+    #[test]
+    fn test_content_range_status() {
+        // Without a total there is nothing to be partial about.
+        assert_eq!(
+            ContentRange::from_pagination(0, 10, None).status(),
+            http::StatusCode::OK
+        );
+        // A window narrower than the total is partial content.
+        assert_eq!(
+            ContentRange::from_pagination(0, 10, Some(100)).status(),
+            http::StatusCode::PARTIAL_CONTENT
+        );
+        // The whole set is a plain 200.
+        assert_eq!(
+            ContentRange::from_pagination(0, 15, Some(15)).status(),
+            http::StatusCode::OK
+        );
+        // Asking past the end is not satisfiable.
+        assert_eq!(
+            ContentRange::from_pagination(50, 0, Some(15)).status(),
+            http::StatusCode::RANGE_NOT_SATISFIABLE
+        );
     }
 
     #[test]

--- a/crates/postrust-response/src/headers.rs
+++ b/crates/postrust-response/src/headers.rs
@@ -71,6 +71,24 @@ impl fmt::Display for ContentRange {
 }
 
 /// Build response headers based on request and result.
+///
+/// # Deprecated
+///
+/// Nothing in this workspace calls this. The headers a response actually
+/// carries are built by `add_common_headers`, and the two have already drifted:
+/// `Allow` is sent for an OPTIONS by that path and not by this one, and the
+/// `Content-Range` a rendered media type reports is likewise decided there.
+/// Keeping a second implementation means every header fix has to be made
+/// twice, and the one that is missed is the one nobody is calling.
+///
+/// Deprecated rather than removed because this crate is published to
+/// crates.io, so the name is public API somebody outside this repository may
+/// be using. It will be removed in a future breaking release.
+#[deprecated(
+    since = "0.4.0",
+    note = "unused within the workspace and drifted from the live header path; \
+            responses are built by postrust_response::format_response"
+)]
 pub fn build_response_headers(
     request: &ApiRequest,
     content_type: &str,

--- a/crates/postrust-response/src/headers.rs
+++ b/crates/postrust-response/src/headers.rs
@@ -121,19 +121,37 @@ pub fn build_response_headers(
     headers
 }
 
-/// Parse GUC headers from database response.
-#[allow(dead_code)] // Reserved for GUC-driven response headers (`response.headers`); not yet wired.
-pub fn parse_guc_headers(guc_headers: &str) -> Vec<(String, String)> {
-    // Format: "header1: value1\nheader2: value2"
-    guc_headers
-        .lines()
-        .filter_map(|line| {
-            let mut parts = line.splitn(2, ':');
-            let key = parts.next()?.trim().to_string();
-            let value = parts.next()?.trim().to_string();
-            Some((key, value))
-        })
-        .collect()
+/// Parse the `response.headers` setting a function may have set.
+///
+/// PostgREST's shape: a JSON array of objects, each with exactly one key and
+/// a string value. An array rather than one object because a response may
+/// carry the same header twice -- two `Set-Cookie`s, say -- which an object
+/// cannot express.
+///
+/// `Err` when it is anything else, which is a fault in the function rather
+/// than in the request and is reported as one.
+pub fn parse_guc_headers(guc_headers: &str) -> Result<Vec<(String, String)>, ()> {
+    let Ok(serde_json::Value::Array(entries)) = serde_json::from_str(guc_headers) else {
+        return Err(());
+    };
+
+    let mut headers = Vec::with_capacity(entries.len());
+    for entry in entries {
+        let serde_json::Value::Object(fields) = entry else {
+            return Err(());
+        };
+        if fields.len() != 1 {
+            return Err(());
+        }
+        for (name, value) in fields {
+            let serde_json::Value::String(value) = value else {
+                return Err(());
+            };
+            headers.push((name, value));
+        }
+    }
+
+    Ok(headers)
 }
 
 #[cfg(test)]
@@ -194,11 +212,35 @@ mod tests {
 
     #[test]
     fn test_parse_guc_headers() {
-        let guc = "X-Custom-Header: value1\nX-Another: value2";
-        let headers = parse_guc_headers(guc);
+        let guc = r#"[{"X-Custom-Header": "value1"}, {"X-Another": "value2"}]"#;
+        let headers = parse_guc_headers(guc).unwrap();
 
         assert_eq!(headers.len(), 2);
         assert_eq!(headers[0], ("X-Custom-Header".into(), "value1".into()));
         assert_eq!(headers[1], ("X-Another".into(), "value2".into()));
+    }
+
+    /// The same header twice is the reason it is an array.
+    #[test]
+    fn guc_headers_may_repeat_a_name() {
+        let guc = r#"[{"Set-Cookie": "a=1"}, {"Set-Cookie": "b=2"}]"#;
+        let headers = parse_guc_headers(guc).unwrap();
+
+        assert_eq!(headers.len(), 2);
+        assert!(headers.iter().all(|(name, _)| name == "Set-Cookie"));
+    }
+
+    /// Anything else is a fault in the function that set it.
+    #[test]
+    fn guc_headers_must_be_single_key_objects_of_strings() {
+        for bad in [
+            r#"{"X": "y"}"#,
+            r#"[{"X": "y", "Z": "w"}]"#,
+            r#"[{"X": 1}]"#,
+            r#"["X: y"]"#,
+            "not json",
+        ] {
+            assert!(parse_guc_headers(bad).is_err(), "accepted {bad}");
+        }
     }
 }

--- a/crates/postrust-response/src/headers.rs
+++ b/crates/postrust-response/src/headers.rs
@@ -130,28 +130,28 @@ pub fn build_response_headers(
 ///
 /// `Err` when it is anything else, which is a fault in the function rather
 /// than in the request and is reported as one.
-pub fn parse_guc_headers(guc_headers: &str) -> Result<Vec<(String, String)>, ()> {
+pub fn parse_guc_headers(guc_headers: &str) -> Option<Vec<(String, String)>> {
     let Ok(serde_json::Value::Array(entries)) = serde_json::from_str(guc_headers) else {
-        return Err(());
+        return None;
     };
 
     let mut headers = Vec::with_capacity(entries.len());
     for entry in entries {
         let serde_json::Value::Object(fields) = entry else {
-            return Err(());
+            return None;
         };
         if fields.len() != 1 {
-            return Err(());
+            return None;
         }
         for (name, value) in fields {
             let serde_json::Value::String(value) = value else {
-                return Err(());
+                return None;
             };
             headers.push((name, value));
         }
     }
 
-    Ok(headers)
+    Some(headers)
 }
 
 #[cfg(test)]
@@ -240,7 +240,7 @@ mod tests {
             r#"["X: y"]"#,
             "not json",
         ] {
-            assert!(parse_guc_headers(bad).is_err(), "accepted {bad}");
+            assert!(parse_guc_headers(bad).is_none(), "accepted {bad}");
         }
     }
 }

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -235,7 +235,7 @@ fn add_common_headers(response: &mut Response, request: &ApiRequest, result: &Qu
     // A function's own headers, added rather than replaced: the shape of the
     // setting is an array precisely so that a name may repeat.
     if let Some(guc) = &result.guc_headers {
-        if let Ok(headers) = crate::headers::parse_guc_headers(guc) {
+        if let Some(headers) = crate::headers::parse_guc_headers(guc) {
             for (name, value) in headers {
                 response.append_header(&name, &value);
             }

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -103,8 +103,17 @@ pub fn format_response(
     // A media type the schema renders itself: the database produced the whole
     // payload, so there is nothing here to serialise.
     if let Some((media_type, body)) = &result.raw_body {
-        let mut response = Response::new(result.status, body.clone().into_bytes());
-        response.set_content_type(media_type);
+        let mut response = Response::new(result.status, body.clone());
+        // Every media type the server names is UTF-8 except the ones that are
+        // not text at all: a stream of bytes has no encoding, and one the
+        // schema named itself is not this side's to characterise.
+        let charset = match media_type.as_str() {
+            "application/octet-stream" => "",
+            already if already.contains("charset=") => "",
+            text if text.starts_with("text/") || text.contains("json") => "; charset=utf-8",
+            _ => "",
+        };
+        response.set_content_type(&format!("{}{}", media_type, charset));
         if let Some(range) = &result.content_range {
             response.set_header("Content-Range", &range.to_string());
         }
@@ -371,7 +380,7 @@ pub struct QueryResult {
     /// Set when the request asked for a media type the schema declares its own
     /// renderer for. The value is the whole payload, so it replaces the usual
     /// JSON rendering rather than being wrapped in it.
-    pub raw_body: Option<(String, String)>,
+    pub raw_body: Option<(String, Vec<u8>)>,
 }
 
 /// Response formatting error.

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -169,6 +169,32 @@ pub fn format_response(
     }
 }
 
+/// Which preferences this request could honour.
+pub(crate) fn preference_scope(
+    request: &ApiRequest,
+) -> postrust_core::api_request::preferences::PreferenceScope {
+    use postrust_core::api_request::preferences::PreferenceScope;
+    use postrust_core::api_request::{Action, DbAction, Mutation};
+
+    let Action::Db(action) = &request.action else {
+        return PreferenceScope::read();
+    };
+
+    match action {
+        DbAction::RelationMut { mutation, .. } => PreferenceScope {
+            resolution: matches!(mutation, Mutation::Create),
+            representation: true,
+            missing: matches!(mutation, Mutation::Create | Mutation::Update),
+            max_affected: matches!(mutation, Mutation::Update | Mutation::Delete),
+        },
+        DbAction::Routine { .. } => PreferenceScope {
+            max_affected: true,
+            ..PreferenceScope::read()
+        },
+        _ => PreferenceScope::read(),
+    }
+}
+
 /// Remove every key whose value is null, at every depth.
 ///
 /// `Accept: application/vnd.pgrst.array+json;nulls=stripped` asks for a body
@@ -203,9 +229,10 @@ fn add_common_headers(response: &mut Response, request: &ApiRequest, result: &Qu
     }
 
     // Preference-Applied
-    if let Some(applied) =
-        postrust_core::api_request::preferences::preference_applied(&request.preferences)
-    {
+    if let Some(applied) = postrust_core::api_request::preferences::preference_applied(
+        &request.preferences,
+        preference_scope(request),
+    ) {
         response.set_header("preference-applied", &applied);
     }
 

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -114,9 +114,11 @@ pub fn format_response(
             _ => "",
         };
         response.set_content_type(&format!("{}{}", media_type, charset));
-        if let Some(range) = &result.content_range {
-            response.set_header("Content-Range", &range.to_string());
-        }
+        // The body being rendered by something other than this side does not
+        // change what else the response has to say: where the created row is,
+        // which preference was honoured, what the function set. Only the body
+        // was somebody else's to write.
+        add_common_headers(&mut response, request, result);
         return Ok(response);
     }
 

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -83,6 +83,15 @@ pub fn format_response(
         .cloned()
         .unwrap_or(MediaType::ApplicationJson);
 
+    // A mutation the caller wanted no representation from sends no body at
+    // all -- not an empty JSON array, which is what an empty row set would
+    // otherwise render as. The headers still apply.
+    if result.omit_body {
+        let mut response = Response::new(result.status, bytes::Bytes::new());
+        add_common_headers(&mut response, request, result);
+        return Ok(response);
+    }
+
     match &media_type {
         MediaType::ApplicationJson => {
             let body = if result.singular {
@@ -238,6 +247,12 @@ pub struct QueryResult {
     pub guc_headers: Option<String>,
     /// Custom status from GUC
     pub guc_status: Option<String>,
+    /// Whether to send no body at all.
+    ///
+    /// Set for a mutation the caller asked no representation from: the
+    /// response carries headers and a status but no payload, where an empty
+    /// row set would otherwise render as `[]`.
+    pub omit_body: bool,
     /// Whether the result should be rendered as a single (un-arrayed) value.
     ///
     /// Set for PostgREST-compatibility RPC responses where the underlying

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -121,6 +121,16 @@ pub fn format_response(
     }
 
     if result.omit_body {
+        // Asking for a single object is a constraint on the statement, not on
+        // the payload: a caller that named one row and changed five has not
+        // had its request answered, however little of it it wanted back.
+        if let MediaType::SingularJson { nullable, .. } = &media_type {
+            match (result.affected, nullable) {
+                (1, _) | (0, true) => {}
+                (0, false) => return Err(FormatError::NotFound),
+                _ => return Err(FormatError::MultipleRows),
+            }
+        }
         let mut response = Response::new(result.status, bytes::Bytes::new());
         add_common_headers(&mut response, request, result);
         return Ok(response);
@@ -369,6 +379,13 @@ pub struct QueryResult {
     /// response carries headers and a status but no payload, where an empty
     /// row set would otherwise render as `[]`.
     pub omit_body: bool,
+    /// How many rows the statement affected.
+    ///
+    /// Distinct from `rows.len()`, which is empty when no representation was
+    /// asked for. How many rows a write touched is a fact about the write, and
+    /// a caller that asked for exactly one object is owed an answer about it
+    /// whether or not it wanted the object back.
+    pub affected: usize,
     /// Whether the result should be rendered as a single (un-arrayed) value.
     ///
     /// Set for PostgREST-compatibility RPC responses where the underlying

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -146,7 +146,7 @@ pub fn format_response(
             add_common_headers(&mut response, request, result);
             Ok(response)
         }
-        _ => {
+        other => {
             // Default to JSON (covers `*/*`, e.g. a default curl request).
             let body = if result.singular {
                 format_singular_or_null(&result.rows)?
@@ -154,7 +154,15 @@ pub fn format_response(
                 format_json_response(&result.rows)?
             };
             let mut response = Response::new(result.status, body);
-            response.set_content_type("application/json; charset=utf-8");
+            // The body is JSON either way, but a client that asked for one of
+            // PostgREST's own JSON media types is told it got that: the type
+            // is how it knows the shape it negotiated was honoured.
+            let content_type = match other {
+                MediaType::ArrayJson { .. } => "application/vnd.pgrst.array+json; charset=utf-8",
+                MediaType::OpenApi => "application/openapi+json; charset=utf-8",
+                _ => "application/json; charset=utf-8",
+            };
+            response.set_content_type(content_type);
             add_common_headers(&mut response, request, result);
             Ok(response)
         }

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -3,6 +3,7 @@
 //! Handles content negotiation and response formatting for JSON, CSV, and other formats.
 
 mod headers;
+pub use headers::parse_guc_headers;
 mod json;
 
 pub use headers::{build_response_headers, ContentRange};
@@ -47,6 +48,19 @@ impl Response {
     }
 
     /// Set a header.
+    /// Add a header without replacing one of the same name.
+    ///
+    /// A response may legitimately carry two `Set-Cookie`s, which `set_header`
+    /// -- being a replace -- cannot express.
+    pub fn append_header(&mut self, name: &str, value: &str) {
+        if let (Ok(name), Ok(value)) = (
+            http::header::HeaderName::from_bytes(name.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            self.headers.append(name, value);
+        }
+    }
+
     pub fn set_header(&mut self, name: &str, value: &str) {
         if let Ok(v) = HeaderValue::from_str(value) {
             self.headers.insert(
@@ -218,6 +232,16 @@ fn strip_nulls(value: serde_json::Value) -> serde_json::Value {
 
 /// Add common response headers.
 fn add_common_headers(response: &mut Response, request: &ApiRequest, result: &QueryResult) {
+    // A function's own headers, added rather than replaced: the shape of the
+    // setting is an array precisely so that a name may repeat.
+    if let Some(guc) = &result.guc_headers {
+        if let Ok(headers) = crate::headers::parse_guc_headers(guc) {
+            for (name, value) in headers {
+                response.append_header(&name, &value);
+            }
+        }
+    }
+
     // Content-Range
     if let Some(range) = &result.content_range {
         response.set_content_range(range);

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -6,7 +6,11 @@ mod headers;
 pub use headers::parse_guc_headers;
 mod json;
 
-pub use headers::{build_response_headers, ContentRange};
+pub use headers::ContentRange;
+// Re-exported for the crates.io consumers the name is public API for. Allowed
+// here so that the re-export itself does not trip the deprecation it carries.
+#[allow(deprecated)]
+pub use headers::build_response_headers;
 pub use json::format_json_response;
 
 use http::{HeaderMap, HeaderValue, StatusCode};
@@ -273,6 +277,11 @@ fn add_common_headers(response: &mut Response, request: &ApiRequest, result: &Qu
         response.set_location(location);
     }
 
+    // Allow (for OPTIONS)
+    if let Some(allow) = &result.allow {
+        response.set_header("allow", allow);
+    }
+
     // Preference-Applied
     if let Some(applied) = postrust_core::api_request::preferences::preference_applied(
         &request.preferences,
@@ -371,6 +380,11 @@ pub struct QueryResult {
     pub content_range: Option<ContentRange>,
     /// Location header (for POST)
     pub location: Option<String>,
+    /// The methods an OPTIONS request is answering about.
+    ///
+    /// Only an OPTIONS sets this; every other response leaves it `None` and
+    /// sends no `Allow`, since the question was not asked.
+    pub allow: Option<String>,
     /// Custom headers from GUC
     pub guc_headers: Option<String>,
     /// Custom status from GUC

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -86,6 +86,17 @@ pub fn format_response(
     // A mutation the caller wanted no representation from sends no body at
     // all -- not an empty JSON array, which is what an empty row set would
     // otherwise render as. The headers still apply.
+    // A media type the schema renders itself: the database produced the whole
+    // payload, so there is nothing here to serialise.
+    if let Some((media_type, body)) = &result.raw_body {
+        let mut response = Response::new(result.status, body.clone().into_bytes());
+        response.set_content_type(media_type);
+        if let Some(range) = &result.content_range {
+            response.set_header("Content-Range", &range.to_string());
+        }
+        return Ok(response);
+    }
+
     if result.omit_body {
         let mut response = Response::new(result.status, bytes::Bytes::new());
         add_common_headers(&mut response, request, result);
@@ -259,6 +270,12 @@ pub struct QueryResult {
     /// function is not set-returning: the bare object/scalar is returned
     /// instead of a one-element array.
     pub singular: bool,
+    /// A body the database rendered in full, with the media type it is in.
+    ///
+    /// Set when the request asked for a media type the schema declares its own
+    /// renderer for. The value is the whole payload, so it replaces the usual
+    /// JSON rendering rather than being wrapped in it.
+    pub raw_body: Option<(String, String)>,
 }
 
 /// Response formatting error.

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -103,6 +103,22 @@ pub fn format_response(
         return Ok(response);
     }
 
+    // `;nulls=stripped` asks for keys with a null value to be left out
+    // entirely, rather than sent as nulls.
+    let rows = match &media_type {
+        MediaType::SingularJson {
+            strip_nulls: true, ..
+        }
+        | MediaType::ArrayJson {
+            strip_nulls: true, ..
+        } => result.rows.iter().cloned().map(strip_nulls).collect(),
+        _ => result.rows.clone(),
+    };
+    let result = &QueryResult {
+        rows,
+        ..result.clone()
+    };
+
     match &media_type {
         MediaType::ApplicationJson => {
             let body = if result.singular {
@@ -123,7 +139,7 @@ pub fn format_response(
             add_common_headers(&mut response, request, result);
             Ok(response)
         }
-        MediaType::SingularJson { nullable } => {
+        MediaType::SingularJson { nullable, .. } => {
             let body = format_singular_json(&result.rows, *nullable)?;
             let mut response = Response::new(result.status, body);
             response.set_content_type("application/vnd.pgrst.object+json; charset=utf-8");
@@ -142,6 +158,27 @@ pub fn format_response(
             add_common_headers(&mut response, request, result);
             Ok(response)
         }
+    }
+}
+
+/// Remove every key whose value is null, at every depth.
+///
+/// `Accept: application/vnd.pgrst.array+json;nulls=stripped` asks for a body
+/// carrying only what a row actually has, which for a wide table with few
+/// populated columns is most of the response.
+fn strip_nulls(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(fields) => serde_json::Value::Object(
+            fields
+                .into_iter()
+                .filter(|(_, value)| !value.is_null())
+                .map(|(key, value)| (key, strip_nulls(value)))
+                .collect(),
+        ),
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.into_iter().map(strip_nulls).collect())
+        }
+        other => other,
     }
 }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -34,9 +34,11 @@ pub async fn handle_request(State(state): State<Arc<AppState>>, request: Request
 
     debug!("{} {}", method, path);
 
+    let verbatim_db_errors = state.config.compat_mode;
+
     match process_request(state, request).await {
         Ok(response) => response.into_response(),
-        Err(e) => error_response(e).into_response(),
+        Err(e) => error_response(e, verbatim_db_errors).into_response(),
     }
 }
 
@@ -141,7 +143,7 @@ async fn execute_plan(
             // been serialised as JSON.
             let media_handler = {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request).and_then(|qi| {
+                read_target(api_request, &schema_cache).and_then(|qi| {
                     api_request.accept_media_types.iter().find_map(|media| {
                         schema_cache
                             .media_handler(&api_request.schema, media.content_type(), &qi)
@@ -226,7 +228,11 @@ async fn execute_plan(
             // two-query path, which can: taking the single-query path for the
             // plain relations would embed those and drop the spread, since the
             // two-query path only runs when the first produced nothing.
-            let embed_level = match read_target(api_request) {
+            let embed_parent = {
+                let schema_cache = state.schema_cache().await;
+                read_target(api_request, &schema_cache)
+            };
+            let embed_level = match embed_parent {
                 Some(parent_qi)
                     if api_request.query_params.select.iter().any(|item| {
                         matches!(
@@ -311,7 +317,7 @@ async fn execute_plan(
             // runs when none matched.
             let geojson_column = if media_handler.is_none() {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request)
+                read_target(api_request, &schema_cache)
                     .filter(|_| {
                         api_request
                             .accept_media_types
@@ -519,8 +525,11 @@ async fn execute_plan(
             // Embeds already came back with the parent query when the SELECT
             // list carried relations. This path remains for anything the
             // single-query form did not handle.
-            if let Some(parent_qi) =
-                read_target(api_request).filter(|_| embed_level.expressions.is_empty())
+            let two_query_parent = {
+                let schema_cache = state.schema_cache().await;
+                read_target(api_request, &schema_cache)
+            };
+            if let Some(parent_qi) = two_query_parent.filter(|_| embed_level.expressions.is_empty())
             {
                 let schema_cache = state.schema_cache().await;
                 embed_relations(
@@ -665,11 +674,17 @@ fn unwrap_rpc_rows(
 /// The table a read targets, if the request is a read.
 fn read_target(
     api_request: &postrust_core::api_request::ApiRequest,
+    schema_cache: &postrust_core::SchemaCache,
 ) -> Option<postrust_core::api_request::QualifiedIdentifier> {
     use postrust_core::api_request::{Action, DbAction};
 
     match &api_request.action {
         Action::Db(DbAction::RelationRead { qi, .. }) => Some(qi.clone()),
+        // A function returning a table's rows embeds, and renders, exactly as
+        // that table does.
+        Action::Db(DbAction::Routine { qi, .. }) => schema_cache
+            .routine_returned_table(qi)
+            .map(|table| table.qualified_identifier()),
         _ => None,
     }
 }
@@ -776,7 +791,7 @@ fn add_embed_join_columns(
 ) -> Result<Vec<String>, postrust_core::Error> {
     use postrust_core::api_request::{Field, SelectItem};
 
-    let Some(parent_qi) = read_target(api_request) else {
+    let Some(parent_qi) = read_target(api_request, schema_cache) else {
         return Ok(Vec::new());
     };
 
@@ -1428,7 +1443,16 @@ fn build_response(response: PgrstResponse) -> Response {
 ///
 /// In production mode (PGRST_DEBUG=false or unset), sensitive error details
 /// are hidden to prevent information leakage.
-fn error_response(error: postrust_core::Error) -> Response {
+/// Build the response for a failed request.
+///
+/// `verbatim_db_errors` passes a database failure through as PostgreSQL
+/// reported it -- its SQLSTATE, message, detail and hint -- which is what
+/// PostgREST does and what a client written against PostgREST branches on.
+/// It is off unless compatibility mode is on, because those fields describe
+/// the schema rather than the request: a constraint's name, a column that was
+/// not selected, the text of a failing query. Everything else is reported the
+/// same either way.
+fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Response {
     let status = error.status_code();
 
     // Check if debug mode is enabled
@@ -1439,6 +1463,14 @@ fn error_response(error: postrust_core::Error) -> Response {
     let body = if debug_mode {
         // Full error details in debug mode
         serde_json::to_vec(&error.to_json()).unwrap_or_default()
+    } else if let (true, postrust_core::Error::Database(db)) = (verbatim_db_errors, &error) {
+        serde_json::to_vec(&serde_json::json!({
+            "code": db.code,
+            "message": db.message,
+            "details": db.details,
+            "hint": db.hint,
+        }))
+        .unwrap_or_default()
     } else {
         // Sanitized error in production
         let sanitized = serde_json::json!({

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -2310,53 +2310,6 @@ impl EmbedFilters<'_> {
 
     /// The `WHERE` fragment for one embedded resource, or `None` if unfiltered.
     #[allow(clippy::result_large_err)] // consistent with the crate's error type
-    /// The `ORDER BY` an embedded resource was asked for, if any.
-    ///
-    /// `clients.order=name.desc` orders the rows inside the embed, which is a
-    /// property of the child's own subselect rather than of the parent.
-    fn order_for(&self, path: &[String], names: &[String]) -> Option<String> {
-        let terms: Vec<String> = self
-            .orders
-            .iter()
-            .filter(|(p, _)| p.as_slice() == path || p.as_slice() == names)
-            .flat_map(|(_, terms)| terms.iter())
-            .map(|term| {
-                use postrust_core::api_request::{OrderDirection, OrderNulls, OrderTerm};
-                let (field, direction, nulls) = match term {
-                    OrderTerm::Field {
-                        field,
-                        direction,
-                        nulls,
-                    }
-                    | OrderTerm::Relation {
-                        field,
-                        direction,
-                        nulls,
-                        ..
-                    } => (field, direction, nulls),
-                };
-
-                let mut rendered = postrust_sql::escape_ident(&field.name);
-                match direction {
-                    Some(OrderDirection::Desc) => rendered.push_str(" DESC"),
-                    Some(OrderDirection::Asc) => rendered.push_str(" ASC"),
-                    None => {}
-                }
-                match nulls {
-                    Some(OrderNulls::First) => rendered.push_str(" NULLS FIRST"),
-                    Some(OrderNulls::Last) => rendered.push_str(" NULLS LAST"),
-                    None => {}
-                }
-                rendered
-            })
-            .collect();
-
-        match terms.is_empty() {
-            true => None,
-            false => Some(terms.join(", ")),
-        }
-    }
-
     /// The row window an embedded resource was asked for.
     ///
     /// The server's own cap still applies, so an embed cannot be asked for
@@ -2750,6 +2703,150 @@ fn build_embed_orders(
     Ok(orders)
 }
 
+/// The relationship an `order=relation(column)` term names, ready to order by.
+///
+/// Resolving it is the same work whether the term sits at the top level or
+/// inside an embed, and it is the same mistake to skip: a relation term
+/// rendered as a bare column name orders by a column of the wrong table --
+/// silently, where the parent happens to have a column of that name, and with
+/// `column "cost" does not exist` where it does not.
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
+fn related_order_target(
+    schema_cache: &postrust_core::SchemaCache,
+    parent_qi: &postrust_core::api_request::QualifiedIdentifier,
+    select: &[postrust_core::api_request::SelectItem],
+    relation: &str,
+    ctx: &mut EmbedFilters<'_>,
+) -> Result<
+    (
+        postrust_core::embed::EmbedPlan,
+        String,
+        postrust_core::api_request::QualifiedIdentifier,
+    ),
+    postrust_core::Error,
+> {
+    // `order=` names a resource this request embedded, by the name the
+    // response gives it -- so `pros:projects(*)` is ordered on as `pros`, and
+    // the table it came from is what the relationship is looked up by. A name
+    // the selection does not carry is not an embedded resource here, whether
+    // or not the schema has a table by that name.
+    let embedded = embedded_by_name(select, relation)
+        .ok_or_else(|| postrust_core::Error::NotAnEmbeddedResource(relation.to_string()))?;
+
+    let rel = schema_cache
+        .find_relationship(parent_qi, embedded.0, embedded.1, &parent_qi.schema)?
+        .ok_or_else(|| {
+            schema_cache.relationship_not_found(parent_qi, embedded.0, embedded.1, &parent_qi.schema)
+        })?;
+
+    // A resource that yields many rows per parent has no single value to order
+    // on, so there is nothing the request could mean.
+    if !rel.is_to_one() {
+        return Err(postrust_core::Error::RelatedOrderNotPossible {
+            origin: parent_qi.name.clone(),
+            relation: relation.to_string(),
+        });
+    }
+
+    let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
+    let child_alias = ctx.next_alias();
+    let child_qi = postrust_core::api_request::QualifiedIdentifier::new(
+        &plan.foreign_schema,
+        &plan.foreign_table,
+    );
+
+    Ok((plan, child_alias, child_qi))
+}
+
+/// The `ORDER BY` an embedded resource was asked for, if any.
+///
+/// `clients.order=name.desc` orders the rows inside the embed, which is a
+/// property of the child's own subselect rather than of the parent.
+/// `tasks.order=projects(id).desc` orders them by a column of a table the
+/// child embeds in turn -- so it is resolved against the child, and rendered
+/// as the same correlated subselect the top level uses.
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
+#[allow(clippy::too_many_arguments)] // each names one part of where the embed sits
+fn embed_order_sql(
+    schema_cache: &postrust_core::SchemaCache,
+    child_qi: &postrust_core::api_request::QualifiedIdentifier,
+    child_select: &[postrust_core::api_request::SelectItem],
+    child_alias: &str,
+    ctx: &mut EmbedFilters<'_>,
+    path: &[String],
+    names: &[String],
+) -> Result<Option<String>, postrust_core::Error> {
+    use postrust_core::api_request::{OrderDirection, OrderNulls, OrderTerm};
+
+    let terms: Vec<OrderTerm> = ctx
+        .orders
+        .iter()
+        .filter(|(p, _)| p.as_slice() == path || p.as_slice() == names)
+        .flat_map(|(_, terms)| terms.iter().cloned())
+        .collect();
+
+    if terms.is_empty() {
+        return Ok(None);
+    }
+
+    let mut rendered = Vec::with_capacity(terms.len());
+    for term in &terms {
+        let (field, direction, nulls) = match term {
+            OrderTerm::Field {
+                field,
+                direction,
+                nulls,
+            }
+            | OrderTerm::Relation {
+                field,
+                direction,
+                nulls,
+                ..
+            } => (field, direction, nulls),
+        };
+
+        let mut sql = match term {
+            OrderTerm::Field { .. } => postrust_sql::escape_ident(&field.name),
+            OrderTerm::Relation { relation, .. } => {
+                let (plan, grandchild_alias, grandchild_qi) =
+                    related_order_target(schema_cache, child_qi, child_select, relation, ctx)?;
+
+                // The column belongs to the related table, so its type is read
+                // from there rather than from the child.
+                let pg_type = schema_cache
+                    .get_table(&grandchild_qi)
+                    .and_then(|table| table.get_column(&field.name))
+                    .map(|column| column.data_type.clone())
+                    .unwrap_or_default();
+                let coercible = postrust_core::plan::CoercibleField::from_field(field, &pg_type);
+                let column = postrust_core::query::QueryBuilder::qualified_column_sql(
+                    Some(&grandchild_alias),
+                    &coercible,
+                );
+
+                // The child is a real table alias at this level, so its alias
+                // is also the expression for its whole row.
+                plan.order_expression(child_alias, child_alias, &grandchild_alias, &column)
+            }
+        };
+
+        match direction {
+            Some(OrderDirection::Desc) => sql.push_str(" DESC"),
+            Some(OrderDirection::Asc) => sql.push_str(" ASC"),
+            None => {}
+        }
+        match nulls {
+            Some(OrderNulls::First) => sql.push_str(" NULLS FIRST"),
+            Some(OrderNulls::Last) => sql.push_str(" NULLS LAST"),
+            None => {}
+        }
+
+        rendered.push(sql);
+    }
+
+    Ok(Some(rendered.join(", ")))
+}
+
 #[allow(clippy::result_large_err)] // consistent with the crate's error type
 #[allow(clippy::too_many_arguments)] // each names one part of where the embed sits
 fn build_embed_expressions(
@@ -2925,7 +3022,15 @@ fn build_embed_expressions(
         }
 
         let inner_select = parts.join(", ");
-        let child_order = ctx.order_for(&child_path, &child_names);
+        let child_order = embed_order_sql(
+            schema_cache,
+            &child_qi,
+            child_select,
+            &child_alias,
+            ctx,
+            &child_path,
+            &child_names,
+        )?;
         let (child_limit, child_offset) = ctx.range_for(&child_path, &child_names);
         let expression = plan.embed_expression(
             parent_alias,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -394,7 +394,7 @@ async fn execute_plan(
             // been serialised as JSON.
             let media_handler = {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request, &schema_cache).and_then(|qi| {
+                read_target(api_request, Some(db_plan), &schema_cache).and_then(|qi| {
                     api_request.accept_media_types.iter().find_map(|media| {
                         schema_cache
                             .media_handler(&api_request.schema, media.content_type(), &qi)
@@ -572,7 +572,7 @@ async fn execute_plan(
             // two-query path only runs when the first produced nothing.
             let embed_parent = {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request, &schema_cache)
+                read_target(api_request, Some(db_plan), &schema_cache)
             };
             let embed_level = match embed_parent.clone() {
                 Some(parent_qi)
@@ -757,7 +757,7 @@ async fn execute_plan(
             // runs when none matched.
             let geojson_column = if media_handler.is_none() {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request, &schema_cache)
+                read_target(api_request, Some(db_plan), &schema_cache)
                     .filter(|_| {
                         api_request
                             .accept_media_types
@@ -986,7 +986,7 @@ async fn execute_plan(
             // single-query form did not handle.
             let two_query_parent = {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request, &schema_cache)
+                read_target(api_request, Some(db_plan), &schema_cache)
             };
             if let Some(parent_qi) = two_query_parent.filter(|_| !embed_level.saw_relations) {
                 let schema_cache = state.schema_cache().await;
@@ -1339,6 +1339,7 @@ fn unwrap_rpc_rows(
 /// The table a read targets, if the request is a read.
 fn read_target(
     api_request: &postrust_core::api_request::ApiRequest,
+    db_plan: Option<&DbActionPlan>,
     schema_cache: &postrust_core::SchemaCache,
 ) -> Option<postrust_core::api_request::QualifiedIdentifier> {
     use postrust_core::api_request::{Action, DbAction};
@@ -1352,9 +1353,20 @@ fn read_target(
         Action::Db(DbAction::RelationMut { qi, .. }) => Some(qi.clone()),
         // A function returning a table's rows embeds, and renders, exactly as
         // that table does.
-        Action::Db(DbAction::Routine { qi, .. }) => schema_cache
-            .routine_returned_table(qi)
-            .map(|table| table.qualified_identifier()),
+        //
+        // Which table that is was settled when the overload was chosen: a
+        // name may carry several signatures returning different things, and
+        // asking the cache again by name answers for whichever comes first.
+        // It also knows the answer for a return type this side cannot read
+        // off the name at all, such as a domain over a table.
+        Action::Db(DbAction::Routine { qi, .. }) => match db_plan {
+            Some(DbActionPlan::Call { read, .. }) => {
+                read.as_ref().map(|tree| tree.root.from.clone())
+            }
+            _ => schema_cache
+                .routine_returned_table(qi)
+                .map(|table| table.qualified_identifier()),
+        },
         _ => None,
     }
 }
@@ -1580,7 +1592,7 @@ fn add_embed_join_columns(
 ) -> Result<Vec<String>, postrust_core::Error> {
     use postrust_core::api_request::{Field, SelectItem};
 
-    let Some(parent_qi) = read_target(api_request, schema_cache) else {
+    let Some(parent_qi) = read_target(api_request, None, schema_cache) else {
         return Ok(Vec::new());
     };
 
@@ -2835,11 +2847,24 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         Error::TableNotFound { name, .. } | Error::NotFound(name) => {
             return format!("Could not find the table '{}' in the schema cache", name)
         }
-        Error::FunctionNotFound { name, params, .. } => {
+        Error::FunctionNotFound {
+            name,
+            params,
+            single_param,
+            ..
+        } => {
+            // A body that is one value carries no argument names, so there is
+            // no argument list to report -- naming the function is the whole
+            // of what was looked for.
+            let looked_for =
+                match postrust_core::error::names_only_one_param(single_param.as_deref()) {
+                    true => name.clone(),
+                    false => postrust_core::error::function_signature(name, params),
+                };
             return format!(
                 "Could not find the function {} in the schema cache",
-                postrust_core::error::function_signature(name, params)
-            )
+                looked_for
+            );
         }
         Error::UnacceptableSchema { requested, .. } => {
             return format!("Invalid schema: {}", requested)

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -824,14 +824,14 @@ fn add_embed_join_columns(
         // it needs that column selected just the same. Without it the parent
         // row has no key to match children against and every spread column
         // comes back null.
-        let relation = match &item {
-            SelectItem::Relation { relation, .. } => relation,
-            SelectItem::SpreadRelation { relation, .. } => relation,
+        let (relation, hint) = match &item {
+            SelectItem::Relation { relation, hint, .. } => (relation, hint),
+            SelectItem::SpreadRelation { relation, hint, .. } => (relation, hint),
             SelectItem::Field { .. } => continue,
         };
 
         let rel = schema_cache
-            .find_relationship(&parent_qi, relation, &parent_qi.schema)
+            .find_relationship(&parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
             .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
 
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
@@ -846,15 +846,29 @@ fn add_embed_join_columns(
             continue;
         }
 
-        if !selected.contains(&plan.local_column) && !added.contains(&plan.local_column) {
-            api_request.query_params.select.push(SelectItem::Field {
-                field: Field::simple(&plan.local_column),
-                aggregate: None,
-                aggregate_cast: None,
-                cast: None,
-                alias: None,
-            });
-            added.push(plan.local_column.clone());
+        // Every column the join is on, not just the first: a foreign key over
+        // several columns correlates on all of them, and one left unselected
+        // is a column the correlation cannot see.
+        let join_columns: Vec<String> = match plan.columns.is_empty() {
+            true => vec![plan.local_column.clone()],
+            false => plan
+                .columns
+                .iter()
+                .map(|(local, _)| local.clone())
+                .collect(),
+        };
+
+        for column in join_columns {
+            if !selected.contains(&column) && !added.contains(&column) {
+                api_request.query_params.select.push(SelectItem::Field {
+                    field: Field::simple(&column),
+                    aggregate: None,
+                    aggregate_cast: None,
+                    cast: None,
+                    alias: None,
+                });
+                added.push(column);
+            }
         }
     }
 
@@ -1014,14 +1028,14 @@ fn build_embed_expressions(
             alias,
             select: child_select,
             join_type,
-            ..
+            hint,
         } = item
         else {
             continue;
         };
 
         let rel = schema_cache
-            .find_relationship(parent_qi, relation, &parent_qi.schema)
+            .find_relationship(parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
             .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
@@ -1161,23 +1175,25 @@ fn embed_relations<'f>(
             // A spread embed is fetched exactly like a plain one -- the two
             // differ only in where the child's columns end up, which is
             // settled once the rows are in hand.
-            let (relation, alias, nested, is_spread) = match item {
+            let (relation, alias, nested, is_spread, hint) = match item {
                 SelectItem::Relation {
                     relation,
                     alias,
                     select: nested,
+                    hint,
                     ..
-                } => (relation, alias.clone(), nested, false),
+                } => (relation, alias.clone(), nested, false, hint),
                 SelectItem::SpreadRelation {
                     relation,
                     select: nested,
+                    hint,
                     ..
-                } => (relation, None, nested, true),
+                } => (relation, None, nested, true, hint),
                 SelectItem::Field { .. } => continue,
             };
 
             let rel = schema_cache
-                .find_relationship(parent_qi, relation, &parent_qi.schema)
+                .find_relationship(parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
                 .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
 
             let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
@@ -1205,7 +1221,10 @@ fn embed_relations<'f>(
                 match nested_item {
                     SelectItem::Field { field, .. } => child_columns.push(field.name.clone()),
                     SelectItem::Relation { relation, .. } => {
-                        match schema_cache.find_relationship(&child_qi, relation, &child_qi.schema)
+                        match schema_cache
+                            .find_relationship(&child_qi, relation, None, &child_qi.schema)
+                            .ok()
+                            .flatten()
                         {
                             Some(nested_rel) => {
                                 let nested_plan = postrust_core::embed::EmbedPlan::resolve(
@@ -1526,7 +1545,11 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         }
         // The candidate list is the whole point of the message: it names the
         // signatures that could not be told apart.
-        Error::AmbiguousFunction { .. } => return error.to_string(),
+        Error::AmbiguousFunction { .. } | Error::AmbiguousRelationship { .. } => {
+            // The candidates are the whole point of these messages: they name
+            // what could not be told apart.
+            return error.to_string();
+        }
         _ => {}
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -572,8 +572,14 @@ fn add_embed_join_columns(
     let mut added = Vec::new();
 
     for item in select.clone() {
-        let SelectItem::Relation { relation, .. } = &item else {
-            continue;
+        // A spread joins on a parent column exactly as a plain embed does, so
+        // it needs that column selected just the same. Without it the parent
+        // row has no key to match children against and every spread column
+        // comes back null.
+        let relation = match &item {
+            SelectItem::Relation { relation, .. } => relation,
+            SelectItem::SpreadRelation { relation, .. } => relation,
+            SelectItem::Field { .. } => continue,
         };
 
         let rel = schema_cache
@@ -1068,13 +1074,15 @@ fn embed_relations<'f>(
                 }
             }
             if is_spread {
-                // The child rows carry the table's own column names, so the
-                // requested list is matched against those rather than against
-                // any alias.
-                let spread_columns: Vec<String> = nested
+                // The child rows carry the table's own column names, so a
+                // column is read by its real name and written under its alias.
+                let spread_columns: Vec<(String, String)> = nested
                     .iter()
                     .filter_map(|nested_item| match nested_item {
-                        SelectItem::Field { field, .. } => Some(field.name.clone()),
+                        SelectItem::Field { field, alias, .. } => Some((
+                            field.name.clone(),
+                            alias.clone().unwrap_or_else(|| field.name.clone()),
+                        )),
                         _ => None,
                     })
                     .collect();

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -236,6 +236,21 @@ fn split_leading_cte(sql: &str) -> (String, &str) {
     (String::new(), sql)
 }
 
+/// Render a map of strings as a JSON object.
+///
+/// PostgreSQL will not accept every header name as a setting name -- a `-` is
+/// not allowed in one from version 14 -- so the whole map goes into a single
+/// setting as JSON and a function picks out what it wants with `->>`.
+fn json_object<'a>(entries: impl IntoIterator<Item = (&'a String, &'a String)>) -> String {
+    serde_json::Value::Object(
+        entries
+            .into_iter()
+            .map(|(name, value)| (name.clone(), serde_json::Value::String(value.clone())))
+            .collect(),
+    )
+    .to_string()
+}
+
 /// The prefix given to primary key columns added only to build `Location`.
 const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 
@@ -845,71 +860,78 @@ async fn execute_plan(
                     .map_err(map_sqlx_error)?;
             }
 
-            // The request's schema comes first on the search path, then the
-            // schemas configured as extra. Without this, anything an exposed
-            // object refers to by bare name -- the domain behind a media type
-            // handler, a type from an extension -- fails to resolve, because
-            // the pool's connection carries whatever search path it was opened
-            // with.
+            // Everything the request tells the database about itself, in
+            // one statement.
+            //
+            // These are `SET LOCAL` by another spelling -- `set_config(k, v,
+            // true)` -- and a function or an RLS policy reads them back with
+            // `current_setting`. Sent as one `SELECT` rather than one
+            // statement each, which is a round trip per setting otherwise, and
+            // there are eight of them before a request has done any work.
+            //
+            // The order is PostgREST's: the settings a role carries, then the
+            // role, then everything about the request. The role goes on after
+            // its own settings so that a `GRANT SET ON PARAMETER` on the
+            // authenticator still applies when they are set.
             {
                 let mut path = vec![api_request.schema.clone()];
                 path.extend(state.config.db_extra_search_path.iter().cloned());
-                let rendered = path
+                let search_path = path
                     .iter()
                     .map(|s| postrust_sql::escape_ident(s))
                     .collect::<Vec<_>>()
                     .join(", ");
-                sqlx::query(&format!("SET LOCAL search_path TO {}", rendered))
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(map_sqlx_error)?;
-            }
 
-            // `Prefer: timezone` is applied to the session, so every value
-            // the database renders -- and every `now()` a function calls --
-            // sees it. An unknown zone is PostgreSQL's to reject, and it does,
-            // with a message naming the value the client sent.
-            if let Some(timezone) = &api_request.preferences.timezone {
-                sqlx::query("SELECT set_config('timezone', $1, true)")
-                    .bind(timezone)
-                    .execute(&mut *tx)
-                    .await
-                    .map_err(map_sqlx_error)?;
-            }
+                // The claims carry the role, as PostgREST's do: a policy
+                // reading `request.jwt.claims` finds the role it is running as
+                // whether or not the token named one.
+                let mut claims: serde_json::Map<String, serde_json::Value> = auth
+                    .claims
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect();
+                claims.insert(
+                    "role".to_string(),
+                    serde_json::Value::String(auth.role.clone()),
+                );
 
-            // Set role
-            sqlx::query(&format!(
-                "SET LOCAL ROLE {}",
-                postrust_sql::escape_ident(&auth.role)
-            ))
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| {
-                postrust_core::Error::Database(postrust_core::error::DatabaseError {
-                    code: "42501".into(),
-                    message: e.to_string(),
-                    details: None,
-                    hint: None,
-                    constraint: None,
-                    table: None,
-                    column: None,
-                })
-            })?;
+                let mut settings: Vec<(String, String)> = vec![
+                    ("search_path".to_string(), search_path),
+                    ("role".to_string(), auth.role.clone()),
+                    (
+                        "request.jwt.claims".to_string(),
+                        serde_json::Value::Object(claims).to_string(),
+                    ),
+                    ("request.method".to_string(), api_request.method.clone()),
+                    ("request.path".to_string(), api_request.path.clone()),
+                    (
+                        "request.headers".to_string(),
+                        json_object(&api_request.headers),
+                    ),
+                    (
+                        "request.cookies".to_string(),
+                        json_object(&api_request.cookies),
+                    ),
+                ];
 
-            // Set claims as GUC
-            for (key, value) in &auth.claims {
-                let guc_key = format!("request.jwt.claims.{}", key);
-                let guc_value = match value {
-                    serde_json::Value::String(s) => s.clone(),
-                    other => other.to_string(),
-                };
+                // `Prefer: timezone` is applied to the session, so every value
+                // the database renders -- and every `now()` a function calls --
+                // sees it. An unknown zone is PostgreSQL's to reject, and it
+                // does, with a message naming the value the client sent.
+                if let Some(timezone) = &api_request.preferences.timezone {
+                    settings.push(("timezone".to_string(), timezone.clone()));
+                }
 
-                sqlx::query("SELECT set_config($1, $2, true)")
-                    .bind(&guc_key)
-                    .bind(&guc_value)
-                    .execute(&mut *tx)
-                    .await
-                    .ok(); // Ignore errors for individual claims
+                let calls = (0..settings.len())
+                    .map(|i| format!("set_config(${}, ${}, true)", i * 2 + 1, i * 2 + 2))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let sql = format!("SELECT {}", calls);
+                let mut query = sqlx::query(&sql);
+                for (name, value) in &settings {
+                    query = query.bind(name).bind(value);
+                }
+                query.execute(&mut *tx).await.map_err(map_sqlx_error)?;
             }
 
             // Execute main query with bound parameters
@@ -978,6 +1000,51 @@ async fn execute_plan(
                 )
                 .await?;
             }
+
+            // A function can set the response's status and headers, and only
+            // it knows whether it did -- so the settings are read back after
+            // it has run, on the same transaction. Reads cannot set them
+            // without a function of their own having run, which is what a
+            // call or a mutation is.
+            let (guc_headers, guc_status) =
+                match is_mutation(db_plan) || matches!(db_plan, DbActionPlan::Call { .. }) {
+                    false => (None, None),
+                    true => {
+                        use sqlx::Row;
+                        let row = sqlx::query(
+                            "SELECT current_setting('response.headers', true), \
+                         current_setting('response.status', true)",
+                        )
+                        .fetch_one(&mut *tx)
+                        .await
+                        .map_err(map_sqlx_error)?;
+                        (
+                            row.try_get::<Option<String>, _>(0).ok().flatten(),
+                            row.try_get::<Option<String>, _>(1).ok().flatten(),
+                        )
+                    }
+                };
+
+            // Both are the function's own words, so both are checked before
+            // they reach the response: a malformed one is a fault in the
+            // schema, and saying so is more use than a header the client
+            // cannot see or a status it cannot explain.
+            if let Some(headers) = &guc_headers {
+                if postrust_response::parse_guc_headers(headers).is_err() {
+                    return Err(postrust_core::Error::InvalidGucHeaders);
+                }
+            }
+            let guc_status = match guc_status {
+                None => None,
+                Some(status) => Some(
+                    status
+                        .trim()
+                        .parse::<u16>()
+                        .ok()
+                        .and_then(|code| StatusCode::from_u16(code).ok())
+                        .ok_or(postrust_core::Error::InvalidGucStatus)?,
+                ),
+            };
 
             // The count runs on the same transaction and so under the same
             // snapshot as the page it describes.
@@ -1052,7 +1119,7 @@ async fn execute_plan(
             // shape for something that returns nothing.
             let returns_void = matches!(
                 db_plan,
-                DbActionPlan::Call { call, .. } if call.return_type.as_deref() == Some("void")
+                DbActionPlan::Call { call, .. } if call.returns_void
             );
 
             // `Prefer: max-affected` guards against a filter that turned out
@@ -1161,21 +1228,27 @@ async fn execute_plan(
             }
 
             Ok(QueryResult {
-                status: match returns_void {
-                    true => StatusCode::NO_CONTENT,
-                    false => mutation_status(db_plan, api_request, created_a_row, reports_inserted)
-                        .unwrap_or_else(|| {
-                            content_range
-                                .as_ref()
-                                .map(postrust_response::ContentRange::status)
-                                .unwrap_or(StatusCode::OK)
-                        }),
+                // A status the function set outright wins: it knows things
+                // about the outcome that the request's shape cannot say.
+                status: match (guc_status, returns_void) {
+                    (Some(status), _) => status,
+                    (None, true) => StatusCode::NO_CONTENT,
+                    (None, false) => {
+                        mutation_status(db_plan, api_request, created_a_row, reports_inserted)
+                            .unwrap_or_else(|| {
+                                content_range
+                                    .as_ref()
+                                    .map(postrust_response::ContentRange::status)
+                                    .unwrap_or(StatusCode::OK)
+                            })
+                    }
                 },
                 rows,
                 singular,
                 omit_body: omit_body || returns_void,
                 location,
                 content_range,
+                guc_headers,
                 ..Default::default()
             })
         }
@@ -2794,6 +2867,8 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::PutLimitNotAllowed
         | Error::PutMatchingPk
         | Error::MaxAffectedExceeded(_)
+        | Error::InvalidGucHeaders
+        | Error::InvalidGucStatus
         | Error::InvalidMediaType(_)
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
@@ -2859,6 +2934,7 @@ mod tests {
             returns_composite: false,
             volatility: "Volatile".into(),
             param_types: Vec::new(),
+            returns_void: false,
         }
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -153,6 +153,12 @@ async fn execute_plan(
                 alias_counter: 0,
             };
 
+            // The single-query form cannot express a spread, whose columns have
+            // to land in the parent object rather than under a key of their
+            // own. One anywhere in the tree sends the whole request down the
+            // two-query path, which can: taking the single-query path for the
+            // plain relations would embed those and drop the spread, since the
+            // two-query path only runs when the first produced nothing.
             let embed_level = match read_target(api_request) {
                 Some(parent_qi)
                     if api_request.query_params.select.iter().any(|item| {
@@ -160,7 +166,7 @@ async fn execute_plan(
                             item,
                             postrust_core::api_request::SelectItem::Relation { .. }
                         )
-                    }) =>
+                    }) && !contains_spread(&api_request.query_params.select) =>
                 {
                     let schema_cache = state.schema_cache().await;
                     build_embed_expressions(
@@ -472,11 +478,22 @@ fn selects_an_aggregate(api_request: &ApiRequest) -> bool {
         items.iter().any(|item| match item {
             SelectItem::Field { aggregate, .. } => aggregate.is_some(),
             SelectItem::Relation { select, .. } => walk(select),
-            SelectItem::SpreadRelation { .. } => false,
+            SelectItem::SpreadRelation { select, .. } => walk(select),
         })
     }
 
     walk(&api_request.query_params.select)
+}
+
+/// Whether a select list spreads a related resource, at any depth.
+fn contains_spread(items: &[postrust_core::api_request::SelectItem]) -> bool {
+    use postrust_core::api_request::SelectItem;
+
+    items.iter().any(|item| match item {
+        SelectItem::SpreadRelation { .. } => true,
+        SelectItem::Relation { select, .. } => contains_spread(select),
+        SelectItem::Field { .. } => false,
+    })
 }
 
 /// Whether this plan changes data.
@@ -867,14 +884,22 @@ fn embed_relations<'f>(
         }
 
         for item in select {
-            let SelectItem::Relation {
-                relation,
-                alias,
-                select: nested,
-                ..
-            } = item
-            else {
-                continue;
+            // A spread embed is fetched exactly like a plain one -- the two
+            // differ only in where the child's columns end up, which is
+            // settled once the rows are in hand.
+            let (relation, alias, nested, is_spread) = match item {
+                SelectItem::Relation {
+                    relation,
+                    alias,
+                    select: nested,
+                    ..
+                } => (relation, alias.clone(), nested, false),
+                SelectItem::SpreadRelation {
+                    relation,
+                    select: nested,
+                    ..
+                } => (relation, None, nested, true),
+                SelectItem::Field { .. } => continue,
             };
 
             let rel = schema_cache
@@ -1001,24 +1026,37 @@ fn embed_relations<'f>(
             // The projection in the query covers the columns; this covers what
             // is left over, which is the join column when the client did not
             // ask for it.
-            let requested: Option<std::collections::HashSet<String>> = if nested.is_empty() {
-                None
-            } else {
-                Some(
-                    nested
-                        .iter()
-                        .filter_map(|nested_item| match nested_item {
-                            SelectItem::Field { field, alias, .. } => {
-                                Some(alias.clone().unwrap_or_else(|| field.name.clone()))
-                            }
-                            SelectItem::Relation {
-                                relation, alias, ..
-                            } => Some(alias.clone().unwrap_or_else(|| relation.clone())),
-                            SelectItem::SpreadRelation { .. } => None,
-                        })
-                        .collect(),
-                )
-            };
+            // A spread picks its own columns out when it merges them, and does
+            // it by the child's own column names, so pruning here would only
+            // get in the way.
+            let requested: Option<std::collections::HashSet<String>> =
+                if nested.is_empty() || is_spread {
+                    None
+                } else {
+                    Some(
+                        nested
+                            .iter()
+                            .flat_map(|nested_item| match nested_item {
+                                SelectItem::Field { field, alias, .. } => {
+                                    vec![alias.clone().unwrap_or_else(|| field.name.clone())]
+                                }
+                                SelectItem::Relation {
+                                    relation, alias, ..
+                                } => vec![alias.clone().unwrap_or_else(|| relation.clone())],
+                                // A spread one level down has already merged
+                                // its columns into these rows, so they are
+                                // part of what was asked for.
+                                SelectItem::SpreadRelation { select, .. } => select
+                                    .iter()
+                                    .filter_map(|column| match column {
+                                        SelectItem::Field { field, .. } => Some(field.name.clone()),
+                                        _ => None,
+                                    })
+                                    .collect(),
+                            })
+                            .collect(),
+                    )
+                };
 
             if let Some(requested) = requested {
                 for group in grouped.values_mut() {
@@ -1029,9 +1067,25 @@ fn embed_relations<'f>(
                     }
                 }
             }
-            let field_name = alias.clone().unwrap_or_else(|| relation.clone());
-            for row in rows.iter_mut() {
-                postrust_core::embed::attach_to_parent(row, &field_name, &plan, &grouped);
+            if is_spread {
+                // The child rows carry the table's own column names, so the
+                // requested list is matched against those rather than against
+                // any alias.
+                let spread_columns: Vec<String> = nested
+                    .iter()
+                    .filter_map(|nested_item| match nested_item {
+                        SelectItem::Field { field, .. } => Some(field.name.clone()),
+                        _ => None,
+                    })
+                    .collect();
+                for row in rows.iter_mut() {
+                    postrust_core::embed::spread_into_parent(row, &plan, &grouped, &spread_columns);
+                }
+            } else {
+                let field_name = alias.clone().unwrap_or_else(|| relation.clone());
+                for row in rows.iter_mut() {
+                    postrust_core::embed::attach_to_parent(row, &field_name, &plan, &grouped);
+                }
             }
         }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -809,6 +809,21 @@ async fn execute_plan(
                 (json_rows, false)
             };
 
+            // A function returning `void` has no result to report. PostgREST
+            // answers 204 rather than a body of `null`, which is the honest
+            // shape for something that returns nothing.
+            let returns_void = matches!(
+                db_plan,
+                DbActionPlan::Call { call, .. } if call.return_type.as_deref() == Some("void")
+            );
+            if returns_void {
+                return Ok(QueryResult {
+                    status: StatusCode::NO_CONTENT,
+                    omit_body: true,
+                    ..Default::default()
+                });
+            }
+
             // A mutation returns the affected rows only when the caller asked
             // for them; otherwise the body is empty whatever the status.
             let omit_body = is_mutation(db_plan) && !wants_representation(api_request);
@@ -2413,6 +2428,11 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::NotSingular { .. }
         | Error::InvalidRange(_)
         | Error::InvalidBody(_)
+        | Error::UnsupportedMethod(_)
+        | Error::InvalidRpcMethod(_)
+        | Error::InvalidPutFilters
+        | Error::PutLimitNotAllowed
+        | Error::PutMatchingPk
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
         // What the token failed on is the client's own token, so naming it

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -2947,6 +2947,9 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::InvalidGucHeaders
         | Error::InvalidGucStatus
         | Error::InvalidMediaType(_)
+        // Quotes the client's own URL back at it, and names the grammar the
+        // API publishes. Neither is the schema's.
+        | Error::UnparsableQuery { .. }
         // Says nothing about the schema beyond that one RAISE is malformed,
         // which is what the author has to fix.
         | Error::RaiseNotUnderstood(_)

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -160,8 +160,11 @@ async fn process_request(
     // with some other number of rows.
     let response = format_response(&api_request, &result).map_err(|e| match e {
         postrust_response::FormatError::MultipleRows | postrust_response::FormatError::NotFound => {
+            // How many rows there were, not how many were kept: a write the
+            // caller wanted no representation from still touched them, and
+            // that count is what the client got wrong.
             postrust_core::Error::NotSingular {
-                rows: result.rows.len(),
+                rows: result.rows.len().max(result.affected),
             }
         }
         other => postrust_core::Error::Internal(other.to_string()),
@@ -1183,6 +1186,10 @@ async fn execute_plan(
             // A mutation returns the affected rows only when the caller asked
             // for them; otherwise the body is empty whatever the status.
             let omit_body = is_mutation(db_plan) && !wants_representation(api_request);
+            // Taken before the rows are dropped: how many a write touched is
+            // still the answer to `Content-Range` and to a request for a
+            // single object.
+            let affected = json_rows.len();
             let rows = if omit_body { Vec::new() } else { json_rows };
 
             // PostgREST reports the returned window on every successful data
@@ -1215,7 +1222,7 @@ async fn execute_plan(
                 }
                 Some(Mutation::Update) => Some(postrust_response::ContentRange::new(
                     0,
-                    rows.len() as i64 - 1,
+                    affected as i64 - 1,
                     total,
                 )),
                 None => Some(postrust_response::ContentRange::from_pagination(
@@ -1261,6 +1268,7 @@ async fn execute_plan(
                 rows,
                 singular,
                 omit_body: omit_body || returns_void,
+                affected,
                 location,
                 content_range,
                 guc_headers,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -201,6 +201,41 @@ fn mutation_kind(api_request: &ApiRequest) -> Option<postrust_core::api_request:
     }
 }
 
+/// Split a leading `WITH ... AS (...)` off the front of a statement.
+///
+/// Returns the clause -- with its trailing space, or empty when there is none
+/// -- and the statement that follows it. A `WITH` containing an `INSERT`,
+/// `UPDATE` or `DELETE` may only appear at the top level, so anything that
+/// wraps the statement has to wrap what follows the clause and put the clause
+/// back in front.
+fn split_leading_cte(sql: &str) -> (String, &str) {
+    let Some(open) = sql.strip_prefix("WITH ").and_then(|rest| rest.find('(')) else {
+        return (String::new(), sql);
+    };
+    let open = open + "WITH ".len();
+
+    let mut depth = 0usize;
+    let mut quoted = None::<char>;
+    for (index, ch) in sql[open..].char_indices() {
+        match (quoted, ch) {
+            (Some(quote), ch) if ch == quote => quoted = None,
+            (Some(_), _) => {}
+            (None, '\'') | (None, '"') => quoted = Some(ch),
+            (None, '(') => depth += 1,
+            (None, ')') => {
+                depth -= 1;
+                if depth == 0 {
+                    let end = open + index + 1;
+                    return (format!("{} ", &sql[..end]), sql[end..].trim_start());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (String::new(), sql)
+}
+
 /// The prefix given to primary key columns added only to build `Location`.
 const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 
@@ -621,8 +656,16 @@ async fn execute_plan(
                     projection.push_str(" AS ");
                     projection.push_str(&postrust_sql::escape_ident(field_name));
                 }
+                // A data-modifying `WITH` has to stay at the top level:
+                // PostgreSQL refuses one nested inside a subquery, which is
+                // where wrapping the whole statement would put it. The clause
+                // is lifted out and put back in front of the wrapper.
                 let inner_sql = std::mem::take(&mut sql);
-                sql = format!("SELECT {} FROM ({}) AS src", projection, inner_sql);
+                let (with_clause, inner_sql) = split_leading_cte(&inner_sql);
+                sql = format!(
+                    "{}SELECT {} FROM ({}) AS src",
+                    with_clause, projection, inner_sql
+                );
 
                 // `?clients=is.null` asks whether the embed matched anything,
                 // not about a column. The embed's expression is the thing to
@@ -669,7 +712,11 @@ async fn execute_plan(
                 // so the count has to be taken after them -- the same wrapper,
                 // over the unpaged query.
                 count_sql = count_sql.map(|base| {
-                    let mut counted = format!("SELECT {} FROM ({}) AS src", projection, base);
+                    let (with_clause, base) = split_leading_cte(&base);
+                    let mut counted = format!(
+                        "{}SELECT {} FROM ({}) AS src",
+                        with_clause, projection, base
+                    );
                     if !predicates.is_empty() {
                         counted.push_str(" WHERE ");
                         counted.push_str(&predicates.join(" AND "));
@@ -2752,6 +2799,32 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// A data-modifying `WITH` may only appear at the top level, so anything
+    /// that wraps the statement has to leave the clause where it is.
+    #[test]
+    fn a_leading_cte_is_lifted_off_the_statement() {
+        let (clause, body) = super::split_leading_cte(
+            "WITH pgrst_mutation_result AS (DELETE FROM t WHERE n = ')' RETURNING t.id) \
+             SELECT \"id\" FROM \"pgrst_mutation_result\"",
+        );
+
+        assert_eq!(
+            clause,
+            "WITH pgrst_mutation_result AS (DELETE FROM t WHERE n = ')' RETURNING t.id) "
+        );
+        assert_eq!(body, "SELECT \"id\" FROM \"pgrst_mutation_result\"");
+    }
+
+    /// A plain read has no clause to lift.
+    #[test]
+    fn a_statement_without_a_cte_is_left_alone() {
+        let sql = "SELECT \"id\" FROM \"test\".\"items\"";
+        let (clause, body) = super::split_leading_cte(sql);
+
+        assert!(clause.is_empty());
+        assert_eq!(body, sql);
+    }
+
     use super::*;
     use postrust_core::plan::CallParams;
     use postrust_core::QualifiedIdentifier;

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -103,14 +103,6 @@ async fn process_request(
         api_request.payload = payload;
     }
 
-    // `application/vnd.pgrst.plan` asks for the query plan instead of the
-    // result. It is off unless a server turns it on -- it says a great deal
-    // about the schema and the data -- and a server that has not is required
-    // to say so rather than answer with something else.
-    if let Some(plan) = requested_plan(&api_request) {
-        return Err(postrust_core::Error::InvalidMediaType(plan));
-    }
-
     // A body that names different columns row by row cannot be written by one
     // statement. Skipped when `?columns=` says which columns to write, since
     // then the rows are free to differ.
@@ -127,6 +119,19 @@ async fn process_request(
         return Err(postrust_core::Error::InvalidBody(
             "Empty or invalid json".into(),
         ));
+    }
+
+    // `application/vnd.pgrst.plan` asks for the query plan instead of the
+    // result. It is off unless a server turns it on -- it says a great deal
+    // about the schema and the data -- and a server that has not is required
+    // to say so rather than answer with something else.
+    //
+    // Checked after the body, not before it: a request that could not be read
+    // at all has not got as far as asking for anything, and PostgREST answers
+    // it with what is wrong with the request rather than with what the server
+    // declines to serve.
+    if let Some(plan) = requested_plan(&api_request) {
+        return Err(postrust_core::Error::InvalidMediaType(plan));
     }
 
     // Get schema cache
@@ -178,17 +183,20 @@ async fn process_request(
 /// A request that would also take JSON gets JSON; one that will take only the
 /// plan is refused, and the message names what it asked for.
 fn requested_plan(api_request: &ApiRequest) -> Option<String> {
-    let accepted: Vec<&str> = api_request
+    use postrust_core::api_request::MediaType;
+
+    // Named back with their parameters, since that is what was asked for: a
+    // plan for CSV and a plan for JSON are different requests, and a client
+    // told only that "application/vnd.pgrst.plan+json" is unavailable has not
+    // been told which of its requests was refused.
+    let accepted: Vec<String> = api_request
         .accept_media_types
         .iter()
-        .map(|media| media.content_type())
+        .filter(|media| matches!(media, MediaType::Plan { .. }))
+        .map(MediaType::to_mime)
         .collect();
 
-    match accepted
-        .iter()
-        .all(|media| media.starts_with("application/vnd.pgrst.plan"))
-        && !accepted.is_empty()
-    {
+    match accepted.len() == api_request.accept_media_types.len() && !accepted.is_empty() {
         true => Some(accepted.join(", ")),
         false => None,
     }
@@ -398,21 +406,50 @@ async fn execute_plan(
                 read_target(api_request, Some(db_plan), &schema_cache).and_then(|qi| {
                     api_request.accept_media_types.iter().find_map(|media| {
                         schema_cache
-                            .media_handler(&api_request.schema, media.content_type(), &qi)
-                            .map(|handler| {
+                            .media_handler(
+                                &api_request.schema,
+                                media.content_type(),
+                                &qi,
+                                has_default_select(&api_request.query_params.select),
+                            )
+                            .map(|(handler, resolved)| {
                                 (
-                                    media.content_type().to_string(),
+                                    resolved.to_string(),
                                     format!(
                                         "{}.{}",
                                         postrust_sql::escape_ident(&handler.aggregate.schema),
                                         postrust_sql::escape_ident(&handler.aggregate.name)
                                     ),
                                     handler.table.is_some(),
+                                    handler.base_type.clone(),
                                 )
                             })
                     })
                 })
             };
+
+            // Content negotiation. A media type is rendered by a builtin, by a
+            // handler the schema declared, or by the function's own return
+            // type -- and a request that names only types nothing here can
+            // render has not been answered by serving it JSON under a
+            // `Content-Type` it never asked for. PostgREST refuses it, naming
+            // everything that was asked for.
+            if media_handler.is_none()
+                && declared_media_type(db_plan, api_request).is_none()
+                && !api_request
+                    .accept_media_types
+                    .iter()
+                    .any(renders_without_a_handler)
+            {
+                return Err(postrust_core::Error::InvalidMediaType(
+                    api_request
+                        .accept_media_types
+                        .iter()
+                        .map(postrust_core::api_request::MediaType::to_mime)
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+            }
 
             // Carry the parent's whole row out of the inner query when a
             // computed relationship needs it as an argument. It has to be
@@ -420,7 +457,7 @@ async fn execute_plan(
             // reference to the table yields its composite type, whereas the
             // derived table it becomes one level up yields a `record`.
             let needs_parent_row = added_join_columns.iter().any(|c| c == PARENT_ROW_COLUMN)
-                || matches!(&media_handler, Some((_, _, true)));
+                || matches!(&media_handler, Some((_, _, true, _)));
             let db_plan = &if needs_parent_row {
                 let mut adjusted = db_plan.clone();
                 // A function's result is a relation too, named after the
@@ -618,6 +655,7 @@ async fn execute_plan(
                     &schema_cache,
                     parent_qi,
                     &tree.root.order,
+                    &api_request.query_params.select,
                     &mut embed_filters,
                 )?;
             }
@@ -756,59 +794,35 @@ async fn execute_plan(
             // table's geometry column and whose properties are the rest. A
             // schema-declared handler overrides it, which is why this only
             // runs when none matched.
-            let geojson_column = if media_handler.is_none() {
+            //
+            // Asking for GeoJSON from rows that carry no geometry is an error
+            // rather than a plain JSON body: the client asked for features,
+            // and a list of objects with no geometry is not features.
+            let wants_geojson = media_handler.is_none()
+                && api_request
+                    .accept_media_types
+                    .iter()
+                    .any(|m| matches!(m, postrust_core::api_request::MediaType::GeoJson));
+            let geojson_column = if wants_geojson {
                 let schema_cache = state.schema_cache().await;
-                read_target(api_request, Some(db_plan), &schema_cache)
-                    .filter(|_| {
-                        api_request
-                            .accept_media_types
-                            .iter()
-                            .any(|m| matches!(m, postrust_core::api_request::MediaType::GeoJson))
-                    })
-                    .and_then(|qi| {
-                        schema_cache.get_table(&qi).and_then(|table| {
-                            table
-                                .columns
-                                .values()
-                                .find(|c| {
-                                    matches!(c.nominal_type.as_str(), "geometry" | "geography")
-                                })
-                                .map(|c| c.name.clone())
-                        })
-                    })
+                let target = read_target(api_request, Some(db_plan), &schema_cache);
+                match target.as_ref().and_then(|qi| schema_cache.get_table(qi)) {
+                    Some(table) => {
+                        match geometry_key(table, &api_request.query_params.select) {
+                            Some(column) => Some(column),
+                            None => return Err(postrust_core::Error::MissingGeometryColumn),
+                        }
+                    }
+                    // Nothing this side can name a geometry column on -- a
+                    // scalar function, say. Left to the database, which is
+                    // where the answer was coming from anyway.
+                    None => None,
+                }
             } else {
                 None
             };
 
-            if let Some(column) = &geojson_column {
-                // The geometry column already arrives as jsonb, since a
-                // user-defined type is rendered by the database. For a
-                // geometry that rendering is GeoJSON with a `crs` key, and
-                // dropping that key is exactly `ST_AsGeoJSON` -- which also
-                // means this needs no PostGIS function in scope.
-                //
-                // The name is a real column's, read from the catalogue rather
-                // than from the request, but it is quoted both ways all the
-                // same: as an identifier to read the column, and as a literal
-                // to drop that key from the properties.
-                // A mutation's rows come from a data-modifying CTE, which
-                // PostgreSQL allows only at the top level -- so the rendering
-                // wraps what follows the `WITH`, not the whole statement.
-                let (with_clause, inner) = split_leading_cte(&sql);
-                sql = format!(
-                    "{with_clause}SELECT json_build_object('type', 'FeatureCollection', \
-                     'features', COALESCE(json_agg(json_build_object('type', 'Feature', \
-                     'geometry', pgrst_geo.{column} - 'crs', 'properties', \
-                     to_jsonb(pgrst_geo) - '{key}')), '[]'::json))::text \
-                     AS pgrst_body FROM ({inner}) pgrst_geo",
-                    with_clause = with_clause,
-                    column = postrust_sql::escape_ident(column),
-                    key = column.replace('\'', "''"),
-                    inner = inner
-                );
-            }
-
-            if let Some((media_type, aggregate, over_row)) = &media_handler {
+            if let Some((media_type, aggregate, over_row, _)) = &media_handler {
                 // The aggregate takes the table's own row type. A derived
                 // table yields `record`, which will not cast to it, so where
                 // the handler names a table the aggregate is applied to the
@@ -957,29 +971,19 @@ async fn execute_plan(
             // `Vec<PgRow>` staying alive alongside the whole `Vec<Value>`.
             // A rendered media type is a single value, not a row set: the
             // aggregate already produced the entire body.
-            if let Some(media_type) = media_handler
+            if let Some((media_type, base_type)) = media_handler
                 .as_ref()
-                .map(|(m, _, _)| m.clone())
-                .or_else(|| {
-                    geojson_column
-                        .as_ref()
-                        .map(|_| "application/geo+json".to_string())
-                })
+                .map(|(m, _, _, base)| (m.clone(), base.clone()))
                 .or_else(|| declared_media_type(db_plan, api_request))
             {
-                use sqlx::Row;
-                // Read as bytes where the media type is not text: a value that
-                // is a PNG is not a string, and asking for one back gets
-                // nothing at all.
+                // The value's type is a domain this side has no mapping for,
+                // so it arrives as PostgreSQL's text rendering of it. For
+                // anything text-like that rendering *is* the value; for a
+                // `bytea` it is `\x` and hex, which describes the bytes
+                // rather than being them.
                 let body = rows
                     .first()
-                    .and_then(|row| {
-                        row.try_get::<Option<String>, _>(0)
-                            .map(|text| text.map(String::into_bytes))
-                            .or_else(|_| row.try_get::<Option<Vec<u8>>, _>(0))
-                            .ok()
-                    })
-                    .flatten()
+                    .and_then(|row| raw_column(row, &base_type))
                     .unwrap_or_default();
                 tx.commit()
                     .await
@@ -1198,6 +1202,19 @@ async fn execute_plan(
             let affected = json_rows.len();
             let rows = if omit_body { Vec::new() } else { json_rows };
 
+            // `application/geo+json` is a rendering of these same rows, done
+            // here rather than in SQL so that everything a mutation reports
+            // has already happened to them: the status derived, the location
+            // taken from the key, the bookkeeping columns removed. Built in
+            // SQL it saw the row as the statement left it, and leaked
+            // `pgrst_inserted` into a feature's properties.
+            let geojson_body = geojson_column.as_ref().filter(|_| !omit_body).map(|column| {
+                (
+                    "application/geo+json".to_string(),
+                    feature_collection(&rows, column),
+                )
+            });
+
             // PostgREST reports the returned window on every successful data
             // response -- reads, mutations and RPC alike, but not on errors or
             // OPTIONS. Without an exact count the total is unknown, which
@@ -1278,6 +1295,7 @@ async fn execute_plan(
                 location,
                 content_range,
                 guc_headers,
+                raw_body: geojson_body,
                 ..Default::default()
             })
         }
@@ -1389,6 +1407,185 @@ fn read_target(
         },
         _ => None,
     }
+}
+
+/// Round a geometry's numbers to nine decimal places.
+///
+/// Not cosmetic: nine is what `ST_AsGeoJSON` emits by default, and a geometry
+/// read through the type's own rendering carries every digit the double has.
+/// Nine decimal places of latitude is under a tenth of a millimetre, so the
+/// digits past it describe floating-point representation rather than any
+/// place on the earth.
+fn round_coordinates(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Array(items) => items.iter_mut().for_each(round_coordinates),
+        serde_json::Value::Object(fields) => fields.values_mut().for_each(round_coordinates),
+        serde_json::Value::Number(number) => {
+            let Some(float) = number.as_f64() else { return };
+            if float.fract() == 0.0 {
+                return;
+            }
+            // Through the decimal text rather than by arithmetic: scaling by a
+            // power of ten and rounding back reintroduces exactly the digits
+            // this is meant to drop.
+            if let Ok(rounded) = format!("{float:.9}").parse::<f64>() {
+                if let Some(rounded) = serde_json::Number::from_f64(rounded) {
+                    *number = rounded;
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The first column of a row, as the bytes the client should receive.
+///
+/// A media type the schema declared is carried by a domain, and a domain is a
+/// type this side has no decoder for -- so the value arrives as PostgreSQL's
+/// own text rendering. For text, xml or json that rendering is the value. For
+/// `bytea` it is `\x` followed by hex, which is a description of the bytes
+/// and not the bytes, so it is decoded back.
+fn raw_column(row: &sqlx::postgres::PgRow, base_type: &str) -> Option<Vec<u8>> {
+    use sqlx::{Row, ValueRef};
+
+    let value = row.try_get_raw(0).ok()?;
+    if value.is_null() {
+        return None;
+    }
+    let bytes = value.as_bytes().ok()?.to_vec();
+    if base_type != "bytea" {
+        return Some(bytes);
+    }
+    // Text or binary, depending on whether this connection asked for a format
+    // it could name -- so the `\x` rendering is decoded where it appears and
+    // the bytes are passed through where they do not.
+    let Some(hex) = bytes.strip_prefix(b"\\x") else {
+        return Some(bytes);
+    };
+    hex.chunks(2)
+        .map(|pair| {
+            let digits = std::str::from_utf8(pair).ok()?;
+            u8::from_str_radix(digits, 16).ok()
+        })
+        .collect::<Option<Vec<u8>>>()
+        .or(Some(bytes))
+}
+
+/// Whether the selection is the one a table has when none was asked for.
+///
+/// A handler declared for a table renders the table's own rows, so it applies
+/// only where the request did not reshape them. `?select=*` is that shape
+/// written out; `?select=id` and any embed are not.
+fn has_default_select(select: &[postrust_core::api_request::SelectItem]) -> bool {
+    use postrust_core::api_request::SelectItem;
+
+    match select {
+        [] => true,
+        [SelectItem::Field { field, alias, .. }] => field.name == "*" && alias.is_none(),
+        _ => false,
+    }
+}
+
+/// Whether this server renders the type itself, with nothing declared for it.
+fn renders_without_a_handler(media: &postrust_core::api_request::MediaType) -> bool {
+    use postrust_core::api_request::MediaType;
+
+    matches!(
+        media,
+        MediaType::ApplicationJson
+            | MediaType::Any
+            | MediaType::TextCsv
+            | MediaType::GeoJson
+            | MediaType::SingularJson { .. }
+            | MediaType::ArrayJson { .. }
+            | MediaType::OpenApi
+    )
+}
+
+/// Render rows as a GeoJSON `FeatureCollection`.
+///
+/// The geometry arrives already rendered: a user-defined type is rendered by
+/// the database, and what PostGIS renders a geometry as is GeoJSON -- with a
+/// `crs` key, which a feature's geometry does not carry. Everything else on
+/// the row is the feature's properties, the geometry excepted, since a
+/// feature's geometry is not also one of its properties.
+fn feature_collection(rows: &[serde_json::Value], column: &str) -> Vec<u8> {
+    let features: Vec<serde_json::Value> = rows
+        .iter()
+        .map(|row| {
+            let mut properties = row.clone();
+            let geometry = properties
+                .as_object_mut()
+                .and_then(|fields| fields.remove(column))
+                .map(|mut geometry| {
+                    if let Some(fields) = geometry.as_object_mut() {
+                        fields.remove("crs");
+                    }
+                    round_coordinates(&mut geometry);
+                    geometry
+                })
+                .unwrap_or(serde_json::Value::Null);
+            serde_json::json!({
+                "type": "Feature",
+                "geometry": geometry,
+                "properties": properties,
+            })
+        })
+        .collect();
+    serde_json::to_vec(&serde_json::json!({
+        "type": "FeatureCollection",
+        "features": features,
+    }))
+    .unwrap_or_default()
+}
+
+/// The key under which a GeoJSON feature's geometry is read.
+///
+/// A table may carry more than one geometry column, and `?select=` is what
+/// says which of them the request is about: `select=id,name,range_area` asks
+/// for a collection of areas, not for whichever geometry the catalogue
+/// happens to list first. The name wanted is the one the response uses, so an
+/// aliased column is found under its alias -- which is also the key that has
+/// to come back out of `properties`, since a feature's geometry is not also
+/// one of its properties.
+///
+/// `None` means the rows carry no geometry at all, which is not a GeoJSON
+/// response with something missing from it but a request that cannot be
+/// answered.
+fn geometry_key(
+    table: &postrust_core::schema_cache::Table,
+    select: &[postrust_core::api_request::SelectItem],
+) -> Option<String> {
+    use postrust_core::api_request::SelectItem;
+
+    let is_geometry = |name: &str| {
+        table
+            .get_column(name)
+            .is_some_and(|c| matches!(c.nominal_type.as_str(), "geometry" | "geography"))
+    };
+
+    // `*` and a named column can both appear in one selection, and a column
+    // named outright is the one meant even so: `select=*,range_area` is a
+    // request about areas.
+    let mut selects_every_column = select.is_empty();
+    for item in select {
+        if let SelectItem::Field { field, alias, .. } = item {
+            if field.name == "*" {
+                selects_every_column = true;
+            } else if is_geometry(&field.name) {
+                return Some(alias.clone().unwrap_or_else(|| field.name.clone()));
+            }
+        }
+    }
+
+    if !selects_every_column {
+        return None;
+    }
+    table
+        .columns
+        .values()
+        .find(|c| matches!(c.nominal_type.as_str(), "geometry" | "geography"))
+        .map(|c| c.name.clone())
 }
 
 /// Whether any part of the selection, at any depth, asks for an aggregate.
@@ -2124,6 +2321,31 @@ fn flatten_spreads(
     }
 }
 
+/// The relation an embed names, found by the name the response uses.
+fn embedded_by_name<'a>(
+    select: &'a [postrust_core::api_request::SelectItem],
+    name: &str,
+) -> Option<(&'a str, Option<&'a str>)> {
+    use postrust_core::api_request::SelectItem;
+
+    select.iter().find_map(|item| match item {
+        SelectItem::Relation {
+            relation,
+            alias,
+            hint,
+            ..
+        } if alias.as_deref().unwrap_or(relation) == name => {
+            Some((relation.as_str(), hint.as_deref()))
+        }
+        // A spread has no alias -- nothing is being named -- so it answers to
+        // the relation's own name.
+        SelectItem::SpreadRelation { relation, hint, .. } if relation == name => {
+            Some((relation.as_str(), hint.as_deref()))
+        }
+        _ => None,
+    })
+}
+
 /// Build the `ORDER BY` expressions for terms naming an embedded resource.
 ///
 /// `order=clients(name)` orders by a column the parent does not have, so each
@@ -2134,6 +2356,7 @@ fn build_embed_orders(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
     order: &[postrust_core::plan::CoercibleOrderTerm],
+    select: &[postrust_core::api_request::SelectItem],
     ctx: &mut EmbedFilters<'_>,
 ) -> Result<Vec<String>, postrust_core::Error> {
     let mut orders = Vec::new();
@@ -2143,10 +2366,18 @@ fn build_embed_orders(
             continue;
         };
 
+        // `order=` names a resource this request embedded, by the name the
+        // response gives it -- so `pros:projects(*)` is ordered on as `pros`,
+        // and the table it came from is what the relationship is looked up
+        // by. A name the selection does not carry is not an embedded resource
+        // here, whether or not the schema has a table by that name.
+        let embedded = embedded_by_name(select, relation)
+            .ok_or_else(|| postrust_core::Error::NotAnEmbeddedResource(relation.clone()))?;
+
         let rel = schema_cache
-            .find_relationship(parent_qi, relation, None, &parent_qi.schema)?
+            .find_relationship(parent_qi, embedded.0, embedded.1, &parent_qi.schema)?
             .ok_or_else(|| {
-                schema_cache.relationship_not_found(parent_qi, relation, None, &parent_qi.schema)
+                schema_cache.relationship_not_found(parent_qi, embedded.0, embedded.1, &parent_qi.schema)
             })?;
 
         // A resource that yields many rows per parent has no single value to
@@ -2441,16 +2672,23 @@ fn build_embed_expressions(
 fn declared_media_type(
     db_plan: &DbActionPlan,
     api_request: &postrust_core::api_request::ApiRequest,
-) -> Option<String> {
+) -> Option<(String, String)> {
     let DbActionPlan::Call { call, .. } = db_plan else {
         return None;
     };
     let declared = call.media_type.as_deref()?;
+    let base = call.media_base_type.clone().unwrap_or_default();
+    // A function declaring `*/*` says it will render whatever was asked for,
+    // so every request is one it answers -- and what it answers with is bytes,
+    // which on the wire is called `application/octet-stream`.
+    if declared == "*/*" {
+        return Some(("application/octet-stream".to_string(), base));
+    }
     api_request
         .accept_media_types
         .iter()
         .any(|accepted| accepted.content_type() == declared)
-        .then(|| declared.to_string())
+        .then(|| (declared.to_string(), base))
 }
 
 /// Whether a selection produces any keys in the response.
@@ -2971,6 +3209,10 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::InvalidGucHeaders
         | Error::InvalidGucStatus
         | Error::InvalidMediaType(_)
+        // Says only that the rows the request asked for carry no geometry,
+        // which is about the request's own shape and is what the client has
+        // to change.
+        | Error::MissingGeometryColumn
         // Quotes the client's own URL back at it, and names the grammar the
         // API publishes. Neither is the schema's.
         | Error::UnparsableQuery { .. }
@@ -3038,6 +3280,7 @@ mod tests {
         CallPlan {
             output_columns: Vec::new(),
             media_type: None,
+            media_base_type: None,
             function: QualifiedIdentifier::new("public", name),
             params: CallParams::None,
             returns_scalar: !returns_set,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -950,20 +950,28 @@ async fn execute_plan(
             // `Vec<PgRow>` staying alive alongside the whole `Vec<Value>`.
             // A rendered media type is a single value, not a row set: the
             // aggregate already produced the entire body.
-            if let Some(media_type) =
-                media_handler
-                    .as_ref()
-                    .map(|(m, _, _)| m.clone())
-                    .or_else(|| {
-                        geojson_column
-                            .as_ref()
-                            .map(|_| "application/geo+json".to_string())
-                    })
+            if let Some(media_type) = media_handler
+                .as_ref()
+                .map(|(m, _, _)| m.clone())
+                .or_else(|| {
+                    geojson_column
+                        .as_ref()
+                        .map(|_| "application/geo+json".to_string())
+                })
+                .or_else(|| declared_media_type(db_plan, api_request))
             {
                 use sqlx::Row;
+                // Read as bytes where the media type is not text: a value that
+                // is a PNG is not a string, and asking for one back gets
+                // nothing at all.
                 let body = rows
                     .first()
-                    .and_then(|row| row.try_get::<Option<String>, _>(0).ok())
+                    .and_then(|row| {
+                        row.try_get::<Option<String>, _>(0)
+                            .map(|text| text.map(String::into_bytes))
+                            .or_else(|_| row.try_get::<Option<Vec<u8>>, _>(0))
+                            .ok()
+                    })
                     .flatten()
                     .unwrap_or_default();
                 tx.commit()
@@ -2411,6 +2419,28 @@ fn build_embed_expressions(
     Ok(level)
 }
 
+/// The media type a function's own return type declares, where the client
+/// asked for it.
+///
+/// A function returning a domain named `text/plain` returns text, and the
+/// value is the whole response. It is still only returned that way to a client
+/// that asked: the same value serialised as JSON is a perfectly good answer to
+/// a request that did not.
+fn declared_media_type(
+    db_plan: &DbActionPlan,
+    api_request: &postrust_core::api_request::ApiRequest,
+) -> Option<String> {
+    let DbActionPlan::Call { call, .. } = db_plan else {
+        return None;
+    };
+    let declared = call.media_type.as_deref()?;
+    api_request
+        .accept_media_types
+        .iter()
+        .any(|accepted| accepted.content_type() == declared)
+        .then(|| declared.to_string())
+}
+
 /// Whether a selection produces any keys in the response.
 ///
 /// A relation contributes only what its own selection does, so `tasks()` and
@@ -2976,6 +3006,8 @@ mod tests {
 
     fn call_plan(name: &str, returns_set: bool) -> CallPlan {
         CallPlan {
+            output_columns: Vec::new(),
+            media_type: None,
             function: QualifiedIdentifier::new("public", name),
             params: CallParams::None,
             returns_scalar: !returns_set,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -25,6 +25,15 @@ use tracing::{debug, error};
 /// embed expression reads it from there. It is stripped from the response like
 /// any other column added for embedding.
 const PARENT_ROW_COLUMN: &str = "pgrst_parent_row";
+
+/// Marks an embedded object whose columns belong to its parent.
+///
+/// A spread has no key of its own in the response -- its columns land in the
+/// parent object. In SQL it is still one JSON column like any other embed, so
+/// it is given a name nothing can collide with and dissolved into its parent
+/// once the rows are JSON. Doing it there rather than in SQL is what lets a
+/// spread nest inside another, and lets it spread a computed relationship.
+const SPREAD_KEY_PREFIX: &str = "pgrst_spread_";
 const PARENT_ROW_COLUMN_REF: &str = "\"src\".\"pgrst_parent_row\"";
 
 /// Main request handler.
@@ -238,8 +247,9 @@ async fn execute_plan(
                         matches!(
                             item,
                             postrust_core::api_request::SelectItem::Relation { .. }
+                                | postrust_core::api_request::SelectItem::SpreadRelation { .. }
                         )
-                    }) && !contains_spread(&api_request.query_params.select) =>
+                    }) =>
                 {
                     let schema_cache = state.schema_cache().await;
                     build_embed_expressions(
@@ -584,6 +594,16 @@ async fn execute_plan(
                 }
             }
 
+            // A spread's columns belong to the object above it. This happens
+            // after the join columns are dropped, not before: a spread may
+            // legitimately produce a column of the same name as one added for
+            // joining, and dropping it afterwards would take the wrong one.
+            let spread_columns: std::collections::HashMap<String, Vec<String>> =
+                embed_level.spread_columns.iter().cloned().collect();
+            for row in json_rows.iter_mut() {
+                flatten_spreads(row, &spread_columns);
+            }
+
             // In PostgREST-compatibility mode, reshape RPC responses to match
             // PostgREST: un-nest the function-name-keyed column and return a
             // bare value for non-set-returning functions.
@@ -739,17 +759,6 @@ fn selects_an_aggregate(api_request: &ApiRequest) -> bool {
     walk(&api_request.query_params.select)
 }
 
-/// Whether a select list spreads a related resource, at any depth.
-fn contains_spread(items: &[postrust_core::api_request::SelectItem]) -> bool {
-    use postrust_core::api_request::SelectItem;
-
-    items.iter().any(|item| match item {
-        SelectItem::SpreadRelation { .. } => true,
-        SelectItem::Relation { select, .. } => contains_spread(select),
-        SelectItem::Field { .. } => false,
-    })
-}
-
 /// Whether this request is a read, and so may run read-only.
 ///
 /// It is the method that decides, not the plan: calling a function is a read
@@ -835,6 +844,14 @@ fn add_embed_join_columns(
         return Ok(Vec::new());
     }
 
+    // `*` already names every column, so no join column needs adding -- and
+    // adding one anyway selects it twice, which makes `src.*` ambiguous. The
+    // relations are still walked: a computed relationship needs the parent's
+    // row carried out, and `*` does not provide that.
+    let selects_everything = select
+        .iter()
+        .any(|item| matches!(item, SelectItem::Field { field, .. } if field.name == "*"));
+
     let selected: std::collections::HashSet<String> = select
         .iter()
         .filter_map(|item| match item {
@@ -883,6 +900,10 @@ fn add_embed_join_columns(
                 .map(|(local, _)| local.clone())
                 .collect(),
         };
+
+        if selects_everything {
+            continue;
+        }
 
         for column in join_columns {
             if !selected.contains(&column) && !added.contains(&column) {
@@ -1029,6 +1050,127 @@ struct EmbedLevel {
     inner_joins: Vec<String>,
     /// `ORDER BY` expressions for terms naming an embedded resource.
     orders: Vec<String>,
+    /// For each spread, the keys it contributes to its parent.
+    ///
+    /// Needed because a spread that matched nothing still carries them --
+    /// as nulls, or as empty arrays for a to-many -- and by then there is no
+    /// row to read the names off.
+    spread_columns: Vec<(String, Vec<String>)>,
+}
+
+/// The keys a spread's selection contributes to the object above it.
+///
+/// `*` names every column of the related table, an alias renames the column it
+/// precedes, and a nested spread contributes its own keys, having already been
+/// flattened into this one.
+fn spread_output_names(
+    schema_cache: &postrust_core::SchemaCache,
+    child_qi: &postrust_core::api_request::QualifiedIdentifier,
+    select: &[postrust_core::api_request::SelectItem],
+) -> Vec<String> {
+    use postrust_core::api_request::SelectItem;
+
+    let mut names = Vec::new();
+    for item in select {
+        match item {
+            SelectItem::Field { field, .. } if field.name == "*" => {
+                if let Some(table) = schema_cache.get_table(child_qi) {
+                    names.extend(table.columns.keys().cloned());
+                }
+            }
+            SelectItem::Field { field, alias, .. } => {
+                names.push(alias.clone().unwrap_or_else(|| field.name.clone()));
+            }
+            SelectItem::Relation {
+                relation, alias, ..
+            } => names.push(alias.clone().unwrap_or_else(|| relation.clone())),
+            SelectItem::SpreadRelation {
+                relation, select, ..
+            } => {
+                if let Some(rel) = schema_cache
+                    .find_relationship(child_qi, relation, None, &child_qi.schema)
+                    .ok()
+                    .flatten()
+                {
+                    let target = rel.foreign_table().clone();
+                    names.extend(spread_output_names(schema_cache, &target, select));
+                }
+            }
+        }
+    }
+    names
+}
+
+/// Dissolve spread embeds into the objects that contain them.
+///
+/// A spread arrives as an ordinary JSON column under a reserved name. This
+/// walks the response and, wherever it finds one, moves its columns up into
+/// the surrounding object and drops the name.
+///
+/// It recurses first, so a spread nested inside another is already flattened
+/// by the time its parent is -- which is what carries a grandchild's columns
+/// all the way up.
+///
+/// Spreading a to-many gives each column an array of that column's values
+/// across the matched rows, rather than an array of objects.
+fn flatten_spreads(
+    value: &mut serde_json::Value,
+    columns: &std::collections::HashMap<String, Vec<String>>,
+) {
+    match value {
+        serde_json::Value::Array(items) => {
+            for item in items {
+                flatten_spreads(item, columns);
+            }
+        }
+        serde_json::Value::Object(object) => {
+            for (_, child) in object.iter_mut() {
+                flatten_spreads(child, columns);
+            }
+
+            let spread_keys: Vec<String> = object
+                .keys()
+                .filter(|key| key.starts_with(SPREAD_KEY_PREFIX))
+                .cloned()
+                .collect();
+
+            for key in spread_keys {
+                let Some(spread) = object.remove(&key) else {
+                    continue;
+                };
+                let names = columns.get(&key).cloned().unwrap_or_default();
+                match spread {
+                    serde_json::Value::Object(columns) => {
+                        for (name, column) in columns {
+                            object.insert(name, column);
+                        }
+                    }
+                    // A to-many: one array per column rather than an array of
+                    // objects, so the rows are transposed. With no rows the
+                    // columns are still named, each holding an empty array.
+                    serde_json::Value::Array(rows) => {
+                        for name in names {
+                            let column = rows
+                                .iter()
+                                .map(|row| {
+                                    row.get(&name).cloned().unwrap_or(serde_json::Value::Null)
+                                })
+                                .collect();
+                            object.insert(name, serde_json::Value::Array(column));
+                        }
+                    }
+                    // The relationship matched nothing. The keys are still
+                    // the client's to expect, so they are there, holding null.
+                    _ => {
+                        for name in names {
+                            object.insert(name, serde_json::Value::Null);
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Build the `ORDER BY` expressions for terms naming an embedded resource.
@@ -1105,15 +1247,25 @@ fn build_embed_expressions(
     let mut level = EmbedLevel::default();
 
     for item in select {
-        let SelectItem::Relation {
-            relation,
-            alias,
-            select: child_select,
-            join_type,
-            hint,
-        } = item
-        else {
-            continue;
+        // A spread is embedded exactly like a plain relation. The two differ
+        // only in where the child's columns end up, and that is settled once
+        // the rows are JSON -- so here the spread is marked by the name its
+        // expression is given, and flattened afterwards.
+        let (relation, alias, child_select, join_type, hint, is_spread) = match item {
+            SelectItem::Relation {
+                relation,
+                alias,
+                select,
+                join_type,
+                hint,
+            } => (relation, alias.clone(), select, join_type, hint, false),
+            SelectItem::SpreadRelation {
+                relation,
+                select,
+                join_type,
+                hint,
+            } => (relation, None, select, join_type, hint, true),
+            SelectItem::Field { .. } => continue,
         };
 
         let rel = schema_cache
@@ -1174,6 +1326,7 @@ fn build_embed_expressions(
             ));
         }
 
+        level.spread_columns.extend(nested.spread_columns);
         let nested_expressions = nested.expressions;
 
         // The child's own columns. Empty means every column, which is what a
@@ -1182,6 +1335,9 @@ fn build_embed_expressions(
         let mut project_everything = child_select.is_empty();
         for nested_item in child_select {
             match nested_item {
+                SelectItem::Field { field, .. } if field.name == "*" => {
+                    project_everything = true;
+                }
                 SelectItem::Field { field, alias, .. } => {
                     let column = postrust_sql::escape_ident(&field.name);
                     match alias {
@@ -1194,8 +1350,7 @@ fn build_embed_expressions(
                     }
                 }
                 // Handled as an expression, not a column.
-                SelectItem::Relation { .. } => {}
-                SelectItem::SpreadRelation { .. } => project_everything = true,
+                SelectItem::Relation { .. } | SelectItem::SpreadRelation { .. } => {}
             }
         }
         if project_everything {
@@ -1220,10 +1375,26 @@ fn build_embed_expressions(
             child_where.as_deref(),
         )?;
 
-        level.expressions.push((
-            alias.clone().unwrap_or_else(|| relation.clone()),
-            expression,
-        ));
+        if is_spread {
+            let names = spread_output_names(schema_cache, &child_qi, child_select);
+            if names.is_empty() {
+                // `...clients()` spreads no columns, so there is nothing to
+                // fetch and nothing to merge.
+                continue;
+            }
+            level
+                .spread_columns
+                .push((format!("{}{}", SPREAD_KEY_PREFIX, child_alias), names));
+        }
+
+        let key = match is_spread {
+            // A name nothing can collide with, since the object it names is
+            // dissolved into its parent before anyone sees it.
+            true => format!("{}{}", SPREAD_KEY_PREFIX, child_alias),
+            false => alias.clone().unwrap_or_else(|| relation.clone()),
+        };
+
+        level.expressions.push((key, expression));
     }
 
     Ok(level)

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -225,6 +225,8 @@ async fn execute_plan(
             // or timestamp renders identically either way.
             let mut embed_filters = EmbedFilters {
                 filters: &api_request.query_params.filters,
+                orders: &api_request.query_params.order,
+                ranges: &api_request.query_params.ranges,
                 params: Vec::new(),
                 base: params.len(),
                 max_rows: api_request.max_rows,
@@ -326,9 +328,40 @@ async fn execute_plan(
                 }
                 sql = format!("SELECT {} FROM ({}) AS src", projection, sql);
 
-                if !embed_level.inner_joins.is_empty() {
+                // `?clients=is.null` asks whether the embed matched anything,
+                // not about a column. The embed's expression is the thing to
+                // test, and it is only in scope out here -- referring to the
+                // name it is given would be referring to a column of the very
+                // select that defines it.
+                let mut predicates = embed_level.inner_joins.clone();
+                for filter in &api_request.query_params.filters_root {
+                    let Some((_, exists)) = embed_level
+                        .filterable
+                        .iter()
+                        .find(|(name, _)| name == &filter.field.name)
+                    else {
+                        continue;
+                    };
+                    let negated = match &filter.op_expr.operation {
+                        postrust_core::api_request::Operation::Is(
+                            postrust_core::api_request::IsValue::Null,
+                        ) => filter.op_expr.negated,
+                        postrust_core::api_request::Operation::Is(
+                            postrust_core::api_request::IsValue::NotNull,
+                        ) => !filter.op_expr.negated,
+                        _ => continue,
+                    };
+                    // `is.null` asks for parents the embed did not match, so
+                    // the existence test is the negation of it.
+                    predicates.push(match negated {
+                        true => exists.clone(),
+                        false => format!("NOT {}", exists),
+                    });
+                }
+
+                if !predicates.is_empty() {
                     sql.push_str(" WHERE ");
-                    sql.push_str(&embed_level.inner_joins.join(" AND "));
+                    sql.push_str(&predicates.join(" AND "));
                 }
 
                 if !embed_level.orders.is_empty() {
@@ -946,6 +979,13 @@ struct EmbedFilters<'a> {
     params: Vec<postrust_sql::SqlParam>,
     /// How many parameters the main query already uses.
     base: usize,
+    /// Ordering asked of each embedded resource, by path.
+    orders: &'a [(
+        postrust_core::api_request::EmbedPath,
+        Vec<postrust_core::api_request::OrderTerm>,
+    )],
+    /// Ranges asked of each embedded resource, by dotted path.
+    ranges: &'a std::collections::HashMap<String, postrust_core::api_request::Range>,
     /// Row cap applied to each embedded resource.
     max_rows: Option<i64>,
     /// Source of unique subquery aliases across the whole embed tree.
@@ -992,6 +1032,67 @@ impl EmbedFilters<'_> {
     }
 
     /// The `WHERE` fragment for one embedded resource, or `None` if unfiltered.
+    #[allow(clippy::result_large_err)] // consistent with the crate's error type
+    /// The `ORDER BY` an embedded resource was asked for, if any.
+    ///
+    /// `clients.order=name.desc` orders the rows inside the embed, which is a
+    /// property of the child's own subselect rather than of the parent.
+    fn order_for(&self, path: &[String]) -> Option<String> {
+        let terms: Vec<String> = self
+            .orders
+            .iter()
+            .filter(|(p, _)| p.as_slice() == path)
+            .flat_map(|(_, terms)| terms.iter())
+            .map(|term| {
+                use postrust_core::api_request::{OrderDirection, OrderNulls, OrderTerm};
+                let (field, direction, nulls) = match term {
+                    OrderTerm::Field {
+                        field,
+                        direction,
+                        nulls,
+                    }
+                    | OrderTerm::Relation {
+                        field,
+                        direction,
+                        nulls,
+                        ..
+                    } => (field, direction, nulls),
+                };
+
+                let mut rendered = postrust_sql::escape_ident(&field.name);
+                match direction {
+                    Some(OrderDirection::Desc) => rendered.push_str(" DESC"),
+                    Some(OrderDirection::Asc) => rendered.push_str(" ASC"),
+                    None => {}
+                }
+                match nulls {
+                    Some(OrderNulls::First) => rendered.push_str(" NULLS FIRST"),
+                    Some(OrderNulls::Last) => rendered.push_str(" NULLS LAST"),
+                    None => {}
+                }
+                rendered
+            })
+            .collect();
+
+        match terms.is_empty() {
+            true => None,
+            false => Some(terms.join(", ")),
+        }
+    }
+
+    /// The row window an embedded resource was asked for.
+    ///
+    /// The server's own cap still applies, so an embed cannot be asked for
+    /// more rows than the server is willing to return.
+    fn range_for(&self, path: &[String]) -> Option<i64> {
+        let requested = self.ranges.get(&path.join(".")).and_then(|r| r.limit);
+        match (requested, self.max_rows) {
+            (Some(limit), Some(cap)) => Some(limit.min(cap)),
+            (Some(limit), None) => Some(limit),
+            (None, cap) => cap,
+        }
+    }
+
     #[allow(clippy::result_large_err)] // consistent with the crate's error type
     fn predicate_for(
         &mut self,
@@ -1050,6 +1151,10 @@ struct EmbedLevel {
     inner_joins: Vec<String>,
     /// `ORDER BY` expressions for terms naming an embedded resource.
     orders: Vec<String>,
+    /// Each embed under the name the client used for it, with its
+    /// expression. A spread's response key is internal, so this is what a
+    /// filter naming the embed -- `?clients=is.null` -- is matched against.
+    filterable: Vec<(String, String)>,
     /// For each spread, the keys it contributes to its parent.
     ///
     /// Needed because a spread that matched nothing still carries them --
@@ -1366,13 +1471,16 @@ fn build_embed_expressions(
         }
 
         let inner_select = parts.join(", ");
+        let child_order = ctx.order_for(&child_path);
+        let child_limit = ctx.range_for(&child_path);
         let expression = plan.embed_expression(
             parent_alias,
             parent_row,
             &child_alias,
             &inner_select,
-            ctx.max_rows,
+            child_limit,
             child_where.as_deref(),
+            child_order.as_deref(),
         )?;
 
         if is_spread {
@@ -1394,6 +1502,22 @@ fn build_embed_expressions(
             false => alias.clone().unwrap_or_else(|| relation.clone()),
         };
 
+        // Under the name the client used, whatever the response key is: a
+        // filter naming the embed is written against that name.
+        //
+        // What it records is an existence test, not the expression. Asking
+        // whether a to-many embed is null would never be true -- it renders as
+        // `[]`, never as null -- and "did this match anything" is the question
+        // either way.
+        level.filterable.push((
+            alias.clone().unwrap_or_else(|| relation.clone()),
+            plan.inner_join_predicate(
+                parent_alias,
+                parent_row,
+                &child_alias,
+                child_where.as_deref(),
+            ),
+        ));
         level.expressions.push((key, expression));
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -440,9 +440,7 @@ async fn execute_plan(
                                     // request did not reshape the rows, since
                                     // then the two are the same rows.
                                     handler.table.is_some()
-                                        || has_default_select(
-                                            &api_request.query_params.select,
-                                        ),
+                                        || has_default_select(&api_request.query_params.select),
                                     handler.base_type.clone(),
                                 )
                             })
@@ -787,16 +785,13 @@ async fn execute_plan(
                 // one predicate combining their existence tests. The read
                 // plan left the tree alone precisely so that it could be
                 // built here, where the embeds are in scope.
-                let embeds = postrust_core::api_request::embedded_names(
-                    &api_request.query_params.select,
-                );
+                let embeds =
+                    postrust_core::api_request::embedded_names(&api_request.query_params.select);
                 for (path, tree) in &api_request.query_params.logic {
                     if !path.is_empty() || !tree.names_only(&embeds) {
                         continue;
                     }
-                    if let Some(predicate) =
-                        embed_logic_predicate(tree, &embed_level.filterable)
-                    {
+                    if let Some(predicate) = embed_logic_predicate(tree, &embed_level.filterable) {
                         predicates.push(predicate);
                     }
                 }
@@ -855,12 +850,10 @@ async fn execute_plan(
                 let schema_cache = state.schema_cache().await;
                 let target = read_target(api_request, Some(db_plan), &schema_cache);
                 match target.as_ref().and_then(|qi| schema_cache.get_table(qi)) {
-                    Some(table) => {
-                        match geometry_key(table, &api_request.query_params.select) {
-                            Some(column) => Some(column),
-                            None => return Err(postrust_core::Error::MissingGeometryColumn),
-                        }
-                    }
+                    Some(table) => match geometry_key(table, &api_request.query_params.select) {
+                        Some(column) => Some(column),
+                        None => return Err(postrust_core::Error::MissingGeometryColumn),
+                    },
                     // Nothing this side can name a geometry column on -- a
                     // scalar function, say. Left to the database, which is
                     // where the answer was coming from anyway.
@@ -1313,12 +1306,15 @@ async fn execute_plan(
             // taken from the key, the bookkeeping columns removed. Built in
             // SQL it saw the row as the statement left it, and leaked
             // `pgrst_inserted` into a feature's properties.
-            let geojson_body = geojson_column.as_ref().filter(|_| !omit_body).map(|column| {
-                (
-                    "application/geo+json".to_string(),
-                    feature_collection(&rows, column),
-                )
-            });
+            let geojson_body = geojson_column
+                .as_ref()
+                .filter(|_| !omit_body)
+                .map(|column| {
+                    (
+                        "application/geo+json".to_string(),
+                        feature_collection(&rows, column),
+                    )
+                });
 
             // PostgREST reports the returned window on every successful data
             // response -- reads, mutations and RPC alike, but not on errors or
@@ -1401,23 +1397,6 @@ async fn execute_plan(
         ActionPlan::Info(info_plan) => {
             use postrust_core::plan::InfoPlan;
 
-            // What an OPTIONS is for: the methods this particular relation or
-            // function will answer. Derived from the relation itself rather
-            // than from the routing table, which offers every method on every
-            // path and so can only ever give the same answer.
-            let allow = {
-                let schema_cache = state.schema_cache().await;
-                Some(match info_plan {
-                    InfoPlan::OpenApiSpec => "OPTIONS,GET,HEAD".to_string(),
-                    // Asking what may be done with a table that is not there
-                    // is answered the same way as asking for the table: an
-                    // OPTIONS that reports methods for a relation nobody can
-                    // reach describes something that does not exist.
-                    InfoPlan::RelationInfo(qi) => relation_allow(schema_cache.require_table(qi)?),
-                    InfoPlan::RoutineInfo(qi) => routine_allow(schema_cache.get_routines(qi)),
-                })
-            };
-
             // Return appropriate metadata based on the info type
             let response_data = match info_plan {
                 InfoPlan::OpenApiSpec => {
@@ -1447,10 +1426,96 @@ async fn execute_plan(
             Ok(QueryResult {
                 status: StatusCode::OK,
                 rows: vec![response_data],
-                allow,
                 ..Default::default()
             })
         }
+    }
+}
+
+/// Answer an `OPTIONS` with the methods its resource actually has.
+///
+/// This runs outside the CORS layer because that layer answers every `OPTIONS`
+/// itself and never calls what it wraps -- `if parts.method == Method::OPTIONS`
+/// returns immediately, preflight or not. So an `OPTIONS` never reached the
+/// request handler at all: the body was empty because nothing built one, and
+/// `Allow` was missing because the code that knows the answer was never asked.
+///
+/// The CORS layer still writes the response, and this adds to it, so a
+/// preflight keeps every header it had.
+pub async fn options_allow(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: axum::middleware::Next,
+) -> Response {
+    if request.method() != http::Method::OPTIONS {
+        return next.run(request).await;
+    }
+
+    let verbatim_db_errors = state.config.compat_mode;
+
+    // Built here, from borrows, before anything is awaited: `axum::body::Body`
+    // is `Send` but not `Sync`, and `&T` is `Send` only where `T` is `Sync`, so
+    // a `&Request` held across an await makes the whole future not `Send` --
+    // which a middleware has to be.
+    let probe = probe_request(&request);
+    let allow = match probe {
+        Ok(probe) => resolve_allow(&state, probe).await,
+        Err(error) => Err(error),
+    };
+
+    let mut response = next.run(request).await;
+
+    match allow {
+        Ok(allow) => {
+            if let Ok(value) = http::HeaderValue::from_str(&allow) {
+                response.headers_mut().insert(http::header::ALLOW, value);
+            }
+            response
+        }
+        // Asking what may be done with a table that is not there is answered
+        // the same way as asking for the table.
+        Err(error) => error_response(error, verbatim_db_errors).into_response(),
+    }
+}
+
+/// The request again, with an empty body, for the parser to read.
+fn probe_request(request: &Request) -> Result<http::Request<bytes::Bytes>, postrust_core::Error> {
+    let mut builder = http::Request::builder()
+        .method(request.method().clone())
+        .uri(request.uri().clone());
+    for (name, value) in request.headers() {
+        builder = builder.header(name, value);
+    }
+    builder
+        .body(bytes::Bytes::new())
+        .map_err(|e| postrust_core::Error::Internal(e.to_string()))
+}
+
+/// What the resource this request names allows, or why it cannot say.
+///
+/// The path is resolved by the same parser the handler uses rather than by
+/// splitting on `/` here, so a percent-encoded table name, an `Accept-Profile`
+/// naming another schema, and the `/rpc/` prefix all mean what they mean
+/// everywhere else.
+async fn resolve_allow(
+    state: &AppState,
+    probe: http::Request<bytes::Bytes>,
+) -> Result<String, postrust_core::Error> {
+    use postrust_core::api_request::Action;
+
+    let api_request = parse_request(
+        &probe,
+        state.default_schema(),
+        state.schemas(),
+        state.config.db_max_rows,
+    )?;
+
+    let schema_cache = state.schema_cache().await;
+    match &api_request.action {
+        Action::RelationInfo(qi) => Ok(relation_allow(schema_cache.require_table(qi)?)),
+        Action::RoutineInfo { qi, .. } => Ok(routine_allow(schema_cache.get_routines(qi))),
+        // The schema description, which is read and nothing else.
+        _ => Ok("OPTIONS,GET,HEAD".to_string()),
     }
 }
 
@@ -2622,7 +2687,12 @@ fn build_embed_orders(
         let rel = schema_cache
             .find_relationship(parent_qi, embedded.0, embedded.1, &parent_qi.schema)?
             .ok_or_else(|| {
-                schema_cache.relationship_not_found(parent_qi, embedded.0, embedded.1, &parent_qi.schema)
+                schema_cache.relationship_not_found(
+                    parent_qi,
+                    embedded.0,
+                    embedded.1,
+                    &parent_qi.schema,
+                )
             })?;
 
         // A resource that yields many rows per parent has no single value to
@@ -2805,12 +2875,11 @@ fn build_embed_expressions(
         level.spread_columns.extend(nested.spread_columns);
         let nested_expressions = nested.expressions;
 
-        let child_table = schema_cache.get_table(
-            &postrust_core::api_request::QualifiedIdentifier::new(
+        let child_table =
+            schema_cache.get_table(&postrust_core::api_request::QualifiedIdentifier::new(
                 &plan.foreign_schema,
                 &plan.foreign_table,
-            ),
-        );
+            ));
 
         // The child's own columns. Empty means every column, which is what a
         // relation with no explicit selection asks for.

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -191,6 +191,16 @@ fn requested_plan(api_request: &ApiRequest) -> Option<String> {
     }
 }
 
+/// Which kind of mutation this request is, if it is one.
+fn mutation_kind(api_request: &ApiRequest) -> Option<postrust_core::api_request::Mutation> {
+    use postrust_core::api_request::{Action, DbAction};
+
+    match &api_request.action {
+        Action::Db(DbAction::RelationMut { mutation, .. }) => Some(mutation.clone()),
+        _ => None,
+    }
+}
+
 /// The prefix given to primary key columns added only to build `Location`.
 const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 
@@ -951,13 +961,6 @@ async fn execute_plan(
                 db_plan,
                 DbActionPlan::Call { call, .. } if call.return_type.as_deref() == Some("void")
             );
-            if returns_void {
-                return Ok(QueryResult {
-                    status: StatusCode::NO_CONTENT,
-                    omit_body: true,
-                    ..Default::default()
-                });
-            }
 
             // `Prefer: max-affected` guards against a filter that turned out
             // to match more than the client meant. Nothing has been committed
@@ -999,15 +1002,40 @@ async fn execute_plan(
                 .filter(|offset| *offset != 0)
                 .unwrap_or(api_request.top_level_range.offset);
 
-            let content_range =
-                postrust_response::ContentRange::from_pagination(offset, rows.len() as i64, total);
+            // What a mutation reports is not a window on a result set. An
+            // insert or a delete reports no window at all -- `*` -- because
+            // the rows it wrote are not a page of anything; an update reports
+            // how many it changed; and an upsert reports nothing, the client
+            // having named the row itself. PostgREST draws exactly these
+            // lines, and a client reading the header expects them.
+            use postrust_core::api_request::Mutation;
+            let content_range = match mutation_kind(api_request) {
+                Some(Mutation::SingleUpsert) => None,
+                Some(Mutation::Create) | Some(Mutation::Delete) => {
+                    Some(postrust_response::ContentRange::new(1, 0, total))
+                }
+                Some(Mutation::Update) => Some(postrust_response::ContentRange::new(
+                    0,
+                    rows.len() as i64 - 1,
+                    total,
+                )),
+                None => Some(postrust_response::ContentRange::from_pagination(
+                    offset,
+                    rows.len() as i64,
+                    total,
+                )),
+            };
 
             // An offset past the end of the result is a range the server
             // cannot satisfy, and saying how many rows there actually are is
             // what lets the client correct it. Only reachable with a count
             // preference: without one the total is unknown and there is
             // nothing to be past the end of.
-            if content_range.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+            if content_range
+                .as_ref()
+                .is_some_and(|range| range.status() == StatusCode::RANGE_NOT_SATISFIABLE)
+                && mutation_kind(api_request).is_none()
+            {
                 return Err(postrust_core::Error::InvalidRange(format!(
                     "An offset of {} was requested, but there are only {} rows.",
                     offset,
@@ -1016,13 +1044,20 @@ async fn execute_plan(
             }
 
             Ok(QueryResult {
-                status: mutation_status(db_plan, api_request)
-                    .unwrap_or_else(|| content_range.status()),
+                status: match returns_void {
+                    true => StatusCode::NO_CONTENT,
+                    false => mutation_status(db_plan, api_request).unwrap_or_else(|| {
+                        content_range
+                            .as_ref()
+                            .map(postrust_response::ContentRange::status)
+                            .unwrap_or(StatusCode::OK)
+                    }),
+                },
                 rows,
                 singular,
-                omit_body,
+                omit_body: omit_body || returns_void,
                 location,
-                content_range: Some(content_range),
+                content_range,
                 ..Default::default()
             })
         }

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -135,12 +135,39 @@ async fn execute_plan(
 ) -> Result<QueryResult, postrust_core::Error> {
     match plan {
         ActionPlan::Db(db_plan) => {
+            // A media type the schema renders itself replaces the whole
+            // response body: the aggregate is applied over the rows the
+            // request selected, so it sees exactly what would otherwise have
+            // been serialised as JSON.
+            let media_handler = {
+                let schema_cache = state.schema_cache().await;
+                read_target(api_request).and_then(|qi| {
+                    api_request.accept_media_types.iter().find_map(|media| {
+                        schema_cache
+                            .media_handler(&api_request.schema, media.content_type(), &qi)
+                            .map(|handler| {
+                                (
+                                    media.content_type().to_string(),
+                                    format!(
+                                        "{}.{}",
+                                        postrust_sql::escape_ident(&handler.aggregate.schema),
+                                        postrust_sql::escape_ident(&handler.aggregate.name)
+                                    ),
+                                    handler.table.is_some(),
+                                )
+                            })
+                    })
+                })
+            };
+
             // Carry the parent's whole row out of the inner query when a
             // computed relationship needs it as an argument. It has to be
             // taken here, where the real table is still in scope: a bare
             // reference to the table yields its composite type, whereas the
             // derived table it becomes one level up yields a `record`.
-            let db_plan = &if added_join_columns.iter().any(|c| c == PARENT_ROW_COLUMN) {
+            let needs_parent_row = added_join_columns.iter().any(|c| c == PARENT_ROW_COLUMN)
+                || matches!(&media_handler, Some((_, _, true)));
+            let db_plan = &if needs_parent_row {
                 let mut adjusted = db_plan.clone();
                 if let DbActionPlan::Read(tree) = &mut adjusted {
                     let mut field = postrust_core::plan::CoercibleField::simple(
@@ -277,6 +304,80 @@ async fn execute_plan(
                 }
             }
 
+            // `application/geo+json` has a rendering of its own even where no
+            // schema declares one: a FeatureCollection whose geometry is the
+            // table's geometry column and whose properties are the rest. A
+            // schema-declared handler overrides it, which is why this only
+            // runs when none matched.
+            let geojson_column = if media_handler.is_none() {
+                let schema_cache = state.schema_cache().await;
+                read_target(api_request)
+                    .filter(|_| {
+                        api_request
+                            .accept_media_types
+                            .iter()
+                            .any(|m| matches!(m, postrust_core::api_request::MediaType::GeoJson))
+                    })
+                    .and_then(|qi| {
+                        schema_cache.get_table(&qi).and_then(|table| {
+                            table
+                                .columns
+                                .values()
+                                .find(|c| {
+                                    matches!(c.nominal_type.as_str(), "geometry" | "geography")
+                                })
+                                .map(|c| c.name.clone())
+                        })
+                    })
+            } else {
+                None
+            };
+
+            if let Some(column) = &geojson_column {
+                // The geometry column already arrives as jsonb, since a
+                // user-defined type is rendered by the database. For a
+                // geometry that rendering is GeoJSON with a `crs` key, and
+                // dropping that key is exactly `ST_AsGeoJSON` -- which also
+                // means this needs no PostGIS function in scope.
+                //
+                // The name is a real column's, read from the catalogue rather
+                // than from the request, but it is quoted both ways all the
+                // same: as an identifier to read the column, and as a literal
+                // to drop that key from the properties.
+                sql = format!(
+                    "SELECT json_build_object('type', 'FeatureCollection', 'features', \
+                     COALESCE(json_agg(json_build_object('type', 'Feature', 'geometry', \
+                     pgrst_geo.{column} - 'crs', 'properties', \
+                     to_jsonb(pgrst_geo) - '{key}')), '[]'::json))::text \
+                     AS pgrst_body FROM ({sql}) pgrst_geo",
+                    column = postrust_sql::escape_ident(column),
+                    key = column.replace('\'', "''"),
+                    sql = sql
+                );
+            }
+
+            if let Some((media_type, aggregate, over_row)) = &media_handler {
+                // The aggregate takes the table's own row type. A derived
+                // table yields `record`, which will not cast to it, so where
+                // the handler names a table the aggregate is applied to the
+                // column carrying the real row -- the same column a computed
+                // relationship reads. A handler taking `anyelement` has no
+                // such requirement and takes the derived row directly.
+                let argument = if *over_row {
+                    format!(
+                        "pgrst_media.{}",
+                        postrust_sql::escape_ident(PARENT_ROW_COLUMN)
+                    )
+                } else {
+                    "pgrst_media".to_string()
+                };
+                sql = format!(
+                    "SELECT {}({})::text AS pgrst_body FROM ({}) pgrst_media",
+                    aggregate, argument, sql
+                );
+                debug!("Rendering {} via {}", media_type, aggregate);
+            }
+
             debug!("Executing SQL: {}", sql);
             debug!("With {} parameters", params.len());
 
@@ -306,8 +407,28 @@ async fn execute_plan(
             // right place to enforce it, since it covers anything reachable
             // from the statement -- a volatile function, a trigger, a rule --
             // rather than only what the planner thought to look at.
-            if !is_mutation(db_plan) {
+            if is_read_only(api_request) {
                 sqlx::query("SET TRANSACTION READ ONLY")
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(map_sqlx_error)?;
+            }
+
+            // The request's schema comes first on the search path, then the
+            // schemas configured as extra. Without this, anything an exposed
+            // object refers to by bare name -- the domain behind a media type
+            // handler, a type from an extension -- fails to resolve, because
+            // the pool's connection carries whatever search path it was opened
+            // with.
+            {
+                let mut path = vec![api_request.schema.clone()];
+                path.extend(state.config.db_extra_search_path.iter().cloned());
+                let rendered = path
+                    .iter()
+                    .map(|s| postrust_sql::escape_ident(s))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                sqlx::query(&format!("SET LOCAL search_path TO {}", rendered))
                     .execute(&mut *tx)
                     .await
                     .map_err(map_sqlx_error)?;
@@ -362,6 +483,34 @@ async fn execute_plan(
             // `into_iter` matters for large result sets: each row's buffers are
             // freed as soon as it has been converted, rather than the whole
             // `Vec<PgRow>` staying alive alongside the whole `Vec<Value>`.
+            // A rendered media type is a single value, not a row set: the
+            // aggregate already produced the entire body.
+            if let Some(media_type) =
+                media_handler
+                    .as_ref()
+                    .map(|(m, _, _)| m.clone())
+                    .or_else(|| {
+                        geojson_column
+                            .as_ref()
+                            .map(|_| "application/geo+json".to_string())
+                    })
+            {
+                use sqlx::Row;
+                let body = rows
+                    .first()
+                    .and_then(|row| row.try_get::<Option<String>, _>(0).ok())
+                    .flatten()
+                    .unwrap_or_default();
+                tx.commit()
+                    .await
+                    .map_err(|e| postrust_core::Error::ConnectionPool(e.to_string()))?;
+                return Ok(QueryResult {
+                    status: StatusCode::OK,
+                    raw_body: Some((media_type, body)),
+                    ..QueryResult::default()
+                });
+            }
+
             let mut json_rows: Vec<serde_json::Value> = rows
                 .into_iter()
                 .map(|row| postrust_core::row_json::row_to_json(&row))
@@ -549,6 +698,26 @@ fn contains_spread(items: &[postrust_core::api_request::SelectItem]) -> bool {
         SelectItem::Relation { select, .. } => contains_spread(select),
         SelectItem::Field { .. } => false,
     })
+}
+
+/// Whether this request is a read, and so may run read-only.
+///
+/// It is the method that decides, not the plan: calling a function is a read
+/// over GET and a write over POST, and the same function may be either. Asking
+/// the plan instead would class every call as a read and refuse the writes a
+/// POST is entitled to make.
+fn is_read_only(api_request: &ApiRequest) -> bool {
+    use postrust_core::api_request::{Action, DbAction, InvokeMethod};
+
+    match &api_request.action {
+        Action::Db(DbAction::RelationRead { .. }) | Action::Db(DbAction::SchemaRead { .. }) => true,
+        Action::Db(DbAction::Routine { invoke_method, .. }) => {
+            matches!(invoke_method, InvokeMethod::InvRead { .. })
+        }
+        Action::Db(DbAction::RelationMut { .. }) => false,
+        // Metadata only; nothing is executed against the database.
+        Action::RelationInfo(_) | Action::RoutineInfo { .. } | Action::SchemaInfo => true,
+    }
 }
 
 /// Whether this plan changes data.

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -103,6 +103,24 @@ async fn process_request(
         api_request.payload = payload;
     }
 
+    // A body that names different columns row by row cannot be written by one
+    // statement. Skipped when `?columns=` says which columns to write, since
+    // then the rows are free to differ.
+    if api_request.query_params.columns.is_none() {
+        if let Some(payload) = &api_request.payload {
+            postrust_core::api_request::payload::validate_uniform_keys(payload)?;
+        }
+    }
+
+    // A write with nothing to write is refused here rather than left to
+    // produce an `UPDATE ... SET` with no assignments, which PostgreSQL
+    // reports as a syntax error -- true, and no use at all to the client.
+    if api_request.payload.is_none() && needs_payload(&api_request) {
+        return Err(postrust_core::Error::InvalidBody(
+            "Empty or invalid json".into(),
+        ));
+    }
+
     // Get schema cache
     let schema_cache = state.schema_cache().await;
 
@@ -142,6 +160,23 @@ async fn process_request(
     })?;
 
     Ok(build_response(response))
+}
+
+/// Whether this request must carry a body.
+///
+/// Insert, update and upsert all write values that can only come from one.
+/// A delete names its rows in the query string, and a function call may take
+/// no arguments at all.
+fn needs_payload(api_request: &ApiRequest) -> bool {
+    use postrust_core::api_request::{Action, DbAction, Mutation};
+
+    matches!(
+        &api_request.action,
+        Action::Db(DbAction::RelationMut {
+            mutation: Mutation::Create | Mutation::Update | Mutation::SingleUpsert,
+            ..
+        })
+    )
 }
 
 /// Classify a JWT failure the way PostgREST reports it.
@@ -1080,13 +1115,26 @@ fn mutation_status(
 ) -> Option<StatusCode> {
     use postrust_core::plan::{DbActionPlan, MutatePlan};
 
+    use postrust_core::api_request::{Action, DbAction, Mutation};
+
     let DbActionPlan::MutateRead { mutate, .. } = db_plan else {
         return None;
     };
 
+    // A `PUT` is an upsert, planned as an insert but answered as an update:
+    // the client named the row it is writing, so nothing was created from its
+    // point of view whether or not a row existed before.
+    let is_upsert = matches!(
+        &api_request.action,
+        Action::Db(DbAction::RelationMut {
+            mutation: Mutation::SingleUpsert,
+            ..
+        })
+    );
+
     Some(match mutate {
-        MutatePlan::Insert { .. } => StatusCode::CREATED,
-        MutatePlan::Update { .. } | MutatePlan::Delete { .. } => {
+        MutatePlan::Insert { .. } if !is_upsert => StatusCode::CREATED,
+        _ => {
             if wants_representation(api_request) {
                 StatusCode::OK
             } else {
@@ -2350,7 +2398,10 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
     }
 
     (match error {
-        Error::ColumnNotFound(_) | Error::UnknownColumn(_) => "Column not found",
+        Error::ColumnNotFound(_) => "Column not found",
+        // The column is the client's own word and the relation is the one it
+        // addressed, so naming both says nothing it did not send.
+        Error::UnknownColumn { .. } => return error.to_string(),
         // Each of these says only what the request itself said: the resource
         // it named, the preference it sent, the shape it asked for. Repeating
         // that back tells the client nothing it did not already know, and is
@@ -2361,9 +2412,9 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::InvalidPreferences(_)
         | Error::NotSingular { .. }
         | Error::InvalidRange(_)
+        | Error::InvalidBody(_)
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
-        Error::InvalidBody(_) => "Invalid request body",
         // What the token failed on is the client's own token, so naming it
         // costs nothing and is the only way it can tell a bad signature from
         // an expired one.

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -89,6 +89,10 @@ async fn process_request(
     // way is removed from the response once the embed is attached.
     let added_join_columns = add_embed_join_columns(&mut api_request, &schema_cache)?;
 
+    if !state.config.db_aggregates_enabled && selects_an_aggregate(&api_request) {
+        return Err(postrust_core::Error::AggregatesNotAllowed);
+    }
+
     // Create execution plan
     let plan = create_action_plan(&api_request, &schema_cache)?;
 
@@ -141,7 +145,15 @@ async fn execute_plan(
             // Parent columns stay ordinary typed columns, so they are converted
             // to JSON by the same code as a request without embeds and a NUMERIC
             // or timestamp renders identically either way.
-            let embed_expressions = match read_target(api_request) {
+            let mut embed_filters = EmbedFilters {
+                filters: &api_request.query_params.filters,
+                params: Vec::new(),
+                base: params.len(),
+                max_rows: api_request.max_rows,
+                alias_counter: 0,
+            };
+
+            let embed_level = match read_target(api_request) {
                 Some(parent_qi)
                     if api_request.query_params.select.iter().any(|item| {
                         matches!(
@@ -151,28 +163,71 @@ async fn execute_plan(
                     }) =>
                 {
                     let schema_cache = state.schema_cache().await;
-                    let mut counter = 0;
                     build_embed_expressions(
                         &schema_cache,
                         &parent_qi,
                         "src",
                         &api_request.query_params.select,
-                        api_request.max_rows,
-                        &mut counter,
+                        &mut embed_filters,
+                        &[],
                     )?
                 }
-                _ => Vec::new(),
+                _ => EmbedLevel::default(),
             };
 
-            if !embed_expressions.is_empty() {
+            // Filter parameters are appended in the order the predicates were
+            // renumbered, so placeholder N in the wrapped SQL lines up with
+            // params[N - 1].
+            let mut params = params;
+            params.extend(embed_filters.params);
+
+            if !embed_level.expressions.is_empty() {
+                // `!inner` removes parent rows, so it has to be applied before
+                // the page is taken. Left where it is, the inner query's
+                // LIMIT would run first and the join would then trim an
+                // already-truncated page -- a request for one row could come
+                // back empty. So the inner query is rebuilt unpaged and the
+                // range moves out to the wrapper, after the join.
+                //
+                // Rebuilding is safe for parameter numbering: LIMIT and OFFSET
+                // render as literals, so dropping them leaves the placeholders
+                // and their count untouched.
+                let mut page = None;
+                if !embed_level.inner_joins.is_empty() {
+                    if let DbActionPlan::Read(tree) = db_plan {
+                        let mut unpaged = tree.clone();
+                        page = Some(std::mem::take(&mut unpaged.root.range));
+                        sql = postrust_core::query::build_query(
+                            &ActionPlan::Db(DbActionPlan::Read(unpaged)),
+                            Some(&auth.role),
+                        )?
+                        .build_main()
+                        .0;
+                    }
+                }
+
                 let mut projection = String::from("src.*");
-                for (field_name, expression) in &embed_expressions {
+                for (field_name, expression) in &embed_level.expressions {
                     projection.push_str(", ");
                     projection.push_str(expression);
                     projection.push_str(" AS ");
                     projection.push_str(&postrust_sql::escape_ident(field_name));
                 }
                 sql = format!("SELECT {} FROM ({}) AS src", projection, sql);
+
+                if !embed_level.inner_joins.is_empty() {
+                    sql.push_str(" WHERE ");
+                    sql.push_str(&embed_level.inner_joins.join(" AND "));
+                }
+
+                if let Some(range) = page {
+                    if let Some(limit) = range.limit {
+                        sql.push_str(&format!(" LIMIT {}", limit));
+                    }
+                    if range.offset > 0 {
+                        sql.push_str(&format!(" OFFSET {}", range.offset));
+                    }
+                }
             }
 
             debug!("Executing SQL: {}", sql);
@@ -255,7 +310,7 @@ async fn execute_plan(
             // list carried relations. This path remains for anything the
             // single-query form did not handle.
             if let Some(parent_qi) =
-                read_target(api_request).filter(|_| embed_expressions.is_empty())
+                read_target(api_request).filter(|_| embed_level.expressions.is_empty())
             {
                 let schema_cache = state.schema_cache().await;
                 embed_relations(
@@ -297,10 +352,28 @@ async fn execute_plan(
                 (json_rows, false)
             };
 
+            // A mutation returns the affected rows only when the caller asked
+            // for them; otherwise the body is empty whatever the status.
+            let omit_body = is_mutation(db_plan) && !wants_representation(api_request);
+            let rows = if omit_body { Vec::new() } else { json_rows };
+
+            // PostgREST reports the returned window on every successful data
+            // response -- reads, mutations and RPC alike, but not on errors or
+            // OPTIONS. Without an exact count the total is unknown, which
+            // renders as `*` and keeps the status at 200.
+            let content_range = postrust_response::ContentRange::from_pagination(
+                api_request.top_level_range.offset,
+                rows.len() as i64,
+                None,
+            );
+
             Ok(QueryResult {
-                status: StatusCode::OK,
-                rows: json_rows,
+                status: mutation_status(db_plan, api_request)
+                    .unwrap_or_else(|| content_range.status()),
+                rows,
                 singular,
+                omit_body,
+                content_range: Some(content_range),
                 ..Default::default()
             })
         }
@@ -391,6 +464,65 @@ fn read_target(
     }
 }
 
+/// Whether any part of the selection, at any depth, asks for an aggregate.
+fn selects_an_aggregate(api_request: &ApiRequest) -> bool {
+    use postrust_core::api_request::SelectItem;
+
+    fn walk(items: &[SelectItem]) -> bool {
+        items.iter().any(|item| match item {
+            SelectItem::Field { aggregate, .. } => aggregate.is_some(),
+            SelectItem::Relation { select, .. } => walk(select),
+            SelectItem::SpreadRelation { .. } => false,
+        })
+    }
+
+    walk(&api_request.query_params.select)
+}
+
+/// Whether this plan changes data.
+fn is_mutation(db_plan: &postrust_core::plan::DbActionPlan) -> bool {
+    matches!(
+        db_plan,
+        postrust_core::plan::DbActionPlan::MutateRead { .. }
+    )
+}
+
+/// Whether the caller asked for the affected rows back.
+fn wants_representation(api_request: &ApiRequest) -> bool {
+    matches!(
+        api_request.preferences.representation,
+        postrust_core::api_request::PreferRepresentation::Full
+    )
+}
+
+/// The status PostgREST gives a successful mutation, or `None` for anything
+/// that isn't one.
+///
+/// An insert reports 201 Created. An update or delete reports 204 No Content
+/// unless the caller asked for the rows back, in which case there is content
+/// to report and it is a plain 200.
+fn mutation_status(
+    db_plan: &postrust_core::plan::DbActionPlan,
+    api_request: &ApiRequest,
+) -> Option<StatusCode> {
+    use postrust_core::plan::{DbActionPlan, MutatePlan};
+
+    let DbActionPlan::MutateRead { mutate, .. } = db_plan else {
+        return None;
+    };
+
+    Some(match mutate {
+        MutatePlan::Insert { .. } => StatusCode::CREATED,
+        MutatePlan::Update { .. } | MutatePlan::Delete { .. } => {
+            if wants_representation(api_request) {
+                StatusCode::OK
+            } else {
+                StatusCode::NO_CONTENT
+            }
+        }
+    })
+}
+
 /// Ensure every embedded relation's join column is selected on the parent.
 ///
 /// Returns the columns that were added purely to make the join possible, so
@@ -457,23 +589,144 @@ fn add_embed_join_columns(
 /// `alias_counter` hands out a distinct alias per level, so a self-referential
 /// relationship stays unambiguous.
 #[allow(clippy::result_large_err)] // consistent with the crate's error type
+/// Filters addressed at embedded resources, and the parameters they bind.
+///
+/// The embed expressions are assembled as SQL text and wrapped around a main
+/// query that already owns `$1..$n`, so any placeholder introduced here has to
+/// be renumbered past that point and its value appended in the same order.
+struct EmbedFilters<'a> {
+    /// Every path-scoped filter on the request, e.g. `(["clients"], id=eq.1)`.
+    filters: &'a [(
+        postrust_core::api_request::EmbedPath,
+        postrust_core::api_request::Filter,
+    )],
+    /// Values bound by the predicates built so far, in placeholder order.
+    params: Vec<postrust_sql::SqlParam>,
+    /// How many parameters the main query already uses.
+    base: usize,
+    /// Row cap applied to each embedded resource.
+    max_rows: Option<i64>,
+    /// Source of unique subquery aliases across the whole embed tree.
+    alias_counter: usize,
+}
+
+/// Renumber the placeholders in `sql` so they start after `offset`.
+///
+/// Scans rather than string-replaces: a naive replacement of `$1` would also
+/// corrupt the `$1` inside `$10`.
+fn shift_placeholders(sql: &str, offset: usize) -> String {
+    let mut out = String::with_capacity(sql.len());
+    let mut chars = sql.char_indices().peekable();
+
+    while let Some((i, ch)) = chars.next() {
+        if ch != '$' {
+            out.push(ch);
+            continue;
+        }
+        let start = i + 1;
+        let mut end = start;
+        while let Some((j, d)) = chars.peek() {
+            if d.is_ascii_digit() {
+                end = j + d.len_utf8();
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        match sql[start..end].parse::<usize>() {
+            Ok(n) => out.push_str(&format!("${}", n + offset)),
+            Err(_) => out.push('$'),
+        }
+    }
+
+    out
+}
+
+impl EmbedFilters<'_> {
+    /// A fresh alias, unique across the embed tree.
+    fn next_alias(&mut self) -> String {
+        self.alias_counter += 1;
+        format!("e{}", self.alias_counter)
+    }
+
+    /// The `WHERE` fragment for one embedded resource, or `None` if unfiltered.
+    #[allow(clippy::result_large_err)] // consistent with the crate's error type
+    fn predicate_for(
+        &mut self,
+        path: &[String],
+        child_qi: &postrust_core::api_request::QualifiedIdentifier,
+        schema_cache: &postrust_core::SchemaCache,
+    ) -> Result<Option<String>, postrust_core::Error> {
+        let matching: Vec<_> = self
+            .filters
+            .iter()
+            .filter(|(filter_path, _)| filter_path.as_slice() == path)
+            .map(|(_, filter)| filter.clone())
+            .collect();
+
+        if matching.is_empty() {
+            return Ok(None);
+        }
+
+        let table = schema_cache.get_table(child_qi);
+        let mut parts = Vec::with_capacity(matching.len());
+
+        for filter in &matching {
+            // Inside the child's subselect an unqualified name binds to the
+            // child, but only because the child has that column: an unknown
+            // name would resolve outward to the correlated parent and filter
+            // the wrong table silently. Refuse instead.
+            let column = table
+                .and_then(|t| t.columns.get(&filter.field.name))
+                .ok_or_else(|| {
+                    postrust_core::Error::ColumnNotFound(format!(
+                        "{}.{}",
+                        child_qi.name, filter.field.name
+                    ))
+                })?;
+
+            let frag =
+                postrust_core::query::QueryBuilder::filter_sql(filter, &column.nominal_type)?;
+            parts.push(shift_placeholders(
+                frag.sql(),
+                self.base + self.params.len(),
+            ));
+            self.params.extend(frag.params().iter().cloned());
+        }
+
+        Ok(Some(format!("({})", parts.join(" AND "))))
+    }
+}
+
+/// One level of the embed tree.
+#[derive(Default)]
+struct EmbedLevel {
+    /// `(response key, SQL expression)` for each relation at this level.
+    expressions: Vec<(String, String)>,
+    /// `EXISTS` predicates from `!inner` on these relations. They reference
+    /// the alias of the level *above*, so the caller applies them.
+    inner_joins: Vec<String>,
+}
+
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn build_embed_expressions(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
     parent_alias: &str,
     select: &[postrust_core::api_request::SelectItem],
-    max_rows: Option<i64>,
-    alias_counter: &mut usize,
-) -> Result<Vec<(String, String)>, postrust_core::Error> {
+    ctx: &mut EmbedFilters<'_>,
+    path: &[String],
+) -> Result<EmbedLevel, postrust_core::Error> {
     use postrust_core::api_request::SelectItem;
 
-    let mut expressions = Vec::new();
+    let mut level = EmbedLevel::default();
 
     for item in select {
         let SelectItem::Relation {
             relation,
             alias,
-            select: nested,
+            select: child_select,
+            join_type,
             ..
         } = item
         else {
@@ -485,28 +738,63 @@ fn build_embed_expressions(
             .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
-        *alias_counter += 1;
-        let child_alias = format!("e{}", alias_counter);
+        let child_alias = ctx.next_alias();
         let child_qi = postrust_core::api_request::QualifiedIdentifier::new(
             &plan.foreign_schema,
             &plan.foreign_table,
         );
 
+        // Filters are addressed by the name the client used, which is the
+        // alias when there is one -- `c:clients(*)&c.id=eq.1`.
+        let mut child_path = path.to_vec();
+        child_path.push(alias.clone().unwrap_or_else(|| relation.clone()));
+        let child_where = ctx.predicate_for(&child_path, &child_qi, schema_cache)?;
+
         // Deeper relations first: they become part of this level's SELECT list.
-        let nested_expressions = build_embed_expressions(
+        let nested = build_embed_expressions(
             schema_cache,
             &child_qi,
             &child_alias,
-            nested,
-            max_rows,
-            alias_counter,
+            child_select,
+            ctx,
+            &child_path,
         )?;
+
+        // A nested `!inner` is written against this child's alias, which is
+        // only in scope inside this child's own subselect -- so it narrows the
+        // child here rather than travelling up to the top-level wrapper.
+        let child_where = match (child_where, nested.inner_joins.is_empty()) {
+            (existing, true) => existing,
+            (Some(existing), false) => Some(format!(
+                "{} AND {}",
+                existing,
+                nested.inner_joins.join(" AND ")
+            )),
+            (None, false) => Some(nested.inner_joins.join(" AND ")),
+        };
+
+        // `!inner` on this relation restricts the parent rows. It is emitted
+        // against `parent_alias`, so it belongs to the caller's level; reusing
+        // the same predicate string lets both places share placeholders.
+        // The child keeps the same alias it has in the embed subselect. The
+        // two are sibling scopes, never nested, so there is no collision --
+        // and any nested predicate folded into `child_where` already names
+        // that alias, so it has to be the one in scope here too.
+        if matches!(join_type, Some(postrust_core::api_request::JoinType::Inner)) {
+            level.inner_joins.push(plan.inner_join_predicate(
+                parent_alias,
+                &child_alias,
+                child_where.as_deref(),
+            ));
+        }
+
+        let nested_expressions = nested.expressions;
 
         // The child's own columns. Empty means every column, which is what a
         // relation with no explicit selection asks for.
         let mut parts: Vec<String> = Vec::new();
-        let mut project_everything = nested.is_empty();
-        for nested_item in nested {
+        let mut project_everything = child_select.is_empty();
+        for nested_item in child_select {
             match nested_item {
                 SelectItem::Field { field, alias, .. } => {
                     let column = postrust_sql::escape_ident(&field.name);
@@ -537,16 +825,21 @@ fn build_embed_expressions(
         }
 
         let inner_select = parts.join(", ");
-        let expression =
-            plan.embed_expression(parent_alias, &child_alias, &inner_select, max_rows)?;
+        let expression = plan.embed_expression(
+            parent_alias,
+            &child_alias,
+            &inner_select,
+            ctx.max_rows,
+            child_where.as_deref(),
+        )?;
 
-        expressions.push((
+        level.expressions.push((
             alias.clone().unwrap_or_else(|| relation.clone()),
             expression,
         ));
     }
 
-    Ok(expressions)
+    Ok(level)
 }
 
 type EmbedFuture<'f> = std::pin::Pin<
@@ -871,6 +1164,10 @@ fn sanitize_error_message(error: &postrust_core::Error) -> &'static str {
         Error::InvalidJwt(_) | Error::JwtExpired | Error::MissingAuth => "Unauthorized",
         Error::InsufficientPermissions(_) => "Forbidden",
         Error::UnacceptableSchema(_) => "Invalid schema",
+        // A fixed policy message that reveals nothing about the request or the
+        // schema, so it is passed through verbatim -- and it is what PostgREST
+        // says, which is what a client branching on it will be matching.
+        Error::AggregatesNotAllowed => "Use of aggregate functions is not allowed",
         Error::InvalidHeader(_) | Error::InvalidQueryParam(_) => "Invalid request",
         Error::Database(_) => "Database error",
         Error::ConnectionPool(_) => "Service temporarily unavailable",
@@ -894,6 +1191,7 @@ mod tests {
             returns_set,
             returns_composite: false,
             volatility: "Volatile".into(),
+            param_types: Vec::new(),
         }
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -103,6 +103,14 @@ async fn process_request(
         api_request.payload = payload;
     }
 
+    // `application/vnd.pgrst.plan` asks for the query plan instead of the
+    // result. It is off unless a server turns it on -- it says a great deal
+    // about the schema and the data -- and a server that has not is required
+    // to say so rather than answer with something else.
+    if let Some(plan) = requested_plan(&api_request) {
+        return Err(postrust_core::Error::InvalidMediaType(plan));
+    }
+
     // A body that names different columns row by row cannot be written by one
     // statement. Skipped when `?columns=` says which columns to write, since
     // then the rows are free to differ.
@@ -160,6 +168,27 @@ async fn process_request(
     })?;
 
     Ok(build_response(response))
+}
+
+/// The plan media type a request asked for, when that is all it will accept.
+///
+/// A request that would also take JSON gets JSON; one that will take only the
+/// plan is refused, and the message names what it asked for.
+fn requested_plan(api_request: &ApiRequest) -> Option<String> {
+    let accepted: Vec<&str> = api_request
+        .accept_media_types
+        .iter()
+        .map(|media| media.content_type())
+        .collect();
+
+    match accepted
+        .iter()
+        .all(|media| media.starts_with("application/vnd.pgrst.plan"))
+        && !accepted.is_empty()
+    {
+        true => Some(accepted.join(", ")),
+        false => None,
+    }
 }
 
 /// The prefix given to primary key columns added only to build `Location`.
@@ -2560,6 +2589,7 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::PutLimitNotAllowed
         | Error::PutMatchingPk
         | Error::MaxAffectedExceeded(_)
+        | Error::InvalidMediaType(_)
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
         // What the token failed on is the client's own token, so naming it

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1018,10 +1018,19 @@ async fn execute_plan(
                         .fetch_one(&mut *tx)
                         .await
                         .map_err(map_sqlx_error)?;
-                        (
-                            row.try_get::<Option<String>, _>(0).ok().flatten(),
-                            row.try_get::<Option<String>, _>(1).ok().flatten(),
-                        )
+                        // Empty is absent. Once any transaction on this
+                        // connection has defined a custom setting, PostgreSQL
+                        // keeps the name for the rest of the session and
+                        // reports it as `''` rather than null -- so a request
+                        // that set nothing would otherwise inherit "the empty
+                        // headers" from whichever request last set some.
+                        let setting = |index: usize| {
+                            row.try_get::<Option<String>, _>(index)
+                                .ok()
+                                .flatten()
+                                .filter(|value| !value.trim().is_empty())
+                        };
+                        (setting(0), setting(1))
                     }
                 };
 
@@ -1030,7 +1039,7 @@ async fn execute_plan(
             // schema, and saying so is more use than a header the client
             // cannot see or a status it cannot explain.
             if let Some(headers) = &guc_headers {
-                if postrust_response::parse_guc_headers(headers).is_err() {
+                if postrust_response::parse_guc_headers(headers).is_none() {
                     return Err(postrust_core::Error::InvalidGucHeaders);
                 }
             }
@@ -2935,6 +2944,7 @@ mod tests {
             volatility: "Volatile".into(),
             param_types: Vec::new(),
             returns_void: false,
+            variadic_params: Vec::new(),
         }
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -872,8 +872,7 @@ async fn execute_plan(
                 let schema_cache = state.schema_cache().await;
                 read_target(api_request, &schema_cache)
             };
-            if let Some(parent_qi) = two_query_parent.filter(|_| embed_level.expressions.is_empty())
-            {
+            if let Some(parent_qi) = two_query_parent.filter(|_| !embed_level.saw_relations) {
                 let schema_cache = state.schema_cache().await;
                 embed_relations(
                     &mut tx,
@@ -1745,6 +1744,13 @@ struct EmbedLevel {
     /// as nulls, or as empty arrays for a to-many -- and by then there is no
     /// row to read the names off.
     spread_columns: Vec<(String, Vec<String>)>,
+    /// Whether this level had any relation to embed at all.
+    ///
+    /// Distinct from having produced an expression: `clients()` is a relation
+    /// that deliberately contributes nothing, and the fallback path must not
+    /// take an absent expression for a relation the single-query form could
+    /// not handle.
+    saw_relations: bool,
 }
 
 /// The keys a spread's selection contributes to the object above it.
@@ -1899,13 +1905,27 @@ fn build_embed_orders(
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
         let child_alias = ctx.next_alias();
-        let column = postrust_core::query::QueryBuilder::column_sql(&term.field);
-        let mut expression = plan.order_expression(
-            "src",
-            PARENT_ROW_COLUMN_REF,
-            &child_alias,
-            &format!("{}.{}", postrust_sql::escape_ident(&child_alias), column),
+
+        // The column belongs to the related table, so its type has to be read
+        // from there. Resolved against the parent it would be unknown, and an
+        // unknown type is one this process asks the database to render -- for
+        // a `jsonb` column that would wrap it in `to_jsonb` and then reach
+        // into the wrapper.
+        let child_qi = postrust_core::api_request::QualifiedIdentifier::new(
+            &plan.foreign_schema,
+            &plan.foreign_table,
         );
+        let mut field = term.field.clone();
+        field.to_json = !field.json_path.is_empty()
+            && !schema_cache
+                .get_table(&child_qi)
+                .and_then(|table| table.get_column(&field.name))
+                .is_some_and(|column| matches!(column.data_type.as_str(), "json" | "jsonb"));
+
+        let column =
+            postrust_core::query::QueryBuilder::qualified_column_sql(Some(&child_alias), &field);
+        let mut expression =
+            plan.order_expression("src", PARENT_ROW_COLUMN_REF, &child_alias, &column);
 
         match term.direction {
             Some(postrust_core::api_request::OrderDirection::Desc) => expression.push_str(" DESC"),
@@ -1972,6 +1992,8 @@ fn build_embed_expressions(
             } => (relation, None, select, join_type, hint, true),
             SelectItem::Field { .. } => continue,
         };
+
+        level.saw_relations = true;
 
         let rel = schema_cache
             .find_relationship(parent_qi, relation, hint.as_deref(), &parent_qi.schema)?

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1163,14 +1163,13 @@ async fn execute_plan(
             Ok(QueryResult {
                 status: match returns_void {
                     true => StatusCode::NO_CONTENT,
-                    false => {
-                        mutation_status(db_plan, api_request, created_a_row).unwrap_or_else(|| {
+                    false => mutation_status(db_plan, api_request, created_a_row, reports_inserted)
+                        .unwrap_or_else(|| {
                             content_range
                                 .as_ref()
                                 .map(postrust_response::ContentRange::status)
                                 .unwrap_or(StatusCode::OK)
-                        })
-                    }
+                        }),
                 },
                 rows,
                 singular,
@@ -1442,6 +1441,11 @@ fn mutation_status(
     db_plan: &postrust_core::plan::DbActionPlan,
     api_request: &ApiRequest,
     created_a_row: bool,
+    // Whether the statement was in a position to say. A write with no conflict
+    // clause could only have created rows, and one on a relation that will not
+    // give up `xmax` cannot tell either way -- in both cases there is nothing
+    // to report but the creation.
+    could_have_merged: bool,
 ) -> Option<StatusCode> {
     use postrust_core::api_request::PreferResolution;
     use postrust_core::plan::{DbActionPlan, MutatePlan};
@@ -1460,7 +1464,10 @@ fn mutation_status(
         // nothing was discovered by the response -- it reports the outcome
         // only where it asked to see the row.
         MutatePlan::Insert { .. } if is_upsert(api_request) => {
-            match (wants_representation(api_request), created_a_row) {
+            match (
+                wants_representation(api_request),
+                created_a_row || !could_have_merged,
+            ) {
                 (false, _) => StatusCode::NO_CONTENT,
                 (true, true) => StatusCode::CREATED,
                 (true, false) => StatusCode::OK,
@@ -1468,7 +1475,9 @@ fn mutation_status(
         }
         // A `POST` that merged into every row it touched created nothing, and
         // 201 would be a promise that something new is at the `Location`.
-        MutatePlan::Insert { .. } if merging && !created_a_row => StatusCode::OK,
+        MutatePlan::Insert { .. } if merging && could_have_merged && !created_a_row => {
+            StatusCode::OK
+        }
         MutatePlan::Insert { .. } => StatusCode::CREATED,
         _ => match wants_representation(api_request) {
             true => StatusCode::OK,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -791,15 +791,20 @@ async fn execute_plan(
                 // than from the request, but it is quoted both ways all the
                 // same: as an identifier to read the column, and as a literal
                 // to drop that key from the properties.
+                // A mutation's rows come from a data-modifying CTE, which
+                // PostgreSQL allows only at the top level -- so the rendering
+                // wraps what follows the `WITH`, not the whole statement.
+                let (with_clause, inner) = split_leading_cte(&sql);
                 sql = format!(
-                    "SELECT json_build_object('type', 'FeatureCollection', 'features', \
-                     COALESCE(json_agg(json_build_object('type', 'Feature', 'geometry', \
-                     pgrst_geo.{column} - 'crs', 'properties', \
+                    "{with_clause}SELECT json_build_object('type', 'FeatureCollection', \
+                     'features', COALESCE(json_agg(json_build_object('type', 'Feature', \
+                     'geometry', pgrst_geo.{column} - 'crs', 'properties', \
                      to_jsonb(pgrst_geo) - '{key}')), '[]'::json))::text \
-                     AS pgrst_body FROM ({sql}) pgrst_geo",
+                     AS pgrst_body FROM ({inner}) pgrst_geo",
+                    with_clause = with_clause,
                     column = postrust_sql::escape_ident(column),
                     key = column.replace('\'', "''"),
-                    sql = sql
+                    inner = inner
                 );
             }
 
@@ -818,9 +823,10 @@ async fn execute_plan(
                 } else {
                     "pgrst_media".to_string()
                 };
+                let (with_clause, inner) = split_leading_cte(&sql);
                 sql = format!(
-                    "SELECT {}({})::text AS pgrst_body FROM ({}) pgrst_media",
-                    aggregate, argument, sql
+                    "{}SELECT {}({})::text AS pgrst_body FROM ({}) pgrst_media",
+                    with_clause, aggregate, argument, inner
                 );
                 debug!("Rendering {} via {}", media_type, aggregate);
             }

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -63,8 +63,7 @@ async fn process_request(
         .and_then(|v| v.to_str().ok());
 
     // Authenticate
-    let auth_result = authenticate(auth_header, &state.jwt_config)
-        .map_err(|e| postrust_core::Error::InvalidJwt(e.to_string()))?;
+    let auth_result = authenticate(auth_header, &state.jwt_config).map_err(jwt_error)?;
 
     debug!("Authenticated as role: {}", auth_result.role);
 
@@ -130,10 +129,46 @@ async fn process_request(
     .await?;
 
     // Format response
-    let response = format_response(&api_request, &result)
-        .map_err(|e| postrust_core::Error::Internal(e.to_string()))?;
+    // A singular response the result cannot satisfy is the client's business,
+    // not an internal failure: it asked for one object and the query answered
+    // with some other number of rows.
+    let response = format_response(&api_request, &result).map_err(|e| match e {
+        postrust_response::FormatError::MultipleRows | postrust_response::FormatError::NotFound => {
+            postrust_core::Error::NotSingular {
+                rows: result.rows.len(),
+            }
+        }
+        other => postrust_core::Error::Internal(other.to_string()),
+    })?;
 
     Ok(build_response(response))
+}
+
+/// Classify a JWT failure the way PostgREST reports it.
+///
+/// A token that could not be read at all and one that was read and found
+/// wanting are different answers to the client: the first says the credential
+/// is unusable, the second says what about it was unacceptable. PostgREST
+/// gives them different codes, and clients branch on them.
+fn jwt_error(error: postrust_auth::JwtError) -> postrust_core::Error {
+    use postrust_auth::JwtError;
+
+    match error {
+        JwtError::MissingHeader => postrust_core::Error::MissingAuth,
+        JwtError::Expired => postrust_core::Error::JwtClaim("JWT expired".into()),
+        JwtError::NotYetValid => postrust_core::Error::JwtClaim("JWT not yet valid".into()),
+        JwtError::InvalidAudience => postrust_core::Error::JwtClaim("JWT not in audience".into()),
+        JwtError::MissingRole => postrust_core::Error::JwtClaim("Parsing claims failed".into()),
+        JwtError::InvalidSignature => {
+            postrust_core::Error::InvalidJwt("JWT cryptographic operation failed".into())
+        }
+        JwtError::InvalidHeaderFormat => {
+            postrust_core::Error::InvalidJwt("Unsupported token type".into())
+        }
+        JwtError::InvalidToken(_) => {
+            postrust_core::Error::InvalidJwt("No suitable key or wrong key type".into())
+        }
+    }
 }
 
 /// Execute an action plan.
@@ -180,11 +215,33 @@ async fn execute_plan(
                 || matches!(&media_handler, Some((_, _, true)));
             let db_plan = &if needs_parent_row {
                 let mut adjusted = db_plan.clone();
-                if let DbActionPlan::Read(tree) = &mut adjusted {
-                    let mut field = postrust_core::plan::CoercibleField::simple(
-                        tree.root.from.name.clone(),
-                        String::new(),
-                    );
+                // A function's result is a relation too, named after the
+                // function, so the row is reachable there by exactly the same
+                // means -- which is what makes a computed relationship work on
+                // `/rpc/getallvideogames` and not only on a table.
+                let (tree, relation) = match &mut adjusted {
+                    DbActionPlan::Read(tree) => {
+                        let relation = tree.root.from.name.clone();
+                        (Some(tree), relation)
+                    }
+                    DbActionPlan::Call { call, read } => {
+                        let relation = call.function.name.clone();
+                        (read.as_mut(), relation)
+                    }
+                    DbActionPlan::MutateRead { .. } => (None, String::new()),
+                };
+
+                if let Some(tree) = tree {
+                    // An empty select means every column; naming the row would
+                    // otherwise replace them rather than join them.
+                    if tree.root.select.is_empty() {
+                        tree.root
+                            .select
+                            .push(postrust_core::plan::CoercibleSelectField::simple("*", ""));
+                    }
+
+                    let mut field =
+                        postrust_core::plan::CoercibleField::simple(relation, String::new());
                     field.full_row = true;
                     tree.root
                         .select
@@ -213,6 +270,16 @@ async fn execute_plan(
 
             let (mut sql, params) = query.build_main();
 
+            // A `Prefer: count` needs the same query without its page: the
+            // total is what the filters match, not what this page returned.
+            // LIMIT and OFFSET render as literals, so dropping them leaves the
+            // placeholders and their numbering untouched and the count query
+            // can be bound with the very same parameters.
+            let mut count_sql = match api_request.preferences.count {
+                Some(_) => unpaged_sql(db_plan, &auth.role)?,
+                None => None,
+            };
+
             // Embed related resources in the same query.
             //
             // Each relation becomes a correlated subselect in the SELECT list,
@@ -227,6 +294,7 @@ async fn execute_plan(
                 filters: &api_request.query_params.filters,
                 orders: &api_request.query_params.order,
                 ranges: &api_request.query_params.ranges,
+                logic: &api_request.query_params.logic,
                 params: Vec::new(),
                 base: params.len(),
                 max_rows: api_request.max_rows,
@@ -261,6 +329,7 @@ async fn execute_plan(
                         PARENT_ROW_COLUMN_REF,
                         &api_request.query_params.select,
                         &mut embed_filters,
+                        &[],
                         &[],
                     )?
                 }
@@ -326,7 +395,8 @@ async fn execute_plan(
                     projection.push_str(" AS ");
                     projection.push_str(&postrust_sql::escape_ident(field_name));
                 }
-                sql = format!("SELECT {} FROM ({}) AS src", projection, sql);
+                let inner_sql = std::mem::take(&mut sql);
+                sql = format!("SELECT {} FROM ({}) AS src", projection, inner_sql);
 
                 // `?clients=is.null` asks whether the embed matched anything,
                 // not about a column. The embed's expression is the thing to
@@ -368,6 +438,18 @@ async fn execute_plan(
                     sql.push_str(" ORDER BY ");
                     sql.push_str(&embed_level.orders.join(", "));
                 }
+
+                // `!inner` and `?rel=is.null` decide which parent rows survive,
+                // so the count has to be taken after them -- the same wrapper,
+                // over the unpaged query.
+                count_sql = count_sql.map(|base| {
+                    let mut counted = format!("SELECT {} FROM ({}) AS src", projection, base);
+                    if !predicates.is_empty() {
+                        counted.push_str(" WHERE ");
+                        counted.push_str(&predicates.join(" AND "));
+                    }
+                    counted
+                });
 
                 if let Some(range) = page {
                     if let Some(limit) = range.limit {
@@ -509,6 +591,18 @@ async fn execute_plan(
                     .map_err(map_sqlx_error)?;
             }
 
+            // `Prefer: timezone` is applied to the session, so every value
+            // the database renders -- and every `now()` a function calls --
+            // sees it. An unknown zone is PostgreSQL's to reject, and it does,
+            // with a message naming the value the client sent.
+            if let Some(timezone) = &api_request.preferences.timezone {
+                sqlx::query("SELECT set_config('timezone', $1, true)")
+                    .bind(timezone)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(map_sqlx_error)?;
+            }
+
             // Set role
             sqlx::query(&format!(
                 "SET LOCAL ROLE {}",
@@ -612,6 +706,22 @@ async fn execute_plan(
                 .await?;
             }
 
+            // The count runs on the same transaction and so under the same
+            // snapshot as the page it describes.
+            let total = match (&api_request.preferences.count, &count_sql) {
+                (Some(preference), Some(count_sql)) => {
+                    resolve_count(
+                        &mut tx,
+                        preference,
+                        count_sql,
+                        &params,
+                        api_request.max_rows,
+                    )
+                    .await?
+                }
+                _ => None,
+            };
+
             // Reads take no locks worth holding and write plans commit their
             // work, so the transaction is committed either way.
             tx.commit()
@@ -686,7 +796,20 @@ async fn execute_plan(
                 .unwrap_or(api_request.top_level_range.offset);
 
             let content_range =
-                postrust_response::ContentRange::from_pagination(offset, rows.len() as i64, None);
+                postrust_response::ContentRange::from_pagination(offset, rows.len() as i64, total);
+
+            // An offset past the end of the result is a range the server
+            // cannot satisfy, and saying how many rows there actually are is
+            // what lets the client correct it. Only reachable with a count
+            // preference: without one the total is unknown and there is
+            // nothing to be past the end of.
+            if content_range.status() == StatusCode::RANGE_NOT_SATISFIABLE {
+                return Err(postrust_core::Error::InvalidRange(format!(
+                    "An offset of {} was requested, but there are only {} rows.",
+                    offset,
+                    total.unwrap_or(0)
+                )));
+            }
 
             Ok(QueryResult {
                 status: mutation_status(db_plan, api_request)
@@ -826,6 +949,109 @@ fn is_read_only(api_request: &ApiRequest) -> bool {
     }
 }
 
+/// The plan's SQL with its page removed, for counting what the filters match.
+///
+/// Only reads and calls are counted. A mutation's `Content-Range` reports the
+/// rows it affected, which is the result set itself.
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
+fn unpaged_sql(
+    db_plan: &postrust_core::plan::DbActionPlan,
+    role: &str,
+) -> Result<Option<String>, postrust_core::Error> {
+    use postrust_core::plan::{ActionPlan, DbActionPlan};
+
+    let unpaged = match db_plan {
+        DbActionPlan::Read(tree) => {
+            let mut tree = tree.clone();
+            tree.root.range = Default::default();
+            DbActionPlan::Read(tree)
+        }
+        DbActionPlan::Call { call, read } => {
+            let read = read.as_ref().map(|tree| {
+                let mut tree = tree.clone();
+                tree.root.range = Default::default();
+                tree
+            });
+            DbActionPlan::Call {
+                call: call.clone(),
+                read,
+            }
+        }
+        DbActionPlan::MutateRead { .. } => return Ok(None),
+    };
+
+    let query = postrust_core::query::build_query(&ActionPlan::Db(unpaged), Some(role))?;
+    Ok(query.has_main().then(|| query.build_main().0))
+}
+
+/// The total the `Prefer: count` asked for, or `None` when it asked for none.
+///
+/// `exact` counts the rows the filters match. `planned` asks the query planner
+/// what it expects without running anything, which is cheap on a large table
+/// and correspondingly rough. `estimated` is the planner's guess only where it
+/// matters: below the server's row ceiling the exact count is already paid for,
+/// so it is used, and above it the larger of the two is reported -- an estimate
+/// that came in under a count we have actually taken would be plainly wrong.
+async fn resolve_count(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    preference: &postrust_core::api_request::PreferCount,
+    count_sql: &str,
+    params: &[postrust_sql::SqlParam],
+    max_rows: Option<i64>,
+) -> Result<Option<i64>, postrust_core::Error> {
+    use postrust_core::api_request::PreferCount;
+
+    match preference {
+        PreferCount::Exact => exact_count(tx, count_sql, params).await,
+        PreferCount::Planned => planned_count(tx, count_sql, params).await,
+        PreferCount::Estimated => match (exact_count(tx, count_sql, params).await?, max_rows) {
+            (Some(exact), Some(ceiling)) if exact <= ceiling => Ok(Some(exact)),
+            (Some(exact), _) => {
+                let planned = planned_count(tx, count_sql, params).await?;
+                Ok(Some(exact.max(planned.unwrap_or(exact))))
+            }
+            (None, _) => planned_count(tx, count_sql, params).await,
+        },
+    }
+}
+
+/// The number of rows the filters match.
+async fn exact_count(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    count_sql: &str,
+    params: &[postrust_sql::SqlParam],
+) -> Result<Option<i64>, postrust_core::Error> {
+    use sqlx::Row;
+
+    let sql = format!("SELECT count(*) FROM ({}) AS pgrst_count", count_sql);
+    let row = bind_params(sqlx::query(&sql), params)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    Ok(row.try_get::<i64, _>(0).ok())
+}
+
+/// The number of rows the query planner expects, without running the query.
+async fn planned_count(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    count_sql: &str,
+    params: &[postrust_sql::SqlParam],
+) -> Result<Option<i64>, postrust_core::Error> {
+    use sqlx::Row;
+
+    let sql = format!("EXPLAIN (FORMAT JSON) {}", count_sql);
+    let row = bind_params(sqlx::query(&sql), params)
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(map_sqlx_error)?;
+    let plan: serde_json::Value = row.try_get(0).unwrap_or(serde_json::Value::Null);
+    Ok(plan
+        .get(0)
+        .and_then(|node| node.get("Plan"))
+        .and_then(|node| node.get("Plan Rows"))
+        .and_then(serde_json::Value::as_i64))
+}
+
 /// Whether this plan changes data.
 fn is_mutation(db_plan: &postrust_core::plan::DbActionPlan) -> bool {
     matches!(
@@ -899,10 +1125,20 @@ fn add_embed_join_columns(
         .iter()
         .any(|item| matches!(item, SelectItem::Field { field, .. } if field.name == "*"));
 
+    // Only a column selected under its own name serves as a join key. An
+    // aliased one -- `myId:id` -- arrives in the result as `myId`, so the
+    // correlation would look for a column the inner query no longer has; the
+    // same goes for one that was cast or reached into with a JSON path.
     let selected: std::collections::HashSet<String> = select
         .iter()
         .filter_map(|item| match item {
-            SelectItem::Field { field, .. } => Some(field.name.clone()),
+            SelectItem::Field {
+                field,
+                aggregate: None,
+                cast: None,
+                alias: None,
+                ..
+            } if field.json_path.is_empty() => Some(field.name.clone()),
             _ => None,
         })
         .collect();
@@ -922,7 +1158,14 @@ fn add_embed_join_columns(
 
         let rel = schema_cache
             .find_relationship(&parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
-            .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
+            .ok_or_else(|| {
+                schema_cache.relationship_not_found(
+                    &parent_qi,
+                    relation,
+                    hint.as_deref(),
+                    &parent_qi.schema,
+                )
+            })?;
 
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
@@ -1000,6 +1243,11 @@ struct EmbedFilters<'a> {
     )],
     /// Ranges asked of each embedded resource, by dotted path.
     ranges: &'a std::collections::HashMap<String, postrust_core::api_request::Range>,
+    /// `and=`/`or=` groups asked of each embedded resource, by path.
+    logic: &'a [(
+        postrust_core::api_request::EmbedPath,
+        postrust_core::api_request::LogicTree,
+    )],
     /// Row cap applied to each embedded resource.
     max_rows: Option<i64>,
     /// Source of unique subquery aliases across the whole embed tree.
@@ -1051,11 +1299,11 @@ impl EmbedFilters<'_> {
     ///
     /// `clients.order=name.desc` orders the rows inside the embed, which is a
     /// property of the child's own subselect rather than of the parent.
-    fn order_for(&self, path: &[String]) -> Option<String> {
+    fn order_for(&self, path: &[String], names: &[String]) -> Option<String> {
         let terms: Vec<String> = self
             .orders
             .iter()
-            .filter(|(p, _)| p.as_slice() == path)
+            .filter(|(p, _)| p.as_slice() == path || p.as_slice() == names)
             .flat_map(|(_, terms)| terms.iter())
             .map(|term| {
                 use postrust_core::api_request::{OrderDirection, OrderNulls, OrderTerm};
@@ -1098,30 +1346,46 @@ impl EmbedFilters<'_> {
     ///
     /// The server's own cap still applies, so an embed cannot be asked for
     /// more rows than the server is willing to return.
-    fn range_for(&self, path: &[String]) -> Option<i64> {
-        let requested = self.ranges.get(&path.join(".")).and_then(|r| r.limit);
-        match (requested, self.max_rows) {
+    fn range_for(&self, path: &[String], names: &[String]) -> (Option<i64>, i64) {
+        let range = self
+            .ranges
+            .get(&path.join("."))
+            .or_else(|| self.ranges.get(&names.join(".")));
+        let requested = range.and_then(|r| r.limit);
+        let offset = range.map(|r| r.offset).unwrap_or(0);
+        let limit = match (requested, self.max_rows) {
             (Some(limit), Some(cap)) => Some(limit.min(cap)),
             (Some(limit), None) => Some(limit),
             (None, cap) => cap,
-        }
+        };
+        (limit, offset)
     }
 
     #[allow(clippy::result_large_err)] // consistent with the crate's error type
     fn predicate_for(
         &mut self,
         path: &[String],
+        names: &[String],
         child_qi: &postrust_core::api_request::QualifiedIdentifier,
         schema_cache: &postrust_core::SchemaCache,
     ) -> Result<Option<String>, postrust_core::Error> {
+        let addresses = |candidate: &[String]| candidate == path || candidate == names;
+
         let matching: Vec<_> = self
             .filters
             .iter()
-            .filter(|(filter_path, _)| filter_path.as_slice() == path)
+            .filter(|(filter_path, _)| addresses(filter_path))
             .map(|(_, filter)| filter.clone())
             .collect();
 
-        if matching.is_empty() {
+        let matching_logic: Vec<_> = self
+            .logic
+            .iter()
+            .filter(|(logic_path, _)| addresses(logic_path))
+            .map(|(_, tree)| tree.clone())
+            .collect();
+
+        if matching.is_empty() && matching_logic.is_empty() {
             return Ok(None);
         }
 
@@ -1151,7 +1415,60 @@ impl EmbedFilters<'_> {
             self.params.extend(frag.params().iter().cloned());
         }
 
+        for tree in matching_logic {
+            // A name the child does not have would bind outward to the
+            // correlated parent and filter the wrong table, exactly as a plain
+            // filter would, so the tree is checked before it is rendered.
+            let mut unknown = None;
+            check_logic_columns(&tree, table, &mut unknown);
+            if let Some(name) = unknown {
+                return Err(postrust_core::Error::ColumnNotFound(format!(
+                    "{}.{}",
+                    child_qi.name, name
+                )));
+            }
+
+            let resolver = |name: &str| -> String {
+                table
+                    .and_then(|t| t.get_column(name))
+                    .map(|c| c.nominal_type.clone())
+                    .unwrap_or_else(|| "text".to_string())
+            };
+            let frag = postrust_core::query::QueryBuilder::logic_sql(&tree, resolver)?;
+            parts.push(shift_placeholders(
+                frag.sql(),
+                self.base + self.params.len(),
+            ));
+            self.params.extend(frag.params().iter().cloned());
+        }
+
         Ok(Some(format!("({})", parts.join(" AND "))))
+    }
+}
+
+/// Record the first column a logic tree names that the table does not have.
+fn check_logic_columns(
+    tree: &postrust_core::api_request::LogicTree,
+    table: Option<&postrust_core::schema_cache::Table>,
+    unknown: &mut Option<String>,
+) {
+    use postrust_core::api_request::LogicTree;
+
+    match tree {
+        LogicTree::Expr { children, .. } => {
+            for child in children {
+                check_logic_columns(child, table, unknown);
+            }
+        }
+        LogicTree::Stmt(filter) => {
+            if unknown.is_none()
+                && table
+                    .map(|t| t.get_column(&filter.field.name).is_none())
+                    .unwrap_or(true)
+            {
+                *unknown = Some(filter.field.name.clone());
+            }
+        }
     }
 }
 
@@ -1313,7 +1630,19 @@ fn build_embed_orders(
 
         let rel = schema_cache
             .find_relationship(parent_qi, relation, None, &parent_qi.schema)?
-            .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
+            .ok_or_else(|| {
+                schema_cache.relationship_not_found(parent_qi, relation, None, &parent_qi.schema)
+            })?;
+
+        // A resource that yields many rows per parent has no single value to
+        // order on, so there is nothing the request could mean.
+        if !rel.is_to_one() {
+            return Err(postrust_core::Error::RelatedOrderNotPossible {
+                origin: parent_qi.name.clone(),
+                relation: relation.clone(),
+            });
+        }
+
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
         let child_alias = ctx.next_alias();
@@ -1347,6 +1676,7 @@ fn build_embed_orders(
 }
 
 #[allow(clippy::result_large_err)] // consistent with the crate's error type
+#[allow(clippy::too_many_arguments)] // each names one part of where the embed sits
 fn build_embed_expressions(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
@@ -1360,6 +1690,9 @@ fn build_embed_expressions(
     select: &[postrust_core::api_request::SelectItem],
     ctx: &mut EmbedFilters<'_>,
     path: &[String],
+    // The same path spelled with each relation's own name rather than the
+    // alias the request gave it.
+    names: &[String],
 ) -> Result<EmbedLevel, postrust_core::Error> {
     use postrust_core::api_request::SelectItem;
 
@@ -1389,7 +1722,14 @@ fn build_embed_expressions(
 
         let rel = schema_cache
             .find_relationship(parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
-            .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
+            .ok_or_else(|| {
+                schema_cache.relationship_not_found(
+                    parent_qi,
+                    relation,
+                    hint.as_deref(),
+                    &parent_qi.schema,
+                )
+            })?;
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
         let child_alias = ctx.next_alias();
@@ -1398,11 +1738,14 @@ fn build_embed_expressions(
             &plan.foreign_table,
         );
 
-        // Filters are addressed by the name the client used, which is the
-        // alias when there is one -- `c:clients(*)&c.id=eq.1`.
+        // Filters are addressed by the name the client used, which may be
+        // either the alias or the relation itself: `c:clients(*)&c.id=eq.1`
+        // and `the_tasks:tasks(*)&tasks.id=eq.1` both name the same embed.
         let mut child_path = path.to_vec();
         child_path.push(alias.clone().unwrap_or_else(|| relation.clone()));
-        let child_where = ctx.predicate_for(&child_path, &child_qi, schema_cache)?;
+        let mut child_names = names.to_vec();
+        child_names.push(relation.clone());
+        let child_where = ctx.predicate_for(&child_path, &child_names, &child_qi, schema_cache)?;
 
         // Deeper relations first: they become part of this level's SELECT list.
         let child_row = postrust_sql::escape_ident(&child_alias);
@@ -1414,6 +1757,7 @@ fn build_embed_expressions(
             child_select,
             ctx,
             &child_path,
+            &child_names,
         )?;
 
         // A nested `!inner` is written against this child's alias, which is
@@ -1485,14 +1829,15 @@ fn build_embed_expressions(
         }
 
         let inner_select = parts.join(", ");
-        let child_order = ctx.order_for(&child_path);
-        let child_limit = ctx.range_for(&child_path);
+        let child_order = ctx.order_for(&child_path, &child_names);
+        let (child_limit, child_offset) = ctx.range_for(&child_path, &child_names);
         let expression = plan.embed_expression(
             parent_alias,
             parent_row,
             &child_alias,
             &inner_select,
             child_limit,
+            child_offset,
             child_where.as_deref(),
             child_order.as_deref(),
         )?;
@@ -1532,10 +1877,36 @@ fn build_embed_expressions(
                 child_where.as_deref(),
             ),
         ));
+
+        // `clients()` asks for none of the related resource's columns. It is
+        // written to narrow the parent -- with `!inner`, or with a filter on
+        // the embed -- and the resource itself is not part of the answer, so
+        // it gets no key at all rather than an empty object. The test is
+        // recursive: an embed whose only content is such an embed contributes
+        // nothing either.
+        if !yields_columns(child_select) {
+            continue;
+        }
+
         level.expressions.push((key, expression));
     }
 
     Ok(level)
+}
+
+/// Whether a selection produces any keys in the response.
+///
+/// A relation contributes only what its own selection does, so `tasks()` and
+/// `tasks(projects())` are alike empty, while `tasks(name)` is not.
+fn yields_columns(select: &[postrust_core::api_request::SelectItem]) -> bool {
+    use postrust_core::api_request::SelectItem;
+
+    select.iter().any(|item| match item {
+        SelectItem::Field { .. } => true,
+        SelectItem::Relation { select, .. } | SelectItem::SpreadRelation { select, .. } => {
+            yields_columns(select)
+        }
+    })
 }
 
 type EmbedFuture<'f> = std::pin::Pin<
@@ -1585,7 +1956,14 @@ fn embed_relations<'f>(
 
             let rel = schema_cache
                 .find_relationship(parent_qi, relation, hint.as_deref(), &parent_qi.schema)?
-                .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
+                .ok_or_else(|| {
+                    schema_cache.relationship_not_found(
+                        parent_qi,
+                        relation,
+                        hint.as_deref(),
+                        &parent_qi.schema,
+                    )
+                })?;
 
             let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
             let keys = postrust_core::embed::parent_keys(rows, &plan.local_column);
@@ -1879,6 +2257,25 @@ fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Resp
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
 
+    // A function that raised `sqlstate 'PGRST'` supplied the whole response:
+    // its status, its headers and its body. Nothing here is the API layer's to
+    // decide, including whether to sanitise it -- the schema wrote it.
+    if let postrust_core::Error::Database(db) = &error {
+        if let Some(raised) = db.raised_response() {
+            let mut builder = Response::builder()
+                .status(status)
+                .header("content-type", "application/json");
+            for (name, value) in &raised.headers {
+                builder = builder.header(name, value);
+            }
+            return builder
+                .body(Body::from(
+                    serde_json::to_vec(&raised.body).unwrap_or_default(),
+                ))
+                .unwrap_or_else(|_| Response::new(Body::empty()));
+        }
+    }
+
     let body = if debug_mode {
         // Full error details in debug mode
         serde_json::to_vec(&error.to_json()).unwrap_or_default()
@@ -1904,9 +2301,17 @@ fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Resp
         serde_json::to_vec(&sanitized).unwrap_or_default()
     };
 
-    Response::builder()
+    let mut builder = Response::builder()
         .status(status)
-        .header("content-type", "application/json")
+        .header("content-type", "application/json");
+
+    // A 401 has to say what would satisfy it, or a client has no way to know
+    // it should be sending a token at all.
+    if status == StatusCode::UNAUTHORIZED {
+        builder = builder.header("www-authenticate", "Bearer");
+    }
+
+    builder
         .body(Body::from(body))
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
@@ -1922,7 +2327,7 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
     // the database's own account of a failure, which is about the schema
     // rather than about the request.
     match error {
-        Error::TableNotFound(name) | Error::NotFound(name) => {
+        Error::TableNotFound { name, .. } | Error::NotFound(name) => {
             return format!("Could not find the table '{}' in the schema cache", name)
         }
         Error::FunctionNotFound { name, params, .. } => {
@@ -1946,10 +2351,23 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
 
     (match error {
         Error::ColumnNotFound(_) | Error::UnknownColumn(_) => "Column not found",
-        Error::RelationshipNotFound(_) => "Relationship not found",
+        // Each of these says only what the request itself said: the resource
+        // it named, the preference it sent, the shape it asked for. Repeating
+        // that back tells the client nothing it did not already know, and is
+        // the difference between a message it can act on and one it cannot.
+        Error::RelationshipNotFound { .. }
+        | Error::NotAnEmbeddedResource(_)
+        | Error::RelatedOrderNotPossible { .. }
+        | Error::InvalidPreferences(_)
+        | Error::NotSingular { .. }
+        | Error::InvalidRange(_)
+        | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
         Error::InvalidBody(_) => "Invalid request body",
-        Error::InvalidJwt(_) | Error::JwtExpired | Error::MissingAuth => "Unauthorized",
+        // What the token failed on is the client's own token, so naming it
+        // costs nothing and is the only way it can tell a bad signature from
+        // an expired one.
+        Error::InvalidJwt(_) | Error::JwtClaim(_) | Error::MissingAuth => return error.to_string(),
         Error::InsufficientPermissions(_) => "Forbidden",
 
         // A fixed policy message that reveals nothing about the request or the

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -619,7 +619,21 @@ async fn execute_plan(
                 .map_err(|e| postrust_core::Error::ConnectionPool(e.to_string()))?;
 
             // Drop columns that were only selected to join the embeds.
-            for column in added_join_columns {
+            //
+            // Except where the embed answers to that very name: embedding
+            // through a column -- `?select=client_id(*)` -- keys the result by
+            // the column it joined on, and the embed is what the client asked
+            // for. Stripping by name would take it along with the column.
+            let embed_keys: std::collections::HashSet<&str> = embed_level
+                .expressions
+                .iter()
+                .map(|(key, _)| key.as_str())
+                .collect();
+
+            for column in added_join_columns
+                .iter()
+                .filter(|column| !embed_keys.contains(column.as_str()))
+            {
                 for row in json_rows.iter_mut() {
                     if let Some(object) = row.as_object_mut() {
                         object.remove(column);

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -930,6 +930,20 @@ async fn execute_plan(
                 });
             }
 
+            // `Prefer: max-affected` guards against a filter that turned out
+            // to match more than the client meant. Nothing has been committed
+            // yet, so refusing here undoes the whole statement.
+            if let (Some(limit), postrust_core::api_request::PreferHandling::Strict) = (
+                api_request.preferences.max_affected,
+                &api_request.preferences.handling,
+            ) {
+                let affected = json_rows.len() as i64;
+                let writes = is_mutation(db_plan) || matches!(db_plan, DbActionPlan::Call { .. });
+                if writes && affected > limit {
+                    return Err(postrust_core::Error::MaxAffectedExceeded(affected));
+                }
+            }
+
             // The created row's own address, taken from its key and then
             // removed from the body -- the client asked for a `?select=`, not
             // for the key.
@@ -2545,6 +2559,7 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::InvalidPutFilters
         | Error::PutLimitNotAllowed
         | Error::PutMatchingPk
+        | Error::MaxAffectedExceeded(_)
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
         // What the token failed on is the client's own token, so naming it

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -232,7 +232,7 @@ async fn execute_plan(
                 let schema_cache = state.schema_cache().await;
                 read_target(api_request, &schema_cache)
             };
-            let embed_level = match embed_parent {
+            let embed_level = match embed_parent.clone() {
                 Some(parent_qi)
                     if api_request.query_params.select.iter().any(|item| {
                         matches!(
@@ -254,6 +254,19 @@ async fn execute_plan(
                 }
                 _ => EmbedLevel::default(),
             };
+            let mut embed_level = embed_level;
+
+            // Ordering by an embedded column is resolved here rather than in
+            // the read plan: the plan has no way to reach another table.
+            if let (Some(parent_qi), DbActionPlan::Read(tree)) = (&embed_parent, db_plan) {
+                let schema_cache = state.schema_cache().await;
+                embed_level.orders = build_embed_orders(
+                    &schema_cache,
+                    parent_qi,
+                    &tree.root.order,
+                    &mut embed_filters,
+                )?;
+            }
 
             // Filter parameters are appended in the order the predicates were
             // renumbered, so placeholder N in the wrapped SQL lines up with
@@ -272,8 +285,16 @@ async fn execute_plan(
                 // Rebuilding is safe for parameter numbering: LIMIT and OFFSET
                 // render as literals, so dropping them leaves the placeholders
                 // and their count untouched.
+                //
+                // Ordering by an embedded resource's column needs the same
+                // treatment for the same reason: the value being ordered on is
+                // only reachable out here, so the page cannot be taken before
+                // it is known.
+                let orders_by_embed = matches!(db_plan, DbActionPlan::Read(tree)
+                    if tree.root.order.iter().any(|t| t.relation.is_some()));
+
                 let mut page = None;
-                if !embed_level.inner_joins.is_empty() {
+                if !embed_level.inner_joins.is_empty() || orders_by_embed {
                     if let DbActionPlan::Read(tree) = db_plan {
                         let mut unpaged = tree.clone();
                         page = Some(std::mem::take(&mut unpaged.root.range));
@@ -298,6 +319,11 @@ async fn execute_plan(
                 if !embed_level.inner_joins.is_empty() {
                     sql.push_str(" WHERE ");
                     sql.push_str(&embed_level.inner_joins.join(" AND "));
+                }
+
+                if !embed_level.orders.is_empty() {
+                    sql.push_str(" ORDER BY ");
+                    sql.push_str(&embed_level.orders.join(", "));
                 }
 
                 if let Some(range) = page {
@@ -1001,6 +1027,62 @@ struct EmbedLevel {
     /// `EXISTS` predicates from `!inner` on these relations. They reference
     /// the alias of the level *above*, so the caller applies them.
     inner_joins: Vec<String>,
+    /// `ORDER BY` expressions for terms naming an embedded resource.
+    orders: Vec<String>,
+}
+
+/// Build the `ORDER BY` expressions for terms naming an embedded resource.
+///
+/// `order=clients(name)` orders by a column the parent does not have, so each
+/// term becomes a scalar subselect fetched per parent row -- the same shape as
+/// the embed itself, reduced to one column.
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
+fn build_embed_orders(
+    schema_cache: &postrust_core::SchemaCache,
+    parent_qi: &postrust_core::api_request::QualifiedIdentifier,
+    order: &[postrust_core::plan::CoercibleOrderTerm],
+    ctx: &mut EmbedFilters<'_>,
+) -> Result<Vec<String>, postrust_core::Error> {
+    let mut orders = Vec::new();
+
+    for term in order.iter() {
+        let Some(relation) = &term.relation else {
+            continue;
+        };
+
+        let rel = schema_cache
+            .find_relationship(parent_qi, relation, None, &parent_qi.schema)?
+            .ok_or_else(|| postrust_core::Error::RelationshipNotFound(relation.clone()))?;
+        let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
+
+        let child_alias = ctx.next_alias();
+        let column = postrust_core::query::QueryBuilder::column_sql(&term.field);
+        let mut expression = plan.order_expression(
+            "src",
+            PARENT_ROW_COLUMN_REF,
+            &child_alias,
+            &format!("{}.{}", postrust_sql::escape_ident(&child_alias), column),
+        );
+
+        match term.direction {
+            Some(postrust_core::api_request::OrderDirection::Desc) => expression.push_str(" DESC"),
+            Some(postrust_core::api_request::OrderDirection::Asc) => expression.push_str(" ASC"),
+            None => {}
+        }
+        match term.nulls {
+            Some(postrust_core::api_request::OrderNulls::First) => {
+                expression.push_str(" NULLS FIRST")
+            }
+            Some(postrust_core::api_request::OrderNulls::Last) => {
+                expression.push_str(" NULLS LAST")
+            }
+            None => {}
+        }
+
+        orders.push(expression);
+    }
+
+    Ok(orders)
 }
 
 #[allow(clippy::result_large_err)] // consistent with the crate's error type

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -470,6 +470,7 @@ async fn execute_plan(
                 DbActionPlan::MutateRead {
                     mutate: postrust_core::plan::MutatePlan::Insert {
                         on_conflict: Some(_),
+                        reports_inserted: true,
                         ..
                     },
                     ..

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1083,6 +1083,15 @@ async fn execute_plan(
                 }
             }
 
+            // A `PUT` writes the row its URL names, and exactly that row. The
+            // filters were applied to the body, so a body naming some other
+            // row wrote nothing -- and one naming several wrote several. Both
+            // are the same mistake, and PostgreSQL cannot report it because
+            // neither is a database error.
+            if is_upsert(api_request) && json_rows.len() != 1 {
+                return Err(postrust_core::Error::PutMatchingPk);
+            }
+
             // The created row's own address, taken from its key and then
             // removed from the body -- the client asked for a `?select=`, not
             // for the key.

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -204,6 +204,16 @@ fn mutation_kind(api_request: &ApiRequest) -> Option<postrust_core::api_request:
 /// The prefix given to primary key columns added only to build `Location`.
 const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 
+/// Whether this request writes rows of a table.
+fn is_relation_mutation(api_request: &ApiRequest) -> bool {
+    use postrust_core::api_request::{Action, DbAction};
+
+    matches!(
+        &api_request.action,
+        Action::Db(DbAction::RelationMut { .. })
+    )
+}
+
 /// Whether this request writes the row its URL names.
 fn is_upsert(api_request: &ApiRequest) -> bool {
     use postrust_core::api_request::{Action, DbAction, Mutation};
@@ -524,11 +534,20 @@ async fn execute_plan(
                     }) =>
                 {
                     let schema_cache = state.schema_cache().await;
+                    // A computed relationship takes the parent's row, and a
+                    // mutation's result is a CTE whose row type is anonymous
+                    // -- there is nothing to pass it. Saying so here leaves
+                    // the embed out rather than referring to a column the
+                    // query does not have.
+                    let parent_row = match is_mutation(db_plan) {
+                        true => "",
+                        false => PARENT_ROW_COLUMN_REF,
+                    };
                     build_embed_expressions(
                         &schema_cache,
                         &parent_qi,
                         "src",
-                        PARENT_ROW_COLUMN_REF,
+                        parent_row,
                         &api_request.query_params.select,
                         &mut embed_filters,
                         &[],
@@ -1188,6 +1207,11 @@ fn read_target(
 
     match &api_request.action {
         Action::Db(DbAction::RelationRead { qi, .. }) => Some(qi.clone()),
+        // The rows a mutation affected are rows of that table, so `?select=`
+        // reaches through them to related resources exactly as it does on a
+        // read -- `DELETE /tasks?select=name,project:projects(id)` says what
+        // was deleted and what it belonged to.
+        Action::Db(DbAction::RelationMut { qi, .. }) => Some(qi.clone()),
         // A function returning a table's rows embeds, and renders, exactly as
         // that table does.
         Action::Db(DbAction::Routine { qi, .. }) => schema_cache
@@ -1471,8 +1495,12 @@ fn add_embed_join_columns(
 
         // A computed relationship joins on nothing -- the parent row is the
         // function's argument. That row has to be carried out of the inner
-        // query, which is a column of its own rather than a join key.
+        // query, which is a column of its own rather than a join key. A
+        // mutation has no such row to carry, so the embed is left out there.
         if plan.function.is_some() {
+            if is_relation_mutation(api_request) {
+                continue;
+            }
             if !added.iter().any(|c| c == PARENT_ROW_COLUMN) {
                 added.push(PARENT_ROW_COLUMN.to_string());
             }
@@ -2054,6 +2082,12 @@ fn build_embed_expressions(
                 )
             })?;
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
+
+        // No row to pass: the caller said the parent's is not expressible
+        // here, and a computed relationship is a function of it.
+        if plan.function.is_some() && parent_row.is_empty() {
+            continue;
+        }
 
         let child_alias = ctx.next_alias();
         let child_qi = postrust_core::api_request::QualifiedIdentifier::new(

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1528,7 +1528,6 @@ fn api_path(path: &str, compat_mode: bool) -> Option<&str> {
 
 /// The request again, with an empty body and the API's own path, for the
 /// parser to read.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn probe_request(
     request: &Request,
     path: &str,
@@ -1976,7 +1975,6 @@ fn is_read_only(api_request: &ApiRequest) -> bool {
 ///
 /// Only reads and calls are counted. A mutation's `Content-Range` reports the
 /// rows it affected, which is the result set itself.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn unpaged_sql(
     db_plan: &postrust_core::plan::DbActionPlan,
     role: &str,
@@ -2164,7 +2162,6 @@ fn mutation_status(
 /// Returns the columns that were added purely to make the join possible, so
 /// they can be removed from the response afterwards. An empty select list means
 /// "all columns", in which case nothing needs adding.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn add_embed_join_columns(
     api_request: &mut postrust_core::api_request::ApiRequest,
     schema_cache: &postrust_core::SchemaCache,
@@ -2287,7 +2284,6 @@ fn add_embed_join_columns(
 ///
 /// `alias_counter` hands out a distinct alias per level, so a self-referential
 /// relationship stays unambiguous.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 /// Filters addressed at embedded resources, and the parameters they bind.
 ///
 /// The embed expressions are assembled as SQL text and wrapped around a main
@@ -2361,7 +2357,6 @@ impl EmbedFilters<'_> {
     }
 
     /// The `WHERE` fragment for one embedded resource, or `None` if unfiltered.
-    #[allow(clippy::result_large_err)] // consistent with the crate's error type
     /// The row window an embedded resource was asked for.
     ///
     /// The server's own cap still applies, so an embed cannot be asked for
@@ -2381,7 +2376,6 @@ impl EmbedFilters<'_> {
         (limit, offset)
     }
 
-    #[allow(clippy::result_large_err)] // consistent with the crate's error type
     fn predicate_for(
         &mut self,
         path: &[String],
@@ -2666,7 +2660,6 @@ fn embedded_by_name<'a>(
 /// `order=clients(name)` orders by a column the parent does not have, so each
 /// term becomes a scalar subselect fetched per parent row -- the same shape as
 /// the embed itself, reduced to one column.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn build_embed_orders(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
@@ -2762,7 +2755,6 @@ fn build_embed_orders(
 /// rendered as a bare column name orders by a column of the wrong table --
 /// silently, where the parent happens to have a column of that name, and with
 /// `column "cost" does not exist` where it does not.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 fn related_order_target(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
@@ -2822,7 +2814,6 @@ fn related_order_target(
 /// `tasks.order=projects(id).desc` orders them by a column of a table the
 /// child embeds in turn -- so it is resolved against the child, and rendered
 /// as the same correlated subselect the top level uses.
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 #[allow(clippy::too_many_arguments)] // each names one part of where the embed sits
 fn embed_order_sql(
     schema_cache: &postrust_core::SchemaCache,
@@ -2904,7 +2895,6 @@ fn embed_order_sql(
     Ok(Some(rendered.join(", ")))
 }
 
-#[allow(clippy::result_large_err)] // consistent with the crate's error type
 #[allow(clippy::too_many_arguments)] // each names one part of where the embed sits
 fn build_embed_expressions(
     schema_cache: &postrust_core::SchemaCache,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -362,19 +362,17 @@ fn jwt_error(error: postrust_auth::JwtError) -> postrust_core::Error {
 
     match error {
         JwtError::MissingHeader => postrust_core::Error::MissingAuth,
-        JwtError::Expired => postrust_core::Error::JwtClaim("JWT expired".into()),
-        JwtError::NotYetValid => postrust_core::Error::JwtClaim("JWT not yet valid".into()),
-        JwtError::InvalidAudience => postrust_core::Error::JwtClaim("JWT not in audience".into()),
-        JwtError::MissingRole => postrust_core::Error::JwtClaim("Parsing claims failed".into()),
+        JwtError::SecretMissing => postrust_core::Error::JwtSecretMissing,
+        // Read, and found wanting: the token itself is intact, and what it
+        // claims is what was not accepted.
+        JwtError::Claim(fault) => postrust_core::Error::JwtClaim(fault.to_string()),
         JwtError::InvalidSignature => {
             postrust_core::Error::InvalidJwt("JWT cryptographic operation failed".into())
         }
         JwtError::InvalidHeaderFormat => {
             postrust_core::Error::InvalidJwt("Unsupported token type".into())
         }
-        JwtError::InvalidToken(_) => {
-            postrust_core::Error::InvalidJwt("No suitable key or wrong key type".into())
-        }
+        JwtError::NoSuitableKey => postrust_core::Error::NoSuitableJwtKey,
     }
 }
 
@@ -2866,9 +2864,21 @@ fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Resp
         .header("content-type", "application/json");
 
     // A 401 has to say what would satisfy it, or a client has no way to know
-    // it should be sending a token at all.
+    // it should be sending a token at all. Where a token *was* sent and was
+    // not accepted, the challenge says which -- `invalid_token` with the
+    // reason, so a client can tell "your key is wrong" from "your clock is"
+    // without parsing the body.
     if status == StatusCode::UNAUTHORIZED {
-        builder = builder.header("www-authenticate", "Bearer");
+        let challenge = match &error {
+            postrust_core::Error::InvalidJwt(_)
+            | postrust_core::Error::NoSuitableJwtKey
+            | postrust_core::Error::JwtClaim(_) => format!(
+                "Bearer error=\"invalid_token\", error_description=\"{}\"",
+                error
+            ),
+            _ => "Bearer".to_string(),
+        };
+        builder = builder.header("www-authenticate", challenge);
     }
 
     builder
@@ -2958,7 +2968,10 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         // What the token failed on is the client's own token, so naming it
         // costs nothing and is the only way it can tell a bad signature from
         // an expired one.
-        Error::InvalidJwt(_) | Error::JwtClaim(_) | Error::MissingAuth => return error.to_string(),
+        Error::InvalidJwt(_)
+        | Error::NoSuitableJwtKey
+        | Error::JwtClaim(_)
+        | Error::MissingAuth => return error.to_string(),
         Error::InsufficientPermissions(_) => "Forbidden",
 
         // A fixed policy message that reveals nothing about the request or the

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -24,7 +24,10 @@ use tracing::{debug, error};
 /// is still in scope and a bare reference to it yields the composite, and the
 /// embed expression reads it from there. It is stripped from the response like
 /// any other column added for embedding.
-const PARENT_ROW_COLUMN: &str = "pgrst_parent_row";
+///
+/// Defined in `postrust-core` beside the `RETURNING` that emits it for a
+/// mutation, so the two spellings cannot drift.
+use postrust_core::query::PARENT_ROW_COLUMN;
 
 /// Marks an embedded object whose columns belong to its parent.
 ///
@@ -272,16 +275,6 @@ const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 /// rendered value, read from the first column.
 const MEDIA_ROW_COUNT_COLUMN: &str = "pgrst_media_rows";
 
-/// Whether this request writes rows of a table.
-fn is_relation_mutation(api_request: &ApiRequest) -> bool {
-    use postrust_core::api_request::{Action, DbAction};
-
-    matches!(
-        &api_request.action,
-        Action::Db(DbAction::RelationMut { .. })
-    )
-}
-
 /// Whether this request writes the row its URL names.
 fn is_upsert(api_request: &ApiRequest) -> bool {
     use postrust_core::api_request::{Action, DbAction, Mutation};
@@ -480,20 +473,63 @@ async fn execute_plan(
                 || matches!(&media_handler, Some((_, _, true, _)));
             let db_plan = &if needs_parent_row {
                 let mut adjusted = db_plan.clone();
-                // A function's result is a relation too, named after the
-                // function, so the row is reachable there by exactly the same
-                // means -- which is what makes a computed relationship work on
+                // A function's result is a relation too, so the row is
+                // reachable there by exactly the same means -- which is what
+                // makes a computed relationship work on
                 // `/rpc/getallvideogames` and not only on a table.
+                //
+                // Named after the table it returns, not after the function.
+                // The builder aliases the call to that table (`FROM
+                // test.getallvideogames() AS videogames`), because a computed
+                // *column* has to be able to name the row it is a function of.
+                // Naming the function here instead asks for a relation that is
+                // no longer in scope, and the request that used to work --
+                // `?select=name,designer:computed_designers(name)` -- answers
+                // `column "getallvideogames" does not exist`.
                 let (tree, relation) = match &mut adjusted {
                     DbActionPlan::Read(tree) => {
                         let relation = tree.root.from.name.clone();
                         (Some(tree), relation)
                     }
-                    DbActionPlan::Call { call, read } => {
-                        let relation = call.function.name.clone();
+                    DbActionPlan::Call { read, .. } => {
+                        let relation = read
+                            .as_ref()
+                            .map(|tree| tree.root.from.name.clone())
+                            .unwrap_or_default();
                         (read.as_mut(), relation)
                     }
-                    DbActionPlan::MutateRead { .. } => (None, String::new()),
+                    // The row is taken inside the statement, by `RETURNING`,
+                    // and read back off the CTE as an ordinary column -- so
+                    // unlike the two above there is no relation to name here,
+                    // and the read tree selects the column rather than a row.
+                    DbActionPlan::MutateRead { mutate, read } => {
+                        let returning = match mutate {
+                            postrust_core::plan::MutatePlan::Insert { returning, .. }
+                            | postrust_core::plan::MutatePlan::Update { returning, .. }
+                            | postrust_core::plan::MutatePlan::Delete { returning, .. } => {
+                                returning
+                            }
+                        };
+                        if !returning.iter().any(|c| c == PARENT_ROW_COLUMN) {
+                            returning.push(PARENT_ROW_COLUMN.to_string());
+                        }
+                        // A mutation that returns no body has no read tree,
+                        // and nothing to embed into either.
+                        if let Some(read) = read.as_mut() {
+                            if !read.root.select.iter().any(|field| {
+                                field.alias.as_deref() == Some(PARENT_ROW_COLUMN)
+                                    || field.field.name == PARENT_ROW_COLUMN
+                            }) {
+                                read.root.select.push(
+                                    postrust_core::plan::CoercibleSelectField::simple(
+                                        PARENT_ROW_COLUMN,
+                                        "",
+                                    ),
+                                );
+                            }
+                        }
+                        (None, String::new())
+                    }
                 };
 
                 if let Some(tree) = tree {
@@ -650,15 +686,12 @@ async fn execute_plan(
                     }) =>
                 {
                     let schema_cache = state.schema_cache().await;
-                    // A computed relationship takes the parent's row, and a
-                    // mutation's result is a CTE whose row type is anonymous
-                    // -- there is nothing to pass it. Saying so here leaves
-                    // the embed out rather than referring to a column the
-                    // query does not have.
-                    let parent_row = match is_mutation(db_plan) {
-                        true => "",
-                        false => PARENT_ROW_COLUMN_REF,
-                    };
+                    // A computed relationship takes the parent's row, which
+                    // now reaches here on every path: a read names the table,
+                    // and a mutation returns the row out of the statement
+                    // where it still has the table's type rather than the
+                    // CTE's anonymous one.
+                    let parent_row = PARENT_ROW_COLUMN_REF;
                     build_embed_expressions(
                         &schema_cache,
                         &parent_qi,
@@ -2231,12 +2264,10 @@ fn add_embed_join_columns(
 
         // A computed relationship joins on nothing -- the parent row is the
         // function's argument. That row has to be carried out of the inner
-        // query, which is a column of its own rather than a join key. A
-        // mutation has no such row to carry, so the embed is left out there.
+        // query, which is a column of its own rather than a join key. After a
+        // mutation it is carried out of the statement itself, by `RETURNING`,
+        // because that is the last place the row still has the table's type.
         if plan.function.is_some() {
-            if is_relation_mutation(api_request) {
-                continue;
-            }
             if !added.iter().any(|c| c == PARENT_ROW_COLUMN) {
                 added.push(PARENT_ROW_COLUMN.to_string());
             }

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -417,7 +417,21 @@ async fn execute_plan(
                 } if !is_upsert(api_request) => pk_cols.clone(),
                 _ => Vec::new(),
             };
-            let db_plan = &if location_keys.is_empty() {
+            // Whether the write created a row or merged into an existing one.
+            // The statement is the only place that can say, so the answer is
+            // carried out of it as a column and taken back out of the response.
+            let reports_inserted = matches!(
+                db_plan,
+                DbActionPlan::MutateRead {
+                    mutate: postrust_core::plan::MutatePlan::Insert {
+                        on_conflict: Some(_),
+                        ..
+                    },
+                    ..
+                }
+            );
+
+            let db_plan = &if location_keys.is_empty() && !reports_inserted {
                 db_plan.clone()
             } else {
                 let mut adjusted = db_plan.clone();
@@ -433,6 +447,14 @@ async fn execute_plan(
                                 &format!("{}{}", LOCATION_KEY_PREFIX, key),
                             ),
                         );
+                    }
+                    if reports_inserted {
+                        tree.root
+                            .select
+                            .push(postrust_core::plan::CoercibleSelectField::simple(
+                                postrust_core::query::INSERTED_COLUMN,
+                                "boolean",
+                            ));
                     }
                 }
                 adjusted
@@ -980,6 +1002,21 @@ async fn execute_plan(
                 }
             }
 
+            // Any row this statement created rather than merged into. Read
+            // before the column is taken back out of the response.
+            let created_a_row = reports_inserted
+                && json_rows.iter().any(|row| {
+                    row.get(postrust_core::query::INSERTED_COLUMN)
+                        == Some(&serde_json::Value::Bool(true))
+                });
+            if reports_inserted {
+                for row in json_rows.iter_mut() {
+                    if let Some(object) = row.as_object_mut() {
+                        object.remove(postrust_core::query::INSERTED_COLUMN);
+                    }
+                }
+            }
+
             // The created row's own address, taken from its key and then
             // removed from the body -- the client asked for a `?select=`, not
             // for the key.
@@ -1050,12 +1087,14 @@ async fn execute_plan(
             Ok(QueryResult {
                 status: match returns_void {
                     true => StatusCode::NO_CONTENT,
-                    false => mutation_status(db_plan, api_request).unwrap_or_else(|| {
-                        content_range
-                            .as_ref()
-                            .map(postrust_response::ContentRange::status)
-                            .unwrap_or(StatusCode::OK)
-                    }),
+                    false => {
+                        mutation_status(db_plan, api_request, created_a_row).unwrap_or_else(|| {
+                            content_range
+                                .as_ref()
+                                .map(postrust_response::ContentRange::status)
+                                .unwrap_or(StatusCode::OK)
+                        })
+                    }
                 },
                 rows,
                 singular,
@@ -1321,35 +1360,39 @@ fn wants_representation(api_request: &ApiRequest) -> bool {
 fn mutation_status(
     db_plan: &postrust_core::plan::DbActionPlan,
     api_request: &ApiRequest,
+    created_a_row: bool,
 ) -> Option<StatusCode> {
+    use postrust_core::api_request::PreferResolution;
     use postrust_core::plan::{DbActionPlan, MutatePlan};
-
-    use postrust_core::api_request::{Action, DbAction, Mutation};
 
     let DbActionPlan::MutateRead { mutate, .. } = db_plan else {
         return None;
     };
 
-    // A `PUT` is an upsert, planned as an insert but answered as an update:
-    // the client named the row it is writing, so nothing was created from its
-    // point of view whether or not a row existed before.
-    let is_upsert = matches!(
-        &api_request.action,
-        Action::Db(DbAction::RelationMut {
-            mutation: Mutation::SingleUpsert,
-            ..
-        })
+    let merging = matches!(
+        api_request.preferences.resolution,
+        Some(PreferResolution::MergeDuplicates)
     );
 
     Some(match mutate {
-        MutatePlan::Insert { .. } if !is_upsert => StatusCode::CREATED,
-        _ => {
-            if wants_representation(api_request) {
-                StatusCode::OK
-            } else {
-                StatusCode::NO_CONTENT
+        // A `PUT` names the row it is writing, so from the client's side
+        // nothing was discovered by the response -- it reports the outcome
+        // only where it asked to see the row.
+        MutatePlan::Insert { .. } if is_upsert(api_request) => {
+            match (wants_representation(api_request), created_a_row) {
+                (false, _) => StatusCode::NO_CONTENT,
+                (true, true) => StatusCode::CREATED,
+                (true, false) => StatusCode::OK,
             }
         }
+        // A `POST` that merged into every row it touched created nothing, and
+        // 201 would be a promise that something new is at the `Location`.
+        MutatePlan::Insert { .. } if merging && !created_a_row => StatusCode::OK,
+        MutatePlan::Insert { .. } => StatusCode::CREATED,
+        _ => match wants_representation(api_request) {
+            true => StatusCode::OK,
+            false => StatusCode::NO_CONTENT,
+        },
     })
 }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -162,6 +162,79 @@ async fn process_request(
     Ok(build_response(response))
 }
 
+/// The prefix given to primary key columns added only to build `Location`.
+const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
+
+/// Whether this request writes the row its URL names.
+fn is_upsert(api_request: &ApiRequest) -> bool {
+    use postrust_core::api_request::{Action, DbAction, Mutation};
+
+    matches!(
+        &api_request.action,
+        Action::Db(DbAction::RelationMut {
+            mutation: Mutation::SingleUpsert,
+            ..
+        })
+    )
+}
+
+/// The `Location` of a newly created row, and removal of the key columns that
+/// were added to find it.
+///
+/// `/projects?id=eq.7` -- the address the row can be read back from, which is
+/// what a 201 is required to give. A key column that came back null is
+/// addressed with `is.null`, since `eq.` would match nothing.
+fn build_location(
+    api_request: &ApiRequest,
+    rows: &mut [serde_json::Value],
+    keys: &[String],
+) -> Option<String> {
+    if keys.is_empty() {
+        return None;
+    }
+
+    let table = api_request.path.rsplit('/').next()?;
+    let mut conditions = Vec::with_capacity(keys.len());
+
+    for key in keys {
+        let value = rows
+            .first()?
+            .get(key)
+            .or_else(|| rows.first()?.get(format!("{}{}", LOCATION_KEY_PREFIX, key)))?;
+        conditions.push(match value {
+            serde_json::Value::Null => format!("{}=is.null", urlencode(key)),
+            serde_json::Value::String(text) => {
+                format!("{}=eq.{}", urlencode(key), urlencode(text))
+            }
+            other => format!("{}=eq.{}", urlencode(key), urlencode(&other.to_string())),
+        });
+    }
+
+    for row in rows.iter_mut() {
+        if let Some(object) = row.as_object_mut() {
+            for key in keys {
+                object.remove(&format!("{}{}", LOCATION_KEY_PREFIX, key));
+            }
+        }
+    }
+
+    Some(format!("/{}?{}", table, conditions.join("&")))
+}
+
+/// Percent-encode everything a query-string value may not carry literally.
+fn urlencode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(*byte as char)
+            }
+            other => encoded.push_str(&format!("%{:02X}", other)),
+        }
+    }
+    encoded
+}
+
 /// Whether this request must carry a body.
 ///
 /// Insert, update and upsert all write values that can only come from one.
@@ -291,6 +364,39 @@ async fn execute_plan(
                 adjusted
             } else {
                 db_plan.clone()
+            };
+
+            // The `Location` of a created row is built from its primary key,
+            // which the client may not have selected. The columns are added
+            // under names of our own so they cannot collide with anything the
+            // request asked for, and are taken back out of the response once
+            // the header is built.
+            let location_keys: Vec<String> = match db_plan {
+                DbActionPlan::MutateRead {
+                    mutate: postrust_core::plan::MutatePlan::Insert { pk_cols, .. },
+                    ..
+                } if !is_upsert(api_request) => pk_cols.clone(),
+                _ => Vec::new(),
+            };
+            let db_plan = &if location_keys.is_empty() {
+                db_plan.clone()
+            } else {
+                let mut adjusted = db_plan.clone();
+                if let DbActionPlan::MutateRead {
+                    read: Some(tree), ..
+                } = &mut adjusted
+                {
+                    for key in &location_keys {
+                        tree.root.select.push(
+                            postrust_core::plan::CoercibleSelectField::with_alias(
+                                key,
+                                "",
+                                &format!("{}{}", LOCATION_KEY_PREFIX, key),
+                            ),
+                        );
+                    }
+                }
+                adjusted
             };
 
             // Build SQL
@@ -799,7 +905,7 @@ async fn execute_plan(
             // In PostgREST-compatibility mode, reshape RPC responses to match
             // PostgREST: un-nest the function-name-keyed column and return a
             // bare value for non-set-returning functions.
-            let (json_rows, singular) = if state.config.compat_mode {
+            let (mut json_rows, singular) = if state.config.compat_mode {
                 if let ActionPlan::Db(DbActionPlan::Call { call, .. }) = plan {
                     unwrap_rpc_rows(json_rows, call)
                 } else {
@@ -823,6 +929,11 @@ async fn execute_plan(
                     ..Default::default()
                 });
             }
+
+            // The created row's own address, taken from its key and then
+            // removed from the body -- the client asked for a `?select=`, not
+            // for the key.
+            let location = build_location(api_request, &mut json_rows, &location_keys);
 
             // A mutation returns the affected rows only when the caller asked
             // for them; otherwise the body is empty whatever the status.
@@ -867,6 +978,7 @@ async fn execute_plan(
                 rows,
                 singular,
                 omit_body,
+                location,
                 content_range: Some(content_range),
                 ..Default::default()
             })

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -258,6 +258,20 @@ async fn execute_plan(
                 .await
                 .map_err(|e| postrust_core::Error::ConnectionPool(e.to_string()))?;
 
+            // A read request runs in a read-only transaction.
+            //
+            // Without this a GET can change data: `GET /rpc/some_volatile_fn`
+            // happily executes whatever the function does. PostgreSQL is the
+            // right place to enforce it, since it covers anything reachable
+            // from the statement -- a volatile function, a trigger, a rule --
+            // rather than only what the planner thought to look at.
+            if !is_mutation(db_plan) {
+                sqlx::query("SET TRANSACTION READ ONLY")
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(map_sqlx_error)?;
+            }
+
             // Set role
             sqlx::query(&format!(
                 "SET LOCAL ROLE {}",

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1524,6 +1524,9 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         Error::UnacceptableSchema { requested, .. } => {
             return format!("Invalid schema: {}", requested)
         }
+        // The candidate list is the whole point of the message: it names the
+        // signatures that could not be told apart.
+        Error::AmbiguousFunction { .. } => return error.to_string(),
         _ => {}
     }
 

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -535,7 +535,12 @@ async fn execute_plan(
             let mut params = params;
             params.extend(embed_filters.params);
 
-            if !embed_level.expressions.is_empty() {
+            // Built whenever there were relations at all, not only when they
+            // produced expressions: `clients!inner()` contributes no column
+            // but does narrow the parent, and its predicate binds parameters
+            // that have already been appended -- left unapplied, the query is
+            // sent with more parameters than it uses.
+            if embed_level.saw_relations {
                 // `!inner` removes parent rows, so it has to be applied before
                 // the page is taken. Left where it is, the inner query's
                 // LIMIT would run first and the join would then trim an

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -15,6 +15,18 @@ use postrust_response::{format_response, QueryResult, Response as PgrstResponse}
 use std::sync::Arc;
 use tracing::{debug, error};
 
+/// Column carrying the parent's whole row, for computed relationships.
+///
+/// A computed relationship is a function taking the parent row. By the time an
+/// embed expression runs, the parent is a derived table, and a derived table's
+/// alias has type `record` -- which PostgreSQL will not cast to the table's
+/// composite type. So the row is captured one level down, where the real table
+/// is still in scope and a bare reference to it yields the composite, and the
+/// embed expression reads it from there. It is stripped from the response like
+/// any other column added for embedding.
+const PARENT_ROW_COLUMN: &str = "pgrst_parent_row";
+const PARENT_ROW_COLUMN_REF: &str = "\"src\".\"pgrst_parent_row\"";
+
 /// Main request handler.
 pub async fn handle_request(State(state): State<Arc<AppState>>, request: Request) -> Response {
     let method = request.method().clone();
@@ -123,6 +135,34 @@ async fn execute_plan(
 ) -> Result<QueryResult, postrust_core::Error> {
     match plan {
         ActionPlan::Db(db_plan) => {
+            // Carry the parent's whole row out of the inner query when a
+            // computed relationship needs it as an argument. It has to be
+            // taken here, where the real table is still in scope: a bare
+            // reference to the table yields its composite type, whereas the
+            // derived table it becomes one level up yields a `record`.
+            let db_plan = &if added_join_columns.iter().any(|c| c == PARENT_ROW_COLUMN) {
+                let mut adjusted = db_plan.clone();
+                if let DbActionPlan::Read(tree) = &mut adjusted {
+                    let mut field = postrust_core::plan::CoercibleField::simple(
+                        tree.root.from.name.clone(),
+                        String::new(),
+                    );
+                    field.full_row = true;
+                    tree.root
+                        .select
+                        .push(postrust_core::plan::CoercibleSelectField {
+                            field,
+                            aggregate: None,
+                            aggregate_cast: None,
+                            cast: None,
+                            alias: Some(PARENT_ROW_COLUMN.to_string()),
+                        });
+                }
+                adjusted
+            } else {
+                db_plan.clone()
+            };
+
             // Build SQL
             let query = postrust_core::query::build_query(
                 &ActionPlan::Db(db_plan.clone()),
@@ -173,6 +213,7 @@ async fn execute_plan(
                         &schema_cache,
                         &parent_qi,
                         "src",
+                        PARENT_ROW_COLUMN_REF,
                         &api_request.query_params.select,
                         &mut embed_filters,
                         &[],
@@ -602,6 +643,16 @@ fn add_embed_join_columns(
 
         let plan = postrust_core::embed::EmbedPlan::resolve(rel, schema_cache)?;
 
+        // A computed relationship joins on nothing -- the parent row is the
+        // function's argument. That row has to be carried out of the inner
+        // query, which is a column of its own rather than a join key.
+        if plan.function.is_some() {
+            if !added.iter().any(|c| c == PARENT_ROW_COLUMN) {
+                added.push(PARENT_ROW_COLUMN.to_string());
+            }
+            continue;
+        }
+
         if !selected.contains(&plan.local_column) && !added.contains(&plan.local_column) {
             api_request.query_params.select.push(SelectItem::Field {
                 field: Field::simple(&plan.local_column),
@@ -750,6 +801,12 @@ fn build_embed_expressions(
     schema_cache: &postrust_core::SchemaCache,
     parent_qi: &postrust_core::api_request::QualifiedIdentifier,
     parent_alias: &str,
+    // The SQL expression yielding the parent's whole row, which a computed
+    // relationship takes as its argument. At a nested level the parent is a
+    // real table alias and so is the row; at the top level the parent is a
+    // derived table, whose alias is a `record` rather than the table's own
+    // composite type, so a column carrying the row is passed instead.
+    parent_row: &str,
     select: &[postrust_core::api_request::SelectItem],
     ctx: &mut EmbedFilters<'_>,
     path: &[String],
@@ -788,10 +845,12 @@ fn build_embed_expressions(
         let child_where = ctx.predicate_for(&child_path, &child_qi, schema_cache)?;
 
         // Deeper relations first: they become part of this level's SELECT list.
+        let child_row = postrust_sql::escape_ident(&child_alias);
         let nested = build_embed_expressions(
             schema_cache,
             &child_qi,
             &child_alias,
+            &child_row,
             child_select,
             ctx,
             &child_path,
@@ -820,6 +879,7 @@ fn build_embed_expressions(
         if matches!(join_type, Some(postrust_core::api_request::JoinType::Inner)) {
             level.inner_joins.push(plan.inner_join_predicate(
                 parent_alias,
+                parent_row,
                 &child_alias,
                 child_where.as_deref(),
             ));
@@ -864,6 +924,7 @@ fn build_embed_expressions(
         let inner_select = parts.join(", ");
         let expression = plan.embed_expression(
             parent_alias,
+            parent_row,
             &child_alias,
             &inner_select,
             ctx.max_rows,

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1276,7 +1276,10 @@ fn error_response(error: postrust_core::Error) -> Response {
             "code": error.code(),
             "message": sanitize_error_message(&error),
             "details": null,
-            "hint": null
+            // A hint says how to correct the request. It is carried by the
+            // error itself, so it never has to reach for anything the
+            // sanitised message deliberately left out.
+            "hint": error.hint(),
         });
         serde_json::to_vec(&sanitized).unwrap_or_default()
     };
@@ -1289,18 +1292,36 @@ fn error_response(error: postrust_core::Error) -> Response {
 }
 
 /// Sanitize error messages for production.
-fn sanitize_error_message(error: &postrust_core::Error) -> &'static str {
+fn sanitize_error_message(error: &postrust_core::Error) -> String {
     use postrust_core::Error;
+
+    // A schema-cache miss names what the client asked for, and the client
+    // already knows that -- it is what it sent. Saying so is what makes the
+    // difference between "Resource not found" and a message the client can act
+    // on, and it discloses nothing it did not supply. What stays sanitised is
+    // the database's own account of a failure, which is about the schema
+    // rather than about the request.
     match error {
-        Error::TableNotFound(_) | Error::NotFound(_) => "Resource not found",
-        Error::FunctionNotFound(_) => "Function not found",
+        Error::TableNotFound(name) | Error::NotFound(name) => {
+            return format!("Could not find the table '{}' in the schema cache", name)
+        }
+        Error::FunctionNotFound(name) => {
+            return format!("Could not find the function {} in the schema cache", name)
+        }
+        Error::UnacceptableSchema { requested, .. } => {
+            return format!("Invalid schema: {}", requested)
+        }
+        _ => {}
+    }
+
+    (match error {
         Error::ColumnNotFound(_) | Error::UnknownColumn(_) => "Column not found",
         Error::RelationshipNotFound(_) => "Relationship not found",
         Error::InvalidPath(_) => "Invalid request path",
         Error::InvalidBody(_) => "Invalid request body",
         Error::InvalidJwt(_) | Error::JwtExpired | Error::MissingAuth => "Unauthorized",
         Error::InsufficientPermissions(_) => "Forbidden",
-        Error::UnacceptableSchema(_) => "Invalid schema",
+
         // A fixed policy message that reveals nothing about the request or the
         // schema, so it is passed through verbatim -- and it is what PostgREST
         // says, which is what a client branching on it will be matching.
@@ -1310,7 +1331,8 @@ fn sanitize_error_message(error: &postrust_core::Error) -> &'static str {
         Error::ConnectionPool(_) => "Service temporarily unavailable",
         Error::Internal(_) => "Internal server error",
         _ => "An error occurred",
-    }
+    })
+    .to_string()
 }
 
 #[cfg(test)]

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -2778,18 +2778,31 @@ fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Resp
     // its status, its headers and its body. Nothing here is the API layer's to
     // decide, including whether to sanitise it -- the schema wrote it.
     if let postrust_core::Error::Database(db) = &error {
-        if let Some(raised) = db.raised_response() {
-            let mut builder = Response::builder()
-                .status(status)
-                .header("content-type", "application/json");
-            for (name, value) in &raised.headers {
-                builder = builder.header(name, value);
+        match db.raised_response() {
+            Some(Ok(raised)) => {
+                let mut builder = Response::builder()
+                    .status(status)
+                    .header("content-type", "application/json");
+                for (name, value) in &raised.headers {
+                    builder = builder.header(name, value);
+                }
+                return builder
+                    .body(Body::from(
+                        serde_json::to_vec(&raised.body).unwrap_or_default(),
+                    ))
+                    .unwrap_or_else(|_| Response::new(Body::empty()));
             }
-            return builder
-                .body(Body::from(
-                    serde_json::to_vec(&raised.body).unwrap_or_default(),
-                ))
-                .unwrap_or_else(|_| Response::new(Body::empty()));
+            // The schema meant to write a response and wrote something else.
+            // Reported as the fault it is, and reported the same way whether
+            // or not database errors are passed through, since this one is
+            // about the schema's own text rather than about the request.
+            Some(Err(fault)) => {
+                return error_response(
+                    postrust_core::Error::RaiseNotUnderstood(fault),
+                    verbatim_db_errors,
+                )
+            }
+            None => {}
         }
     }
 
@@ -2904,6 +2917,9 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         | Error::InvalidGucHeaders
         | Error::InvalidGucStatus
         | Error::InvalidMediaType(_)
+        // Says nothing about the schema beyond that one RAISE is malformed,
+        // which is what the author has to fix.
+        | Error::RaiseNotUnderstood(_)
         | Error::InvalidResourcePath => return error.to_string(),
         Error::InvalidPath(_) => "Invalid request path",
         // What the token failed on is the client's own token, so naming it

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -379,7 +379,7 @@ fn jwt_error(error: postrust_auth::JwtError) -> postrust_core::Error {
     use postrust_auth::JwtError;
 
     match error {
-        JwtError::MissingHeader => postrust_core::Error::MissingAuth,
+        JwtError::NoIdentity => postrust_core::Error::MissingAuth,
         JwtError::SecretMissing => postrust_core::Error::JwtSecretMissing,
         // Read, and found wanting: the token itself is intact, and what it
         // claims is what was not accepted.
@@ -1451,13 +1451,21 @@ pub async fn options_allow(
         return next.run(request).await;
     }
 
+    // Not every route is the API's. A layer added to the router wraps every
+    // one of them, so `/admin` and `/_` arrive here too, and answering those
+    // with what a table allows -- or with "no such table" -- takes a working
+    // preflight and turns it into a 404.
+    let Some(path) = api_path(request.uri().path(), state.config.compat_mode) else {
+        return next.run(request).await;
+    };
+
     let verbatim_db_errors = state.config.compat_mode;
 
     // Built here, from borrows, before anything is awaited: `axum::body::Body`
     // is `Send` but not `Sync`, and `&T` is `Send` only where `T` is `Sync`, so
     // a `&Request` held across an await makes the whole future not `Send` --
     // which a middleware has to be.
-    let probe = probe_request(&request);
+    let probe = probe_request(&request, path);
     let allow = match probe {
         Ok(probe) => resolve_allow(&state, probe).await,
         Err(error) => Err(error),
@@ -1474,15 +1482,64 @@ pub async fn options_allow(
         }
         // Asking what may be done with a table that is not there is answered
         // the same way as asking for the table.
-        Err(error) => error_response(error, verbatim_db_errors).into_response(),
+        Err(error) => {
+            let mut refusal = error_response(error, verbatim_db_errors).into_response();
+            // The CORS layer wrote its headers on the response this replaces.
+            // Without them a browser reports the request as blocked by CORS
+            // rather than as the 404 it earned, which is a different thing to
+            // go and fix.
+            for (name, value) in response.headers() {
+                if name.as_str().starts_with("access-control-") || name == http::header::VARY {
+                    refusal.headers_mut().append(name, value.clone());
+                }
+            }
+            refusal
+        }
     }
 }
 
-/// The request again, with an empty body, for the parser to read.
-fn probe_request(request: &Request) -> Result<http::Request<bytes::Bytes>, postrust_core::Error> {
+/// The path the API parser should read, or `None` where the request names
+/// something that is not the REST surface.
+///
+/// A layer added with `Router::layer` wraps each endpoint, and `nest` puts its
+/// prefix-stripping *inside* that endpoint -- so the path seen here is the one
+/// the client wrote and still carries the mount it arrived under, unlike the
+/// one the handler reads.
+fn api_path(path: &str, compat_mode: bool) -> Option<&str> {
+    /// Whether a path names a mount point or something under it.
+    fn under(path: &str, mount: &str) -> bool {
+        path == mount || path.strip_prefix(mount).is_some_and(|r| r.starts_with('/'))
+    }
+
+    if under(path, "/admin") || under(path, "/_") || under(path, "/api/graphql") {
+        return None;
+    }
+    if under(path, "/api") {
+        return Some(match path.strip_prefix("/api") {
+            None | Some("") => "/",
+            Some(rest) => rest,
+        });
+    }
+    // Everywhere else the REST surface exists only in compatibility mode,
+    // where it answers at the root. Without it `/` is this server's own
+    // directory of endpoints, which allows what its handler allows.
+    compat_mode.then_some(path)
+}
+
+/// The request again, with an empty body and the API's own path, for the
+/// parser to read.
+#[allow(clippy::result_large_err)] // consistent with the crate's error type
+fn probe_request(
+    request: &Request,
+    path: &str,
+) -> Result<http::Request<bytes::Bytes>, postrust_core::Error> {
+    let target = match request.uri().query() {
+        Some(query) => format!("{path}?{query}"),
+        None => path.to_string(),
+    };
     let mut builder = http::Request::builder()
         .method(request.method().clone())
-        .uri(request.uri().clone());
+        .uri(target);
     for (name, value) in request.headers() {
         builder = builder.header(name, value);
     }
@@ -1720,6 +1777,16 @@ fn round_coordinates(value: &mut serde_json::Value) {
     }
 }
 
+/// Where the response's window starts.
+///
+/// The same resolution the plan itself used, asked again rather than restated:
+/// the JSON path and the rendered-media path both report a `Content-Range`,
+/// and a `Content-Range` that disagrees with the rows underneath it is worse
+/// than none at all.
+fn top_level_offset(api_request: &ApiRequest) -> i64 {
+    postrust_core::plan::resolve_top_level_range(api_request).offset
+}
+
 /// The first column of a row, as the bytes the client should receive.
 ///
 /// A media type the schema declared is carried by a domain, and a domain is a
@@ -1727,21 +1794,6 @@ fn round_coordinates(value: &mut serde_json::Value) {
 /// own text rendering. For text, xml or json that rendering is the value. For
 /// `bytea` it is `\x` followed by hex, which is a description of the bytes
 /// and not the bytes, so it is decoded back.
-/// Where the response's window starts.
-///
-/// An explicit top-level `?offset=` if there is one, and the range taken from
-/// the `Range` header otherwise. Both the JSON path and the rendered-media
-/// path report a `Content-Range` and must agree on where it begins.
-fn top_level_offset(api_request: &ApiRequest) -> i64 {
-    api_request
-        .query_params
-        .ranges
-        .get("")
-        .map(|range| range.offset)
-        .filter(|offset| *offset != 0)
-        .unwrap_or(api_request.top_level_range.offset)
-}
-
 fn raw_column(row: &sqlx::postgres::PgRow, base_type: &str) -> Option<Vec<u8>> {
     use sqlx::{Row, ValueRef};
 
@@ -2736,7 +2788,12 @@ fn related_order_target(
     let rel = schema_cache
         .find_relationship(parent_qi, embedded.0, embedded.1, &parent_qi.schema)?
         .ok_or_else(|| {
-            schema_cache.relationship_not_found(parent_qi, embedded.0, embedded.1, &parent_qi.schema)
+            schema_cache.relationship_not_found(
+                parent_qi,
+                embedded.0,
+                embedded.1,
+                &parent_qi.schema,
+            )
         })?;
 
     // A resource that yields many rows per parent has no single value to order
@@ -3678,6 +3735,52 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
 
 #[cfg(test)]
 mod tests {
+    /// The REST surface is mounted at `/api`, and an `OPTIONS` reaches the
+    /// layer before the mount is stripped off.
+    #[test]
+    fn the_api_path_is_the_one_below_the_mount() {
+        assert_eq!(super::api_path("/api/items", false), Some("/items"));
+        assert_eq!(super::api_path("/api/rpc/f", false), Some("/rpc/f"));
+        assert_eq!(super::api_path("/api", false), Some("/"));
+        assert_eq!(super::api_path("/api/", false), Some("/"));
+    }
+
+    /// Answering for a route that is not the API's turns a working preflight
+    /// into a 404 for a table nobody asked about.
+    #[test]
+    fn a_route_that_is_not_the_api_is_left_alone() {
+        for path in [
+            "/admin",
+            "/admin/swagger",
+            "/_",
+            "/_/health",
+            "/api/graphql",
+        ] {
+            assert_eq!(super::api_path(path, false), None, "{path}");
+            assert_eq!(super::api_path(path, true), None, "{path}");
+        }
+    }
+
+    /// Outside the mounts the surface exists only in compatibility mode,
+    /// where PostgREST's own paths answer at the root.
+    #[test]
+    fn the_root_is_the_api_only_in_compatibility_mode() {
+        assert_eq!(super::api_path("/items", true), Some("/items"));
+        assert_eq!(super::api_path("/", true), Some("/"));
+        assert_eq!(super::api_path("/items", false), None);
+        assert_eq!(super::api_path("/", false), None);
+    }
+
+    /// A mount is a path segment: `/apiary` is not under `/api`.
+    #[test]
+    fn a_mount_matches_whole_segments_only() {
+        assert_eq!(super::api_path("/apiary", true), Some("/apiary"));
+        assert_eq!(
+            super::api_path("/administrators", true),
+            Some("/administrators")
+        );
+    }
+
     /// A data-modifying `WITH` may only appear at the top level, so anything
     /// that wraps the statement has to leave the clause where it is.
     #[test]

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -580,11 +580,20 @@ async fn execute_plan(
             // response -- reads, mutations and RPC alike, but not on errors or
             // OPTIONS. Without an exact count the total is unknown, which
             // renders as `*` and keeps the status at 200.
-            let content_range = postrust_response::ContentRange::from_pagination(
-                api_request.top_level_range.offset,
-                rows.len() as i64,
-                None,
-            );
+            // The window starts where the request asked it to, and `offset`
+            // overrides the `Range` header exactly as it does when the plan
+            // resolves the range -- otherwise the reported window says 0 for a
+            // request that plainly skipped rows.
+            let offset = api_request
+                .query_params
+                .ranges
+                .get("")
+                .map(|range| range.offset)
+                .filter(|offset| *offset != 0)
+                .unwrap_or(api_request.top_level_range.offset);
+
+            let content_range =
+                postrust_response::ContentRange::from_pagination(offset, rows.len() as i64, None);
 
             Ok(QueryResult {
                 status: mutation_status(db_plan, api_request)
@@ -1476,7 +1485,7 @@ fn error_response(error: postrust_core::Error, verbatim_db_errors: bool) -> Resp
         let sanitized = serde_json::json!({
             "code": error.code(),
             "message": sanitize_error_message(&error),
-            "details": null,
+            "details": error.details(),
             // A hint says how to correct the request. It is carried by the
             // error itself, so it never has to reach for anything the
             // sanitised message deliberately left out.
@@ -1506,8 +1515,11 @@ fn sanitize_error_message(error: &postrust_core::Error) -> String {
         Error::TableNotFound(name) | Error::NotFound(name) => {
             return format!("Could not find the table '{}' in the schema cache", name)
         }
-        Error::FunctionNotFound(name) => {
-            return format!("Could not find the function {} in the schema cache", name)
+        Error::FunctionNotFound { name, params, .. } => {
+            return format!(
+                "Could not find the function {} in the schema cache",
+                postrust_core::error::function_signature(name, params)
+            )
         }
         Error::UnacceptableSchema { requested, .. } => {
             return format!("Invalid schema: {}", requested)

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -265,6 +265,13 @@ fn json_object<'a>(entries: impl IntoIterator<Item = (&'a String, &'a String)>) 
 /// The prefix given to primary key columns added only to build `Location`.
 const LOCATION_KEY_PREFIX: &str = "pgrst_location_";
 
+/// The column a media handler's statement carries its row count in.
+///
+/// Named like the other bookkeeping columns so it cannot collide with anything
+/// the request selected. Never reaches the client: the response body is the
+/// rendered value, read from the first column.
+const MEDIA_ROW_COUNT_COLUMN: &str = "pgrst_media_rows";
+
 /// Whether this request writes rows of a table.
 fn is_relation_mutation(api_request: &ApiRequest) -> bool {
     use postrust_core::api_request::{Action, DbAction};
@@ -420,7 +427,22 @@ async fn execute_plan(
                                         postrust_sql::escape_ident(&handler.aggregate.schema),
                                         postrust_sql::escape_ident(&handler.aggregate.name)
                                     ),
-                                    handler.table.is_some(),
+                                    // Applied to the table's own row, not to
+                                    // the derived one, whenever the derived
+                                    // row would be a worse description of it.
+                                    // A handler naming a table needs the row
+                                    // type by name; one taking `anyelement`
+                                    // needs the columns to still *be* what
+                                    // they are -- a handler calling
+                                    // `ST_AsGeoJSON` cannot find a geometry in
+                                    // a row whose geometry this side already
+                                    // rendered to jsonb. Only where the
+                                    // request did not reshape the rows, since
+                                    // then the two are the same rows.
+                                    handler.table.is_some()
+                                        || has_default_select(
+                                            &api_request.query_params.select,
+                                        ),
                                     handler.base_type.clone(),
                                 )
                             })
@@ -508,11 +530,18 @@ async fn execute_plan(
             // under names of our own so they cannot collide with anything the
             // request asked for, and are taken back out of the response once
             // the header is built.
+            //
+            // Only for `Prefer: return=headers-only`, which is the request
+            // that has no other way to learn where the row went. A client
+            // given the row back can read the key out of it, and PostgREST
+            // sends no `Location` there -- so neither does this. Deciding it
+            // here also means the key columns are never added to a select
+            // that had no use for them.
             let location_keys: Vec<String> = match db_plan {
                 DbActionPlan::MutateRead {
                     mutate: postrust_core::plan::MutatePlan::Insert { pk_cols, .. },
                     ..
-                } if !is_upsert(api_request) => pk_cols.clone(),
+                } if !is_upsert(api_request) && wants_location(api_request) => pk_cols.clone(),
                 _ => Vec::new(),
             };
             // Whether the write created a row or merged into an existing one.
@@ -753,6 +782,25 @@ async fn execute_plan(
                     });
                 }
 
+                // `or=(clientinfo.not.is.null,contact.not.is.null)` asks the
+                // same question of several embeds at once, and the answer is
+                // one predicate combining their existence tests. The read
+                // plan left the tree alone precisely so that it could be
+                // built here, where the embeds are in scope.
+                let embeds = postrust_core::api_request::embedded_names(
+                    &api_request.query_params.select,
+                );
+                for (path, tree) in &api_request.query_params.logic {
+                    if !path.is_empty() || !tree.names_only(&embeds) {
+                        continue;
+                    }
+                    if let Some(predicate) =
+                        embed_logic_predicate(tree, &embed_level.filterable)
+                    {
+                        predicates.push(predicate);
+                    }
+                }
+
                 if !predicates.is_empty() {
                     sql.push_str(" WHERE ");
                     sql.push_str(&predicates.join(" AND "));
@@ -837,10 +885,17 @@ async fn execute_plan(
                 } else {
                     "pgrst_media".to_string()
                 };
+                // `count(*)` alongside the handler: both are aggregates over
+                // the same set, and the rendered body is one value that has
+                // forgotten how many rows went into it. `Content-Range`
+                // describes the row set rather than the rendering, so the
+                // count has to be carried out of the same statement -- asking
+                // again afterwards would be a second snapshot.
                 let (with_clause, inner) = split_leading_cte(&sql);
                 sql = format!(
-                    "{}SELECT {}({})::text AS pgrst_body FROM ({}) pgrst_media",
-                    with_clause, aggregate, argument, inner
+                    "{}SELECT {}({})::text AS pgrst_body, count(*) AS {} \
+                     FROM ({}) pgrst_media",
+                    with_clause, aggregate, argument, MEDIA_ROW_COUNT_COLUMN, inner
                 );
                 debug!("Rendering {} via {}", media_type, aggregate);
             }
@@ -981,16 +1036,66 @@ async fn execute_plan(
                 // anything text-like that rendering *is* the value; for a
                 // `bytea` it is `\x` and hex, which describes the bytes
                 // rather than being them.
-                let body = rows
+                let mut body = rows
                     .first()
                     .and_then(|row| raw_column(row, &base_type))
                     .unwrap_or_default();
+
+                // PostgREST reads a handler's value as raw bytes in binary
+                // format, and a `jsonb` in binary format begins with a version
+                // byte -- which it forwards to the client. Its own suite
+                // records the result and marks it: "TODO SOH (start of
+                // heading) is being added to results".
+                //
+                // It is a bug, and the byte makes the body invalid JSON, so it
+                // is not something to do by default. Compatibility mode is
+                // where this server sets out to be PostgREST rather than to be
+                // right, and a client written against PostgREST's bytes gets
+                // PostgREST's bytes.
+                if state.config.compat_mode && base_type == "jsonb" {
+                    body.insert(0, 0x01);
+                }
+
+                // A rendered body is still a window on a result set, and
+                // PostgREST reports one. The row count comes from the
+                // aggregate's own statement where a handler rendered the rows;
+                // where the value is a function's media-type domain there was
+                // no aggregate, and the rows in hand are the answer.
+                let rendered_rows = match media_handler.is_some() {
+                    true => rows
+                        .first()
+                        .and_then(|row| {
+                            sqlx::Row::try_get::<i64, _>(row, MEDIA_ROW_COUNT_COLUMN).ok()
+                        })
+                        .unwrap_or_default(),
+                    false => rows.len() as i64,
+                };
+                let total = match (&api_request.preferences.count, &count_sql) {
+                    (Some(preference), Some(count_sql)) => {
+                        resolve_count(
+                            &mut tx,
+                            preference,
+                            count_sql,
+                            &params,
+                            api_request.max_rows,
+                        )
+                        .await?
+                    }
+                    _ => None,
+                };
+                let content_range = postrust_response::ContentRange::from_pagination(
+                    top_level_offset(api_request),
+                    rendered_rows,
+                    total,
+                );
+
                 tx.commit()
                     .await
                     .map_err(|e| postrust_core::Error::ConnectionPool(e.to_string()))?;
                 return Ok(QueryResult {
                     status: StatusCode::OK,
                     raw_body: Some((media_type, body)),
+                    content_range: Some(content_range),
                     ..QueryResult::default()
                 });
             }
@@ -1223,13 +1328,7 @@ async fn execute_plan(
             // overrides the `Range` header exactly as it does when the plan
             // resolves the range -- otherwise the reported window says 0 for a
             // request that plainly skipped rows.
-            let offset = api_request
-                .query_params
-                .ranges
-                .get("")
-                .map(|range| range.offset)
-                .filter(|offset| *offset != 0)
-                .unwrap_or(api_request.top_level_range.offset);
+            let offset = top_level_offset(api_request);
 
             // What a mutation reports is not a window on a result set. An
             // insert or a delete reports no window at all -- `*` -- because
@@ -1302,6 +1401,23 @@ async fn execute_plan(
         ActionPlan::Info(info_plan) => {
             use postrust_core::plan::InfoPlan;
 
+            // What an OPTIONS is for: the methods this particular relation or
+            // function will answer. Derived from the relation itself rather
+            // than from the routing table, which offers every method on every
+            // path and so can only ever give the same answer.
+            let allow = {
+                let schema_cache = state.schema_cache().await;
+                Some(match info_plan {
+                    InfoPlan::OpenApiSpec => "OPTIONS,GET,HEAD".to_string(),
+                    // Asking what may be done with a table that is not there
+                    // is answered the same way as asking for the table: an
+                    // OPTIONS that reports methods for a relation nobody can
+                    // reach describes something that does not exist.
+                    InfoPlan::RelationInfo(qi) => relation_allow(schema_cache.require_table(qi)?),
+                    InfoPlan::RoutineInfo(qi) => routine_allow(schema_cache.get_routines(qi)),
+                })
+            };
+
             // Return appropriate metadata based on the info type
             let response_data = match info_plan {
                 InfoPlan::OpenApiSpec => {
@@ -1331,9 +1447,61 @@ async fn execute_plan(
             Ok(QueryResult {
                 status: StatusCode::OK,
                 rows: vec![response_data],
+                allow,
                 ..Default::default()
             })
         }
+    }
+}
+
+/// The methods a relation answers, for the `Allow` of an OPTIONS.
+///
+/// Reading is always offered. Writing follows what the relation can actually
+/// do, which for a view is what its triggers give it: a view with only an
+/// INSERT trigger takes a POST and nothing else.
+///
+/// PUT is the exception that is not simply a permission. It replaces one row
+/// named by its primary key, so a relation without a primary key cannot
+/// answer it however writable it otherwise is -- which is why an auto-updatable
+/// view without a key offers POST, PATCH and DELETE but not PUT.
+///
+fn relation_allow(table: &postrust_core::schema_cache::Table) -> String {
+    let mut methods = vec!["OPTIONS", "GET", "HEAD"];
+
+    if table.insertable {
+        methods.push("POST");
+    }
+    if table.insertable && table.updatable && !table.pk_cols.is_empty() {
+        methods.push("PUT");
+    }
+    if table.updatable {
+        methods.push("PATCH");
+    }
+    if table.deletable {
+        methods.push("DELETE");
+    }
+
+    methods.join(",")
+}
+
+/// The methods a function answers, for the `Allow` of an OPTIONS.
+///
+/// A volatile function may change data, so it is reachable only by POST. One
+/// that cannot can also be read, and is offered under GET and HEAD as well.
+/// An overloaded name is readable when any of its overloads is.
+fn routine_allow(routines: Option<&Vec<postrust_core::schema_cache::Routine>>) -> String {
+    let readable = routines.is_some_and(|routines| {
+        routines.iter().any(|routine| {
+            !matches!(
+                routine.volatility,
+                postrust_core::schema_cache::FuncVolatility::Volatile
+            )
+        })
+    });
+
+    match readable {
+        true => "OPTIONS,GET,HEAD,POST".to_string(),
+        false => "OPTIONS,POST".to_string(),
     }
 }
 
@@ -1409,6 +1577,55 @@ fn read_target(
     }
 }
 
+/// One `?or=` or `?and=` over embedded resources, as a `WHERE` fragment.
+///
+/// Every leaf asks whether an embed matched, which is an existence test, and
+/// the tree is what combines them. `None` where any leaf asks something else,
+/// since half a condition is worse than none.
+fn embed_logic_predicate(
+    tree: &postrust_core::api_request::LogicTree,
+    filterable: &[(String, String)],
+) -> Option<String> {
+    use postrust_core::api_request::{IsValue, LogicOperator, LogicTree, Operation};
+
+    match tree {
+        LogicTree::Expr {
+            negated,
+            op,
+            children,
+        } => {
+            let rendered = children
+                .iter()
+                .map(|child| embed_logic_predicate(child, filterable))
+                .collect::<Option<Vec<String>>>()?;
+            let joined = rendered.join(match op {
+                LogicOperator::And => " AND ",
+                LogicOperator::Or => " OR ",
+            });
+            Some(match negated {
+                true => format!("NOT ({joined})"),
+                false => format!("({joined})"),
+            })
+        }
+        LogicTree::Stmt(filter) => {
+            let (_, exists) = filterable
+                .iter()
+                .find(|(name, _)| name == &filter.field.name)?;
+            // `is.null` asks for parents the embed did not match, so the
+            // existence test is the negation of it.
+            let negated = match &filter.op_expr.operation {
+                Operation::Is(IsValue::Null) => filter.op_expr.negated,
+                Operation::Is(IsValue::NotNull) => !filter.op_expr.negated,
+                _ => return None,
+            };
+            Some(match negated {
+                true => exists.clone(),
+                false => format!("NOT {exists}"),
+            })
+        }
+    }
+}
+
 /// Round a geometry's numbers to nine decimal places.
 ///
 /// Not cosmetic: nine is what `ST_AsGeoJSON` emits by default, and a geometry
@@ -1445,6 +1662,21 @@ fn round_coordinates(value: &mut serde_json::Value) {
 /// own text rendering. For text, xml or json that rendering is the value. For
 /// `bytea` it is `\x` followed by hex, which is a description of the bytes
 /// and not the bytes, so it is decoded back.
+/// Where the response's window starts.
+///
+/// An explicit top-level `?offset=` if there is one, and the range taken from
+/// the `Range` header otherwise. Both the JSON path and the rendered-media
+/// path report a `Content-Range` and must agree on where it begins.
+fn top_level_offset(api_request: &ApiRequest) -> i64 {
+    api_request
+        .query_params
+        .ranges
+        .get("")
+        .map(|range| range.offset)
+        .filter(|offset| *offset != 0)
+        .unwrap_or(api_request.top_level_range.offset)
+}
+
 fn raw_column(row: &sqlx::postgres::PgRow, base_type: &str) -> Option<Vec<u8>> {
     use sqlx::{Row, ValueRef};
 
@@ -1739,6 +1971,19 @@ fn wants_representation(api_request: &ApiRequest) -> bool {
     matches!(
         api_request.preferences.representation,
         postrust_core::api_request::PreferRepresentation::Full
+    )
+}
+
+/// Whether a created row's address is worth reporting.
+///
+/// `Prefer: return=headers-only` asks for exactly that and nothing else, and
+/// is the only request PostgREST answers with a `Location`. A caller taking
+/// the row back reads the key out of the body; a caller wanting neither asked
+/// for a minimal response and gets one.
+fn wants_location(api_request: &ApiRequest) -> bool {
+    matches!(
+        api_request.preferences.representation,
+        postrust_core::api_request::PreferRepresentation::HeadersOnly
     )
 }
 
@@ -2560,6 +2805,13 @@ fn build_embed_expressions(
         level.spread_columns.extend(nested.spread_columns);
         let nested_expressions = nested.expressions;
 
+        let child_table = schema_cache.get_table(
+            &postrust_core::api_request::QualifiedIdentifier::new(
+                &plan.foreign_schema,
+                &plan.foreign_table,
+            ),
+        );
+
         // The child's own columns. Empty means every column, which is what a
         // relation with no explicit selection asks for.
         let mut parts: Vec<String> = Vec::new();
@@ -2571,14 +2823,21 @@ fn build_embed_expressions(
                 }
                 SelectItem::Field { field, alias, .. } => {
                     let column = postrust_sql::escape_ident(&field.name);
-                    match alias {
-                        Some(alias) => parts.push(format!(
-                            "{} AS {}",
-                            column,
-                            postrust_sql::escape_ident(alias)
-                        )),
-                        None => parts.push(column),
-                    }
+                    // A schema that declared how one of its domains is written
+                    // on the wire meant it wherever the value appears, and an
+                    // embedded row is the same value in a different place.
+                    let rendered = child_table
+                        .as_ref()
+                        .and_then(|table| table.get_column(&field.name))
+                        .and_then(|c| schema_cache.representation(c.representation_type(), "json"))
+                        .map(|function| format!("{}({})", function, column))
+                        .unwrap_or_else(|| column.clone());
+                    let name = alias.as_deref().unwrap_or(&field.name);
+                    parts.push(format!(
+                        "{} AS {}",
+                        rendered,
+                        postrust_sql::escape_ident(name)
+                    ));
                 }
                 // Handled as an expression, not a column.
                 SelectItem::Relation { .. } | SelectItem::SpreadRelation { .. } => {}

--- a/crates/postrust-server/src/app.rs
+++ b/crates/postrust-server/src/app.rs
@@ -1563,6 +1563,7 @@ mod tests {
             function: QualifiedIdentifier::new("public", name),
             params: CallParams::None,
             returns_scalar: !returns_set,
+            return_type: None,
             returns_set,
             returns_composite: false,
             volatility: "Volatile".into(),
@@ -1574,6 +1575,7 @@ mod tests {
         CallPlan {
             returns_composite: true,
             returns_scalar: false,
+            return_type: None,
             ..call_plan(name, returns_set)
         }
     }

--- a/crates/postrust-server/src/lenient_uri.rs
+++ b/crates/postrust-server/src/lenient_uri.rs
@@ -34,11 +34,18 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-/// Bytes that httparse accepts in a request target but `http::Uri` rejects.
+/// Bytes that httparse accepts in a request target but `http::Uri` rejects,
+/// or reads as something other than part of the path and query.
 ///
 /// Checked against http 1.4 by parsing a URI containing each byte in turn.
+///
+/// `#` is not rejected -- it is read as starting a fragment, and everything
+/// after it disappears from the query. A fragment is a client-side notion that
+/// never reaches a server, so a `#` in a request target is an ordinary
+/// character of the query: `?select=data->!@#$%^&*_d` names a JSON key that
+/// happens to contain one.
 fn needs_encoding(b: u8) -> bool {
-    matches!(b, b'"' | b'<' | b'>') || b >= 0x80
+    matches!(b, b'"' | b'<' | b'>' | b'#') || b >= 0x80
 }
 
 /// Cap on a buffered request line or header line.

--- a/crates/postrust-server/src/lenient_uri.rs
+++ b/crates/postrust-server/src/lenient_uri.rs
@@ -54,8 +54,26 @@ fn needs_encoding(b: u8) -> bool {
 /// bound; hyper applies its own, smaller limits once it sees the bytes.
 const MAX_LINE: usize = 64 * 1024;
 
+/// The bytes a client sends to open an HTTP/2 connection without negotiating.
+///
+/// Nothing serves HTTP/2 here today: `axum::serve` builds on hyper-util's
+/// automatic builder, which speaks it only with `hyper-util/http2` on, and
+/// this workspace does not enable it -- so such a connection is refused
+/// before it starts.
+///
+/// Recognised anyway, because of what happens if it ever is enabled, which is
+/// the kind of thing feature unification does without anyone deciding it.
+/// Everything after this preface is binary frames, and HPACK sets the high bit
+/// constantly; read as request lines they are full of bytes this adapter would
+/// percent-encode, so the connections would be quietly corrupted rather than
+/// refused. This costs a comparison of at most one byte per connection -- no
+/// HTTP method but `PRI` shares even a first character with it.
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+
 #[derive(Debug)]
 enum State {
+    /// At the very start of the connection, deciding whether this is HTTP/2.
+    Preface,
     /// At the start of a message, reading the request line.
     RequestLine,
     /// Reading the header block that follows a request line.
@@ -82,7 +100,7 @@ impl<T> LenientStream<T> {
     pub fn new(inner: T) -> Self {
         Self {
             inner,
-            state: State::RequestLine,
+            state: State::Preface,
             out: Vec::new(),
             out_pos: 0,
             line: Vec::new(),
@@ -103,6 +121,29 @@ impl<T> LenientStream<T> {
                 State::PassThrough => {
                     self.out.extend_from_slice(data);
                     return;
+                }
+                State::Preface => {
+                    // Held back rather than emitted, because until enough of
+                    // it has arrived to rule the preface out these bytes might
+                    // not be a request line at all.
+                    let want = H2_PREFACE.len() - self.line.len();
+                    let take = std::cmp::min(want, data.len());
+                    self.line.extend_from_slice(&data[..take]);
+
+                    if !H2_PREFACE.starts_with(&self.line) {
+                        // An ordinary request line, and one byte is usually
+                        // enough to know it. Read it as one, from the start.
+                        self.state = State::RequestLine;
+                        let mut buffered = std::mem::take(&mut self.line);
+                        buffered.extend_from_slice(&data[take..]);
+                        self.process(&buffered);
+                        return;
+                    }
+
+                    data = &data[take..];
+                    if self.line.len() == H2_PREFACE.len() {
+                        self.give_up();
+                    }
                 }
                 State::Body(remaining) => {
                     let take = std::cmp::min(remaining, data.len() as u64) as usize;
@@ -183,7 +224,9 @@ impl<T> LenientStream<T> {
                 self.out.extend_from_slice(&line);
                 self.state = State::Headers { content_length };
             }
-            State::Body(_) | State::PassThrough => unreachable!("not a line state"),
+            State::Preface | State::Body(_) | State::PassThrough => {
+                unreachable!("not a line state")
+            }
         }
     }
 }
@@ -441,5 +484,50 @@ mod tests {
     fn a_malformed_request_line_is_left_for_hyper_to_reject() {
         let raw: &[u8] = b"nonsense\r\n";
         assert_eq!(run(&[raw]), raw.to_vec());
+    }
+
+    /// HPACK sets the high bit constantly, so a frame read as a request line
+    /// is full of bytes this would otherwise percent-encode.
+    #[test]
+    fn an_http2_connection_is_passed_through_untouched() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(H2_PREFACE);
+        // A SETTINGS frame, then header-block bytes with the high bit set and
+        // a `>` and a newline among them, which is what would be mangled.
+        raw.extend_from_slice(b"\x00\x00\x00\x04\x00\x00\x00\x00\x00");
+        raw.extend_from_slice(b"\x82\x86\x84\x41\x8a > \n\xff\xfe HTTP/1.1\r\n");
+        assert_eq!(run(&[&raw]), raw);
+    }
+
+    /// The preface is decided on the bytes as they arrive, not on a whole
+    /// read landing at once.
+    #[test]
+    fn an_http2_preface_split_across_reads_is_still_recognised() {
+        let out = run(&[b"PRI * HTTP/2.0\r\n", b"\r\nSM\r\n\r\n", b"\xff\xfe->\n"]);
+        assert_eq!(
+            out,
+            [H2_PREFACE, b"\xff\xfe->\n"].concat(),
+            "an HTTP/2 connection was rewritten"
+        );
+    }
+
+    /// Holding bytes back to check for the preface must not lose them.
+    #[test]
+    fn a_request_beginning_like_the_preface_is_read_as_http1() {
+        let out = run(&[b"PRI /t?s=a->b HTTP/1.1\r\n\r\n"]);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "PRI /t?s=a-%3Eb HTTP/1.1\r\n\r\n"
+        );
+    }
+
+    /// Including where it is split inside the shared prefix.
+    #[test]
+    fn a_request_beginning_like_the_preface_survives_being_split() {
+        let out = run(&[b"P", b"OST /t?s=a->b HTTP/1.1\r\n", b"\r\n"]);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "POST /t?s=a-%3Eb HTTP/1.1\r\n\r\n"
+        );
     }
 }

--- a/crates/postrust-server/src/lenient_uri.rs
+++ b/crates/postrust-server/src/lenient_uri.rs
@@ -1,0 +1,438 @@
+//! Accepting the request targets PostgREST clients actually send.
+//!
+//! `select=data->>id` is ordinary PostgREST usage: it is what curl puts on the
+//! wire and what the PostgREST documentation shows. Haskell's Warp, which
+//! serves PostgREST, hands those bytes to the application unexamined.
+//!
+//! hyper builds an [`http::Uri`] from the request target, and that rejects
+//! three printable characters -- `"`, `<` and `>` -- along with everything
+//! from `0x80` up. httparse, which reads the request line first, is happy with
+//! all of them. So the request is answered `400` with an empty body before any
+//! routing, handler, or error formatting of ours runs, and there is no point
+//! above the connection where it can be caught.
+//!
+//! This adapter percent-encodes those bytes in the request target, and only
+//! there. The query string is percent-decoded when it is parsed, so nothing
+//! above this sees a difference.
+//!
+//! # Not touching anything else
+//!
+//! A request line appears only at the start of a message, and mistaking body
+//! bytes for one would corrupt the body. So the adapter follows the framing:
+//! it reads each request line, then the header block, and uses `Content-Length`
+//! to know how many body bytes to pass through before another request line can
+//! begin.
+//!
+//! The moment framing becomes something it does not model -- a chunked body, a
+//! header block too large to buffer, a request line it cannot make sense of --
+//! it stops rewriting for the remainder of the connection and copies bytes
+//! through verbatim. That degrades to exactly hyper's own behaviour. It is
+//! never left guessing whether the bytes in hand are a request line.
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+/// Bytes that httparse accepts in a request target but `http::Uri` rejects.
+///
+/// Checked against http 1.4 by parsing a URI containing each byte in turn.
+fn needs_encoding(b: u8) -> bool {
+    matches!(b, b'"' | b'<' | b'>') || b >= 0x80
+}
+
+/// Cap on a buffered request line or header line.
+///
+/// Beyond this the adapter stops rewriting rather than buffering without
+/// bound; hyper applies its own, smaller limits once it sees the bytes.
+const MAX_LINE: usize = 64 * 1024;
+
+#[derive(Debug)]
+enum State {
+    /// At the start of a message, reading the request line.
+    RequestLine,
+    /// Reading the header block that follows a request line.
+    Headers { content_length: u64 },
+    /// Copying a body through; this many bytes still to come.
+    Body(u64),
+    /// Framing is no longer modelled: copy everything, rewrite nothing.
+    PassThrough,
+}
+
+/// A connection whose request targets are normalised as they are read.
+#[derive(Debug)]
+pub struct LenientStream<T> {
+    inner: T,
+    state: State,
+    /// Bytes processed and waiting to be handed to the reader.
+    out: Vec<u8>,
+    out_pos: usize,
+    /// A request or header line still being accumulated.
+    line: Vec<u8>,
+}
+
+impl<T> LenientStream<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            state: State::RequestLine,
+            out: Vec::new(),
+            out_pos: 0,
+            line: Vec::new(),
+        }
+    }
+
+    /// Give up on framing: flush what is buffered and copy through from here.
+    fn give_up(&mut self) {
+        let line = std::mem::take(&mut self.line);
+        self.out.extend_from_slice(&line);
+        self.state = State::PassThrough;
+    }
+
+    /// Feed freshly read bytes through the state machine.
+    fn process(&mut self, mut data: &[u8]) {
+        while !data.is_empty() {
+            match self.state {
+                State::PassThrough => {
+                    self.out.extend_from_slice(data);
+                    return;
+                }
+                State::Body(remaining) => {
+                    let take = std::cmp::min(remaining, data.len() as u64) as usize;
+                    self.out.extend_from_slice(&data[..take]);
+                    data = &data[take..];
+                    let left = remaining - take as u64;
+                    self.state = if left == 0 {
+                        State::RequestLine
+                    } else {
+                        State::Body(left)
+                    };
+                }
+                State::RequestLine | State::Headers { .. } => {
+                    match data.iter().position(|&b| b == b'\n') {
+                        Some(idx) => {
+                            self.line.extend_from_slice(&data[..=idx]);
+                            data = &data[idx + 1..];
+                            self.finish_line();
+                        }
+                        None => {
+                            self.line.extend_from_slice(data);
+                            data = &[];
+                            if self.line.len() > MAX_LINE {
+                                self.give_up();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handle one complete line, newline included.
+    fn finish_line(&mut self) {
+        let line = std::mem::take(&mut self.line);
+
+        match self.state {
+            State::RequestLine => {
+                self.out.extend_from_slice(&normalize_request_line(&line));
+                self.state = State::Headers { content_length: 0 };
+            }
+            State::Headers { content_length } => {
+                let is_blank = matches!(line.as_slice(), b"\r\n" | b"\n");
+                if is_blank {
+                    self.out.extend_from_slice(&line);
+                    self.state = if content_length == 0 {
+                        State::RequestLine
+                    } else {
+                        State::Body(content_length)
+                    };
+                    return;
+                }
+
+                // A chunked body is framed by the body itself, which this does
+                // not read, so where the next message starts is unknown.
+                if header_is(&line, b"transfer-encoding") {
+                    self.out.extend_from_slice(&line);
+                    self.state = State::PassThrough;
+                    return;
+                }
+
+                let content_length = match header_value(&line, b"content-length") {
+                    Some(value) => match std::str::from_utf8(value)
+                        .ok()
+                        .and_then(|v| v.trim().parse::<u64>().ok())
+                    {
+                        Some(len) => len,
+                        // Unparseable framing: stop guessing.
+                        None => {
+                            self.out.extend_from_slice(&line);
+                            self.state = State::PassThrough;
+                            return;
+                        }
+                    },
+                    None => content_length,
+                };
+
+                self.out.extend_from_slice(&line);
+                self.state = State::Headers { content_length };
+            }
+            State::Body(_) | State::PassThrough => unreachable!("not a line state"),
+        }
+    }
+}
+
+/// Whether a header line names the given (lowercase) header.
+fn header_is(line: &[u8], name: &[u8]) -> bool {
+    match line.iter().position(|&b| b == b':') {
+        Some(colon) => line[..colon].eq_ignore_ascii_case(name),
+        None => false,
+    }
+}
+
+/// The value of a header line, if it names the given (lowercase) header.
+fn header_value<'a>(line: &'a [u8], name: &[u8]) -> Option<&'a [u8]> {
+    let colon = line.iter().position(|&b| b == b':')?;
+    line[..colon]
+        .eq_ignore_ascii_case(name)
+        .then(|| &line[colon + 1..])
+}
+
+/// Percent-encode the target of a request line, leaving the rest alone.
+///
+/// A line that is not shaped like `METHOD SP TARGET SP VERSION` is returned
+/// unchanged, for hyper to reject as it sees fit.
+fn normalize_request_line(line: &[u8]) -> Vec<u8> {
+    let end = line.len() - trailing_newline_len(line);
+    let head = &line[..end];
+
+    let (Some(first), Some(last)) = (
+        head.iter().position(|&b| b == b' '),
+        head.iter().rposition(|&b| b == b' '),
+    ) else {
+        return line.to_vec();
+    };
+    if first == last {
+        return line.to_vec();
+    }
+
+    let target = &head[first + 1..last];
+    if !target.iter().copied().any(needs_encoding) {
+        return line.to_vec();
+    }
+
+    let mut out = Vec::with_capacity(line.len() + 16);
+    out.extend_from_slice(&head[..=first]);
+    for &b in target {
+        if needs_encoding(b) {
+            out.extend_from_slice(format!("%{:02X}", b).as_bytes());
+        } else {
+            out.push(b);
+        }
+    }
+    out.extend_from_slice(&head[last..]);
+    out.extend_from_slice(&line[end..]);
+    out
+}
+
+fn trailing_newline_len(line: &[u8]) -> usize {
+    if line.ends_with(b"\r\n") {
+        2
+    } else if line.ends_with(b"\n") {
+        1
+    } else {
+        0
+    }
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for LenientStream<T> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        dst: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let me = self.get_mut();
+
+        loop {
+            if me.out_pos < me.out.len() {
+                let take = std::cmp::min(dst.remaining(), me.out.len() - me.out_pos);
+                dst.put_slice(&me.out[me.out_pos..me.out_pos + take]);
+                me.out_pos += take;
+                if me.out_pos == me.out.len() {
+                    me.out.clear();
+                    me.out_pos = 0;
+                }
+                return Poll::Ready(Ok(()));
+            }
+
+            // Once framing is no longer tracked there is nothing to do but
+            // hand the reader the socket directly.
+            if matches!(me.state, State::PassThrough) && me.line.is_empty() {
+                return Pin::new(&mut me.inner).poll_read(cx, dst);
+            }
+
+            let mut scratch = [0u8; 8192];
+            let mut read = ReadBuf::new(&mut scratch);
+            match Pin::new(&mut me.inner).poll_read(cx, &mut read) {
+                Poll::Ready(Ok(())) => {
+                    let filled = read.filled();
+                    if filled.is_empty() {
+                        // End of stream. Anything half-read is still owed to
+                        // the reader, so it is not dropped silently.
+                        if !me.line.is_empty() {
+                            me.give_up();
+                            continue;
+                        }
+                        return Poll::Ready(Ok(()));
+                    }
+                    let owned = filled.to_vec();
+                    me.process(&owned);
+                }
+                Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for LenientStream<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// A [`TcpListener`](tokio::net::TcpListener) whose connections normalise
+/// request targets.
+pub struct LenientListener(pub tokio::net::TcpListener);
+
+impl axum::serve::Listener for LenientListener {
+    type Io = LenientStream<tokio::net::TcpStream>;
+    type Addr = std::net::SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            match self.0.accept().await {
+                Ok((stream, addr)) => return (LenientStream::new(stream), addr),
+                // Mirrors axum's own listener: a failed accept is transient,
+                // and spinning on it would burn a core.
+                Err(e) => {
+                    tracing::debug!("accept failed: {e}");
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+            }
+        }
+    }
+
+    fn local_addr(&self) -> io::Result<Self::Addr> {
+        self.0.local_addr()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut s = LenientStream::new(tokio::io::empty());
+        for chunk in chunks {
+            s.process(chunk);
+        }
+        s.out
+    }
+
+    #[test]
+    fn encodes_only_what_the_uri_parser_rejects() {
+        let out = run(&[b"GET /t?select=data->>id HTTP/1.1\r\n\r\n"]);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "GET /t?select=data-%3E%3Eid HTTP/1.1\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn encodes_quotes() {
+        let out = run(&[b"GET /t?a=in.(\"x\") HTTP/1.1\r\n\r\n"]);
+        assert!(String::from_utf8(out).unwrap().contains("in.(%22x%22)"));
+    }
+
+    #[test]
+    fn leaves_an_ordinary_request_untouched() {
+        let raw: &[u8] = b"GET /t?a=eq.1 HTTP/1.1\r\nHost: x\r\n\r\n";
+        assert_eq!(run(&[raw]), raw.to_vec());
+    }
+
+    #[test]
+    fn percent_escapes_already_present_are_not_re_encoded() {
+        let raw: &[u8] = b"GET /t?select=data-%3E%3Eid HTTP/1.1\r\n\r\n";
+        assert_eq!(run(&[raw]), raw.to_vec());
+    }
+
+    #[test]
+    fn a_body_is_never_rewritten() {
+        // The body is a request line character for character. It must survive.
+        let body = b"GET /evil?x=a>b HTTP/1.1";
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"POST /t HTTP/1.1\r\nContent-Length: 24\r\n\r\n");
+        raw.extend_from_slice(body);
+        let out = run(&[&raw]);
+        assert_eq!(out, raw, "body bytes were altered");
+    }
+
+    #[test]
+    fn the_request_after_a_body_is_still_rewritten() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"POST /t HTTP/1.1\r\nContent-Length: 2\r\n\r\nhi");
+        raw.extend_from_slice(b"GET /t?s=a->b HTTP/1.1\r\n\r\n");
+        let out = String::from_utf8(run(&[&raw])).unwrap();
+        assert!(out.contains("\r\n\r\nhi"), "body changed: {out}");
+        assert!(
+            out.contains("s=a-%3Eb"),
+            "second request not rewritten: {out}"
+        );
+    }
+
+    #[test]
+    fn a_chunked_body_stops_rewriting_rather_than_guessing() {
+        let mut raw = Vec::new();
+        raw.extend_from_slice(b"POST /t HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n");
+        raw.extend_from_slice(b"2\r\nhi\r\n0\r\n\r\nGET /t?s=a->b HTTP/1.1\r\n\r\n");
+        // Passed through verbatim: not rewritten, but not corrupted either.
+        assert_eq!(run(&[&raw]), raw);
+    }
+
+    #[test]
+    fn a_request_split_across_reads_is_still_rewritten() {
+        let out = run(&[b"GET /t?s=da", b"ta->>id HT", b"TP/1.1\r\n\r\n"]);
+        assert_eq!(
+            String::from_utf8(out).unwrap(),
+            "GET /t?s=data-%3E%3Eid HTTP/1.1\r\n\r\n"
+        );
+    }
+
+    #[test]
+    fn keeps_pipelined_requests_aligned() {
+        let out = String::from_utf8(run(&[
+            b"GET /a?s=x->y HTTP/1.1\r\n\r\nGET /b?s=p->q HTTP/1.1\r\n\r\n",
+        ]))
+        .unwrap();
+        assert!(out.contains("/a?s=x-%3Ey"), "{out}");
+        assert!(out.contains("/b?s=p-%3Eq"), "{out}");
+    }
+
+    #[test]
+    fn a_malformed_request_line_is_left_for_hyper_to_reject() {
+        let raw: &[u8] = b"nonsense\r\n";
+        assert_eq!(run(&[raw]), raw.to_vec());
+    }
+}

--- a/crates/postrust-server/src/lib.rs
+++ b/crates/postrust-server/src/lib.rs
@@ -8,6 +8,7 @@
 //!   Swagger UI, Scalar, and GraphQL Playground at `/admin`.
 
 pub mod app;
+pub mod lenient_uri;
 pub mod state;
 
 #[cfg(feature = "admin-ui")]

--- a/crates/postrust-server/src/lib.rs
+++ b/crates/postrust-server/src/lib.rs
@@ -7,6 +7,14 @@
 //! - `admin-ui` - Enables the admin UI with OpenAPI documentation,
 //!   Swagger UI, Scalar, and GraphQL Playground at `/admin`.
 
+// Every fallible function in this crate returns `postrust_core::Error`, which
+// is a wide enum by design: a PostgREST error carries its code, message,
+// details and hint. Boxing it to satisfy the lint would put an allocation on
+// the error path of every request to save a return slot on the success path.
+// `postrust-core` takes the same position at its own crate root; this was
+// being restated a dozen times a file instead.
+#![allow(clippy::result_large_err)]
+
 pub mod app;
 pub mod lenient_uri;
 pub mod state;

--- a/crates/postrust-server/src/main.rs
+++ b/crates/postrust-server/src/main.rs
@@ -215,21 +215,29 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Add root info endpoint
-    app = app.route(
-        "/",
-        axum::routing::get(|| async {
-            Json(serde_json::json!({
-                "name": "postrust",
-                "version": env!("CARGO_PKG_VERSION"),
-                "api": "/api",
-                "custom": "/_",
-                "health": "/_/health",
-                "admin": "/admin",
-                "docs": "/admin/swagger"
-            }))
-        }),
-    );
+    // Add root info endpoint.
+    //
+    // Not in compatibility mode: there `/` is part of the API surface -- it is
+    // where PostgREST serves the schema description, and where it reports an
+    // `Accept-Profile` naming a schema that is not exposed. A directory of
+    // this server's own endpoints in its place answers a different question
+    // from the one asked.
+    if !config.compat_mode {
+        app = app.route(
+            "/",
+            axum::routing::get(|| async {
+                Json(serde_json::json!({
+                    "name": "postrust",
+                    "version": env!("CARGO_PKG_VERSION"),
+                    "api": "/api",
+                    "custom": "/_",
+                    "health": "/_/health",
+                    "admin": "/admin",
+                    "docs": "/admin/swagger"
+                }))
+            }),
+        );
+    }
 
     // Apply CORS and state
     let app = app

--- a/crates/postrust-server/src/main.rs
+++ b/crates/postrust-server/src/main.rs
@@ -255,7 +255,9 @@ async fn main() -> Result<()> {
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Listening on http://{}", addr);
 
-    axum::serve(listener, app).await?;
+    // Wrapped so that a request target carrying a raw `>` or `"` reaches the
+    // router instead of being refused by the URI parser. See `lenient_uri`.
+    axum::serve(postrust_server::lenient_uri::LenientListener(listener), app).await?;
 
     Ok(())
 }

--- a/crates/postrust-server/src/main.rs
+++ b/crates/postrust-server/src/main.rs
@@ -56,7 +56,12 @@ async fn main() -> Result<()> {
     info!("Connected to database");
 
     // Load schema cache
-    let schema_cache = postrust_core::SchemaCache::load(&pool, &config.db_schemas).await?;
+    let schema_cache = postrust_core::SchemaCache::load_with_search_path(
+        &pool,
+        &config.db_schemas,
+        &config.db_extra_search_path,
+    )
+    .await?;
     info!("{}", schema_cache.summary());
 
     // Create app state

--- a/crates/postrust-server/src/main.rs
+++ b/crates/postrust-server/src/main.rs
@@ -2,6 +2,11 @@
 //!
 //! A PostgREST-compatible REST API server for PostgreSQL.
 
+// This binary compiles `app` and `state` again as modules of its own crate,
+// so the crate-level allow in `lib.rs` does not reach them. See the note
+// there for why the lint is not worth satisfying.
+#![allow(clippy::result_large_err)]
+
 use anyhow::Result;
 use axum::{http::Method, response::Json, routing::any, Router};
 use sqlx::postgres::PgPoolOptions;

--- a/crates/postrust-server/src/main.rs
+++ b/crates/postrust-server/src/main.rs
@@ -261,6 +261,13 @@ async fn main() -> Result<()> {
                 .allow_headers(CorsAny)
                 .expose_headers(CorsAny),
         )
+        // Outermost, so it runs before the CORS layer -- which answers every
+        // OPTIONS itself and never calls what it wraps, so nothing downstream
+        // of it can say what a resource allows.
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            app::options_allow,
+        ))
         .with_state(state);
 
     // Start server

--- a/crates/postrust-server/src/state.rs
+++ b/crates/postrust-server/src/state.rs
@@ -26,7 +26,12 @@ impl AppState {
     /// Reload the schema cache.
     #[allow(dead_code)] // Public API for schema reload; wired up by the (optional) NOTIFY listener.
     pub async fn reload_schema(&self) -> Result<(), postrust_core::Error> {
-        let new_cache = SchemaCache::load(&self.pool, &self.config.db_schemas).await?;
+        let new_cache = SchemaCache::load_with_search_path(
+            &self.pool,
+            &self.config.db_schemas,
+            &self.config.db_extra_search_path,
+        )
+        .await?;
         let mut guard = self.schema_cache.write().await;
         *guard = new_cache;
         Ok(())

--- a/crates/postrust-sql/src/expr.rs
+++ b/crates/postrust-sql/src/expr.rs
@@ -256,6 +256,12 @@ impl Expr {
 #[derive(Clone, Debug)]
 pub struct OrderExpr {
     column: String,
+    /// Whether `column` is already SQL rather than a bare identifier.
+    ///
+    /// A JSON path (`"data" ->> 'id'`) is an expression, so escaping it as one
+    /// identifier would quote the whole thing into a column name that does not
+    /// exist.
+    raw: bool,
     direction: Option<OrderDirection>,
     nulls: Option<NullsOrder>,
 }
@@ -277,6 +283,17 @@ impl OrderExpr {
     pub fn new(column: impl Into<String>) -> Self {
         Self {
             column: column.into(),
+            raw: false,
+            direction: None,
+            nulls: None,
+        }
+    }
+
+    /// Order by an already-rendered SQL expression.
+    pub fn raw(expression: impl Into<String>) -> Self {
+        Self {
+            column: expression.into(),
+            raw: true,
             direction: None,
             nulls: None,
         }
@@ -308,7 +325,11 @@ impl OrderExpr {
 
     /// Convert to SQL fragment.
     pub fn into_fragment(self) -> SqlFragment {
-        let mut frag = SqlFragment::raw(escape_ident(&self.column));
+        let mut frag = SqlFragment::raw(if self.raw {
+            self.column.clone()
+        } else {
+            escape_ident(&self.column)
+        });
 
         if let Some(dir) = self.direction {
             match dir {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,7 +20,7 @@ Complete reference for the Postrust REST and GraphQL APIs.
 | `PUT` | `/{table}` | Upsert row |
 | `DELETE` | `/{table}` | Delete rows |
 | `HEAD` | `/{table}` | Get headers only |
-| `OPTIONS` | `/{table}` | Get table info |
+| `OPTIONS` | `/{table}` | The methods this table allows, in `Allow` |
 
 ### RPC Functions
 
@@ -29,12 +29,48 @@ Complete reference for the Postrust REST and GraphQL APIs.
 | `GET` | `/rpc/{function}` | Call read-only function |
 | `POST` | `/rpc/{function}` | Call any function |
 | `HEAD` | `/rpc/{function}` | Get function headers |
-| `OPTIONS` | `/rpc/{function}` | Get function info |
+| `OPTIONS` | `/rpc/{function}` | The methods this function allows, in `Allow` |
 
 By default, RPC results are array-wrapped and keyed by function name
 (`[{"my_func": ...}]`). In [compatibility mode](configuration.md#compatibility-settings)
 they match PostgREST: a bare object/scalar for non-set-returning functions and a
 top-level array for set-returning ones.
+
+### OPTIONS and Allow
+
+`OPTIONS` reports what a resource actually answers, in the `Allow` header. It
+is derived from the schema rather than fixed, so it is worth reading before
+assuming a `405`.
+
+For a table or view:
+
+- `OPTIONS, GET, HEAD` always.
+- `POST` where the relation is insertable, `PATCH` where it is updatable,
+  `DELETE` where it is deletable.
+- `PUT` only where the relation is both insertable and updatable **and** has a
+  primary key. `PUT` replaces one row named by its key, so a keyless view that
+  is otherwise fully writable offers `POST`, `PATCH` and `DELETE` and not
+  `PUT`.
+
+A view's writability is what PostgreSQL can actually do with it — whether it
+is simple enough to write through automatically, or carries an `INSTEAD OF`
+trigger that says how. Being granted `INSERT` on a view does not make it
+insertable, and Postrust no longer reports it as such.
+
+For a function:
+
+- `OPTIONS, POST` for a `VOLATILE` function, which may change data.
+- `OPTIONS, GET, HEAD, POST` for a `STABLE` or `IMMUTABLE` one. An overloaded
+  name is readable when any of its overloads is.
+
+```bash
+curl -i -X OPTIONS http://localhost:3000/api/users
+# Allow: OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE
+```
+
+This works under `/api` and, in compatibility mode, at the root as well. A
+CORS preflight to either keeps its `Access-Control-*` headers; naming a table
+that does not exist is a `404`, the same answer as asking for the table.
 
 ### GraphQL
 
@@ -190,7 +226,8 @@ GET /users?limit=10&offset=20
 
 ### Range Header
 
-Alternative pagination using HTTP Range header:
+Alternative pagination using the HTTP `Range` header. Rows are counted from
+zero and both bounds are inclusive, so `0-9` is the first ten.
 
 ```bash
 # Rows 0-9 (first 10)
@@ -200,13 +237,36 @@ Range: 0-9
 # Rows 100-149
 GET /users
 Range: 100-149
+
+# Row 100 to the end
+GET /users
+Range: 100-
+
+# The unit may be named, for a client that follows RFC 9110
+GET /users
+Range: items=100-149
 ```
 
-Response includes `Content-Range` header:
+A range whose end precedes its start names no rows, and is refused rather
+than widened into all of them:
 
 ```
-Content-Range: 0-9/100
+HTTP/1.1 416 Range Not Satisfiable
+{"code":"PGRST103","message":"Requested range not satisfiable", ...}
 ```
+
+The response reports the window it actually returned, and `206` rather than
+`200` when that window is a part of the whole:
+
+```
+HTTP/1.1 206 Partial Content
+Content-Range: 100-149/1000
+```
+
+`?limit=` and `?offset=` take precedence over the header where both are
+given, which is also PostgREST's rule. Note that `?offset=0` is an offset:
+it starts at the first row and overrides a `Range` that would have started
+later.
 
 ## Resource Embedding
 
@@ -353,12 +413,23 @@ Accept: application/openapi+json
 
 ## Response Headers
 
-| Header | Description |
-|--------|-------------|
-| `Content-Range` | Pagination info: `0-24/100` |
-| `Range-Unit` | Always `items` |
-| `Content-Location` | URL of created resource |
-| `Preference-Applied` | Applied Prefer values |
+| Header | When | Description |
+|--------|------|-------------|
+| `Content-Range` | Reads, and writes reporting a count | The window returned and the total: `0-24/100`, or `*/100` where no rows were returned |
+| `Range-Unit` | With `Content-Range` | Always `items` |
+| `Location` | `POST` with `Prefer: return=headers-only` | The primary key of the created row, as a query string: `/users?id=eq.42` |
+| `Preference-Applied` | When a `Prefer` was honoured | The preferences actually applied — see the note below |
+| `Allow` | `OPTIONS` | The methods this resource answers; see [OPTIONS and Allow](#options-and-allow) |
+| `WWW-Authenticate` | `401` | `Bearer`, and for a token that was read and refused, `error="invalid_token"` with an `error_description` naming what was wrong with it |
+
+**`Location` is sent only for `Prefer: return=headers-only`.** This matches
+PostgREST: a caller asking for the row back reads the key out of the body, and
+one asking for neither asked for a minimal response and gets one. Earlier
+versions of Postrust sent it on every insert.
+
+**`Preference-Applied` never reports `tx=`.** `Prefer: tx=rollback` is not
+implemented. Reporting it as applied while committing the write was worse than
+not offering it, so it is no longer named in the response.
 
 ## HTTP Status Codes
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -59,6 +59,29 @@ PGRST_DB_ANON_ROLE="web_anon"
 | `aud` | Audience | Optional |
 | `sub` | Subject (user ID) | Optional |
 
+#### How the claims are checked
+
+A claim that is absent is not a claim that is wrong. A token carrying no `exp`
+does not expire; one carrying no `aud` is for anybody. Only a claim that is
+*present and not the kind of thing that claim is* is rejected — `"exp":
+"soon"` is a malformed token, and so is an `aud` that is neither a string nor
+a list of them.
+
+**`exp` is checked to the second.** `nbf` and `iat` are given thirty seconds
+of slack. The asymmetry is deliberate: `nbf` and `iat` describe a token that
+is not valid *yet*, and a client whose clock runs slightly fast mints one
+through nobody's fault, so refusing it makes a working deployment fail
+intermittently. Forgiving an `exp` is a different thing — it keeps a session
+alive past the second its issuer said it ended.
+
+**A role claim must be a string.** `"role": 42` or `"role": {"a": 1}` names no
+role; it falls back to `PGRST_DB_ANON_ROLE` exactly as an absent claim does,
+rather than asking PostgreSQL for a role of that spelling.
+
+Faults are reported in a fixed order, so a token that is both expired and out
+of audience is reported as expired — the first thing wrong with it, and the
+one the client can act on.
+
 ### Custom Claims
 
 Add any custom claims for use in RLS policies:
@@ -287,35 +310,66 @@ $$;
 
 ## Error Handling
 
-### Missing Token
+A `401` also carries a `WWW-Authenticate` challenge. Where no token was
+offered it is a plain `Bearer`; where a token was read and refused it names
+which refusal, so a client can tell "rotate your key" from "fix your clock"
+without parsing the body:
 
-```json
-{
-  "code": "PGRST301",
-  "message": "JWT token required"
-}
 ```
-HTTP Status: 401
+WWW-Authenticate: Bearer error="invalid_token", error_description="JWT expired"
+```
 
-### Invalid Token
+### No identity — `PGRST302`
+
+Nothing said who is asking, and there is no `PGRST_DB_ANON_ROLE` to be.
 
 ```json
 {
   "code": "PGRST302",
-  "message": "Invalid JWT token"
+  "message": "Anonymous access is disabled"
 }
 ```
 HTTP Status: 401
 
-### Expired Token
+### The token could not be read — `PGRST301`
+
+The signature did not verify, the key was wrong, or the `Authorization`
+header was not a bearer token.
+
+```json
+{
+  "code": "PGRST301",
+  "message": "JWT cryptographic operation failed"
+}
+```
+HTTP Status: 401
+
+### The token was read and refused — `PGRST303`
+
+The signature verified and the claims were not acceptable. The message names
+which claim: `JWT expired`, `JWT not yet valid`, `JWT issued at future`,
+`JWT not in audience`, `The JWT 'exp' claim must be a number`, or `The JWT
+'aud' claim must be a string or an array of strings`.
 
 ```json
 {
   "code": "PGRST303",
-  "message": "JWT token has expired"
+  "message": "JWT expired"
 }
 ```
 HTTP Status: 401
+
+### No JWT secret configured — `PGRST300`
+
+A token was offered and the server has nothing to verify it with.
+
+```json
+{
+  "code": "PGRST300",
+  "message": "Server lacks JWT secret"
+}
+```
+HTTP Status: 500
 
 ### Insufficient Permissions
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -103,6 +103,10 @@ PGRST_SERVER_CORS_ORIGINS="*"
 
 ## Compatibility Settings
 
+How closely Postrust matches PostgREST is measured against PostgREST itself;
+see [PostgREST conformance](postgrest-conformance.md) for what is covered and
+where the two differ deliberately.
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PGRST_COMPAT_MODE` | PostgREST compatibility mode (alias: `POSTRUST_COMPAT_MODE`) | `false` |

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ Welcome to the Postrust documentation. Postrust is a high-performance, serverles
 - [SaaS Domain Management](./saas-domains.md) - Multi-tenant custom domains with automatic SSL (Beta)
 - [Deployment](./deployment.md) - Deploy to various platforms
 - [Benchmarking](./benchmarking.md) - Measured size, latency and memory, and how to reproduce them
+- [PostgREST Conformance](./postgrest-conformance.md) - How closely the two agree, measured against PostgREST itself
 
 ## What is Postrust?
 

--- a/docs/postgrest-conformance.md
+++ b/docs/postgrest-conformance.md
@@ -8,19 +8,20 @@ servers disagree on purpose.
 
 ## Where it stands
 
-Run 9, over 1499 replayed cases, against PostgREST v16.1:
+Run 10, over 1499 replayed cases, against PostgREST v16.1:
 
 | Compared on | All (1499) | Reads (1068) | Writes (431) |
 |---|---|---|---|
-| Status code | 98.2% | 97.8% | 99.1% |
-| Status and body | 96.1% | 95.6% | 97.2% |
-| …and headers, except `Content-Range` | 94.5% | 93.9% | 96.1% |
-| Full contract | **94.3%** | 93.8% | 95.4% |
+| Status code | 98.6% | 98.5% | 98.8% |
+| Status and body | 96.7% | 96.3% | 97.9% |
+| …and headers, except `Content-Range` | 95.2% | 94.6% | 96.8% |
+| Full contract | **94.9%** | 94.5% | 96.1% |
 
-Both halves completed with zero transport failures, on a binary the harness
-built itself and then verified at runtime. See
-[`FINDINGS.md`](../scripts/conformance/FINDINGS.md) for the run history,
-including the two runs whose numbers are not publishable and why.
+Measured on a binary the harness built itself and then verified at runtime.
+One case got no response at all — a socket fault that has not reproduced in
+440 attempts — and is counted as a failure, so the true figures are at or
+above these. See [`FINDINGS.md`](../scripts/conformance/FINDINGS.md) for the
+run history, including the runs whose numbers are not publishable and why.
 
 ## How it is measured
 

--- a/docs/postgrest-conformance.md
+++ b/docs/postgrest-conformance.md
@@ -1,0 +1,121 @@
+# PostgREST conformance
+
+Postrust follows PostgREST's URL grammar deliberately: `?select=`, `?order=`,
+the filter operators and the `Prefer` headers mean the same thing in both. How
+closely is not a matter of opinion here — it is measured, against PostgREST
+itself, and this page says what the measurement covers and where the two
+servers disagree on purpose.
+
+## Where it stands
+
+Run 9, over 1499 replayed cases, against PostgREST v16.1:
+
+| Compared on | All (1499) | Reads (1068) | Writes (431) |
+|---|---|---|---|
+| Status code | 98.2% | 97.8% | 99.1% |
+| Status and body | 96.1% | 95.6% | 97.2% |
+| …and headers, except `Content-Range` | 94.5% | 93.9% | 96.1% |
+| Full contract | **94.3%** | 93.8% | 95.4% |
+
+Both halves completed with zero transport failures, on a binary the harness
+built itself and then verified at runtime. See
+[`FINDINGS.md`](../scripts/conformance/FINDINGS.md) for the run history,
+including the two runs whose numbers are not publishable and why.
+
+## How it is measured
+
+PostgREST's own spec suite cannot be pointed at another server: it drives the
+WAI application in-process and imports `PostgREST.Config` directly, so there is
+no HTTP boundary to intercept. Two parts of it are reusable — the fixture
+database (~280 tables of plain SQL) and the request literals inside the
+examples, each of which spells out a method, path, headers and body.
+
+So the harness lifts those requests out of the Haskell and replays them over
+HTTP against **both** stock PostgREST and Postrust, each on an identically
+loaded fixture database, and diffs the live responses.
+
+The reference implementation is the oracle. No hspec expectation is ever
+interpreted, which means a mistake in the extractor shows up as a case both
+servers answer the same way rather than as a false failure.
+
+```bash
+scripts/conformance/conformance.sh
+```
+
+Takes about ten minutes per server, most of it restoring fixture data between
+mutating cases. See [`scripts/conformance/README.md`](../scripts/conformance/README.md)
+for the mechanics.
+
+## What "conformance" counts
+
+Agreement is reported at four strictness levels, because one systemic gap — a
+single header never emitted — would otherwise sink every case and hide the
+hundreds that differ in nothing else.
+
+The strictest is **status, body, and six headers**: `Content-Type`,
+`Content-Range`, `Location`, `Preference-Applied`, `Allow`, and
+`WWW-Authenticate`. Those are part of the answer. `Date`, `Server` and
+`Connection` differ between any two servers and say nothing about conformance,
+so they are not compared.
+
+Bodies are compared as parsed JSON, so whitespace and formatting do not count
+against either server — but **object key order does not survive parsing**, and
+a CSV response puts its columns in key order. See
+[key ordering](configuration.md#compatibility-settings).
+
+**The figures are for the compatibility build**, which is the configuration
+the harness runs in every respect: `PGRST_COMPAT_MODE=true`, PostgREST's paths,
+verbatim database errors, and `--features admin-ui,compat-key-order`. A
+default-mode deployment is not what is measured.
+
+## Where the two disagree on purpose
+
+Some cases fail because PostgREST is wrong, or because neither answer is wrong.
+They are listed here so that nobody later "fixes" one without deciding to.
+[`FINDINGS.md`](../scripts/conformance/FINDINGS.md) carries the evidence.
+
+**PostgREST truncates a select at a stray `)`.** Probed against the reference
+directly, `/clients?select=id)ZZ,nameQQ` returns 200 and `nameQQ` never becomes
+a column. Everything after the paren is discarded silently. Postrust rejects
+it, because matching this means reintroducing a bug that was fixed on purpose —
+`select=id, name, billing(address)` used to return the id alone.
+
+**Two upsert status codes.** `POST` with an empty body and a `PUT` that
+replaced an existing row return `201` where PostgREST returns `200`. The
+evidence is one case each, against 58 that pass.
+
+**Unspecified row order.** Two cases return the same rows in a different order,
+and neither request specifies `order=`. SQL guarantees nothing there, so both
+answers are correct and the measurement is over-reporting.
+
+**Clock skew on `nbf` and `iat`, and none on `exp`.** PostgREST checks all
+three to the second. Postrust allows thirty seconds on the two that describe a
+token not yet valid, and none on the one that describes a token withdrawn. See
+[Authentication](authentication.md#how-the-claims-are-checked).
+
+## Known gaps
+
+**The OpenAPI document at `/`.** PostgREST serves a 638 KB Swagger 2.0
+document there — 428 paths, 273 definitions, 1035 parameters. Postrust serves
+OpenAPI 3.0 for its own surface under `/admin` (behind the `admin-ui` feature)
+and does not yet generate PostgREST's. Bodies compare as exact JSON, so this is
+all-or-nothing rather than something to land incrementally.
+
+**Parser error detail.** `?or=()` and some JSON-path failures answer generically
+where PostgREST names the offending character and what would have been
+accepted. The logic tree matches exactly; the select parser does not yet.
+
+**Not every config knob.** `Prefer: tx=rollback` in particular is not
+implemented, and is no longer reported as applied.
+
+## Reading a failing case
+
+`scripts/conformance/.work/diff.json` carries per-case detail for every
+divergence: the request, both statuses, both bodies, and which headers differ.
+
+Before treating one as a bug, read
+[`FINDINGS.md`](../scripts/conformance/FINDINGS.md). It records the faults
+found in the harness itself, which matter more than the score — a harness fault
+either invents work or hides it, and the ones that hide it are indistinguishable
+from success. Several have been found so far, including one that had an entire
+category reporting success while measuring nothing.

--- a/scripts/conformance/FINDINGS.md
+++ b/scripts/conformance/FINDINGS.md
@@ -33,6 +33,14 @@ differ between any two servers and say nothing about conformance.
 | 12  | 90.3% | 83.0% | before the harness configuration was corrected |
 | 13  | —     | —     | reference only; candidate half cut short (see below) |
 | 14  | 96.0% | 87.1% | committed binary, corrected reference |
+| 4   | 95.9% | 93.1% | **not publishable** — measured without `compat-key-order` |
+| 8   | —     | —     | died at `writes 300/431`; the machine had filled its disk |
+| 9   | 96.1% | 94.3% | clean: both halves complete, 0 transport failures, features verified at runtime |
+
+Run 9 by group: reads 95.6% / 93.8%, writes 97.2% / 95.4%. It is the first run
+whose provenance is recorded rather than remembered — see below. Its reference
+was re-recorded rather than reused, because `run.py`'s `encode_path` had
+changed and a reference records the answers to requests as they were sent.
 
 Run 14 confirmed the three specs `0d8ef2f` claimed: CustomMedia 19/50 → 50/50,
 PostGIS 1/13 → 13/13, Plan 4/29 → 29/29, ExtraSearchPath 8/9 → 9/9.
@@ -116,6 +124,14 @@ the wire; that needs a client that writes its own request line.
 can only move every percentage up. It counts and names them now. The two halves
 replay the same file, so the count should always be zero — which is the point:
 a silent zero and a silent skip look identical until one of them isn't.
+
+**A run did not record what it had measured.** Run 4's figures were quoted for
+weeks before anyone could say which features its binary carried, and the answer
+turned out to be "not the ones that matter". The harness now writes
+`run-meta.json` beside `diff.json` — reference version, build features, commit,
+date — and `scripts/gen-conformance.mjs` refuses to publish a run without it,
+or one whose features do not include `compat-key-order`. A number that cannot
+say what produced it is not a measurement.
 
 **Non-compatibility mode is not measured at all.** The harness runs
 `PGRST_COMPAT_MODE=true`, where the REST surface answers at the root. In the

--- a/scripts/conformance/FINDINGS.md
+++ b/scripts/conformance/FINDINGS.md
@@ -36,11 +36,29 @@ differ between any two servers and say nothing about conformance.
 | 4   | 95.9% | 93.1% | **not publishable** — measured without `compat-key-order` |
 | 8   | —     | —     | died at `writes 300/431`; the machine had filled its disk |
 | 9   | 96.1% | 94.3% | clean: both halves complete, 0 transport failures, features verified at runtime |
+| 10  | 96.7% | 94.9% | computed relationships; 1 unanswered request, counted against us |
+
+Run 10 by group: reads 96.3% / 94.5%, writes 97.9% / 96.1%. It reused run 9's
+reference, which is what `CONFORMANCE_REUSE_REF=1` is for: nothing that shapes
+a request had changed, only the candidate. Run 9's own reference had to be
+re-recorded, because `run.py`'s `encode_path` had changed and a reference
+records the answers to requests *as they were sent*.
 
 Run 9 by group: reads 95.6% / 93.8%, writes 97.2% / 95.4%. It is the first run
-whose provenance is recorded rather than remembered — see below. Its reference
-was re-recorded rather than reused, because `run.py`'s `encode_path` had
-changed and a reference records the answers to requests as they were sent.
+whose provenance was recorded rather than remembered — see below; run 10 is
+the first where the harness wrote that record itself.
+
+**One request in run 10 got no answer at all.** `Query/InsertSpec.hs:604`, a
+`POST` carrying multibyte UTF-8, failed with `BadStatusLine` naming its own
+request line back — the signature of a socket carrying somebody else's
+leftovers. It did not reproduce in 440 attempts of the identical request, the
+server logged no error, and the code path is untouched by anything in that
+run; 400 requests leave 440 sockets in `TIME_WAIT` on this host, which is how
+a reused ephemeral port becomes possible over 1499 of them. Treated as
+environmental, and counted as a failure regardless, so the figures understate
+by one case. `report.py` now names such a case rather than letting it dissolve
+into the totals: a flaky socket must not read as a conformance gap, and a real
+one must not read as a flaky socket.
 
 Run 14 confirmed the three specs `0d8ef2f` claimed: CustomMedia 19/50 → 50/50,
 PostGIS 1/13 → 13/13, Plan 4/29 → 29/29, ExtraSearchPath 8/9 → 9/9.

--- a/scripts/conformance/FINDINGS.md
+++ b/scripts/conformance/FINDINGS.md
@@ -79,6 +79,20 @@ runs both has to leave room for both. Recorded because the failure mode is
 silent until it is total — the first symptom was an unrelated-looking test
 failure.
 
+**`cargo test --workspace` silently strips the candidate's features.** It
+rebuilds the same `target/release/postrust` with default features and
+overwrites it, so *build, then test, then measure* measured a binary with
+neither `admin-ui` nor `compat-key-order`. Nothing said so. The only visible
+sign was the file shrinking by 1.1 MB:
+
+    built with features                    5,717,136
+    after cargo test --release --workspace 4,559,968
+
+This is the same class as the `db-extra-search-path` fault: the instrument
+quietly measuring something other than what it claims. The harness now builds
+the binary itself rather than requiring one to exist, and asserts against the
+server's own startup warning once it is up, so neither half can drift again.
+
 ## Part 2 — divergences kept on purpose
 
 **These cases fail by choice. Do not "fix" them without deciding to.**
@@ -123,19 +137,13 @@ under-performing.*
 
 ## Part 3 — known gaps, in the order worth doing them
 
-Real work, not corrections. Roughly 19 cases across five pieces.
-
-| # | gap | cases | needs | risk if left |
-|---|-----|-------|-------|--------------|
-| 1 | Ordering across an embed boundary | ~4 | resolve identifiers at the right nesting level | **silently wrong answers** |
-| 2 | Composite-key junctions | 4–5 | widen the embed path to tuple keys | missing embeds, loud |
-| 3 | Junctions through views | ~2 | derive junctions from views, not just tables | missing embeds, loud |
-| 4 | Parser error detail | ~3 | expectation sets in the query parser | poor diagnostics |
-| 5 | The OpenAPI document at `/` | 6 | a PostgREST-shaped generator | endpoint absent |
-
-Ordered by consequence rather than size: item 1 is first because it is the only
-one that answers wrongly instead of refusing, and item 5 is last because it is
-the only one that is a project rather than a change.
+| # | gap | cases | state |
+|---|-----|-------|-------|
+| 1 | Ordering across an embed boundary | ~4 | **done** |
+| 2 | Composite-key junctions | 4–5 | **done** |
+| 3 | Junctions through views | ~2 | **done** |
+| 4 | Parser error detail | ~3 | **done** for the logic tree; the select parser still answers generically |
+| 5 | The OpenAPI document at `/` | 6 | open — see below |
 
 ### 1. Ordering and filtering across an embed boundary — ~4 cases
 
@@ -220,20 +228,43 @@ for the three cases.
 
 ### 5. The OpenAPI document at `/` — 6 cases
 
-638 KB, 428 paths, 273 definitions, generated from every table, view, column
-and function in the schema, with `info` taken from the schema comment. Every
-column becomes a `rowFilter.<table>.<column>` parameter; every relation becomes
-a definition.
+Still open, and the only item here that is a project rather than a change.
+What the reference actually serves, measured:
 
-Bodies are compared as exact JSON, so a 95%-correct generator scores **zero on
-all six cases**. There is no partial credit to collect, and no way to land it
-incrementally against this measurement — which is the argument for treating it
-as a project with its own tests rather than as conformance work.
+    638 KB      428 paths      273 definitions      1035 parameters
 
-Note the admin surface already generates OpenAPI 3.0 via `utoipa`
-(`postrust-server/src/admin.rs`), which describes the admin endpoints and is
-not a starting point for this: PostgREST emits Swagger 2.0 describing the data
-API.
+The shape is regular, which is the argument for doing it and also the reason
+it cannot be done by halves:
+
+- **paths** — `/`, one per table and view with a method per operation the
+  relation supports, one per function under `/rpc/`;
+- **parameters** — 11 shared (`select`, `order`, `range`, `limit`,
+  `preferCount`, …), one `rowFilter.<table>.<column>` for every column of
+  every relation, one `body.<table>` for every writable one;
+- **definitions** — one per relation, a property per column.
+
+The detail is where the work is. A column carries PostgREST's own conventions,
+not just its type:
+
+    "id": {
+      "description": "Note:\nThis is a Primary Key.<pk/>",
+      "format": "int64",
+      "type": "integer"
+    }
+
+so matching means reproducing its type-to-(type, format) mapping, its
+`<pk/>`/`<fk/>` annotations, how a column comment is folded into the
+description, which columns count as `required`, and the same again for every
+function signature.
+
+**Bodies are compared as exact JSON, so a 95%-correct generator scores zero on
+all six cases.** There is no partial credit to collect and no way to land it
+incrementally against this measurement — which is why it belongs in its own
+change, with its own tests, rather than being started here and left half-built.
+
+The admin surface already emits OpenAPI 3.0 through `utoipa`
+(`postrust-server/src/admin.rs`). It is not a starting point: it describes the
+admin endpoints, and PostgREST emits Swagger 2.0 describing the data API.
 
 ## Part 4 — a note on where bugs hide
 

--- a/scripts/conformance/FINDINGS.md
+++ b/scripts/conformance/FINDINGS.md
@@ -1,0 +1,255 @@
+# What the conformance harness has found
+
+Running notes on the differential runs against PostgREST v16.1. See
+[README.md](README.md) for what the harness is and how to run it.
+
+Three things are recorded here that the commit history does not hold:
+
+- **faults in the instrument itself**, which matter more than the score —
+  a harness fault either invents work or hides it, and the ones that hide it
+  are indistinguishable from success;
+- **divergences kept on purpose**, so that nobody later "fixes" a case that is
+  failing because PostgREST is wrong;
+- **known gaps**, with the reason each is a piece of work rather than a
+  correction.
+
+> **Provenance.** Part of an earlier revision of this file was lost when the
+> machine filled its disk (fault 10). Instrument faults 1–8 are not fully
+> recovered; the two that were inflating the score are restated below because
+> they change how the number reads. Everything from run 14 onward is first-hand.
+> The per-fix narrative lives in the commit messages, which is the more durable
+> place for it.
+
+## Results
+
+Measured over 1499 replayed cases. "Strict" is the full contract: status, body,
+and every header including `Content-Range`.
+
+| run | status + body | strict | note |
+|-----|---------------|--------|------|
+| 12  | 90.3% | 83.0% | before the harness configuration was corrected |
+| 13  | —     | —     | reference only; candidate half cut short (see below) |
+| 14  | 96.0% | 87.1% | committed binary, corrected reference |
+
+Run 14 confirmed the three specs `0d8ef2f` claimed: CustomMedia 19/50 → 50/50,
+PostGIS 1/13 → 13/13, Plan 4/29 → 29/29, ExtraSearchPath 8/9 → 9/9.
+
+**Run 13 was stopped once its reference was written.** The reference is the
+expensive half and the only half that had changed; its candidate half would
+have measured a binary the probe runs had already characterised. Set
+`CONFORMANCE_REUSE_REF=1` to replay a candidate against a recorded reference —
+the reference only changes when PostgREST's version, the fixtures, or the
+harness configuration change.
+
+## Part 1 — faults in the instrument
+
+**`db-extra-search-path` was never set.** Both servers answered `42883`,
+function does not exist, to every request touching PostGIS or `isn`. They
+agreed perfectly and agreement scored as a pass, so an entire category was
+reporting success while measuring nothing. Fixed in `0d8ef2f`.
+
+**Header literals kept their Haskell escapes**, so eight cases were replayed
+with a header the spec never wrote, and eight results described a request
+nobody had made. Also `0d8ef2f`.
+
+**The harness built without `compat-key-order`.** PostgREST returns object keys
+in select order; `serde_json::Map` is a `BTreeMap` unless `preserve_order` is
+on, so this server returns them alphabetically. The workspace already had the
+feature, and the server already logged a warning when compatibility mode was
+enabled without it — so it was announcing a known incompatibility to anyone
+reading its logs while the instrument measured the incompatible build. It is
+invisible in JSON, because bodies are compared as parsed JSON and key order
+does not survive parsing. A CSV response puts its columns in key order, and
+there it is the whole answer.
+
+> **The conformance number is for the compatibility build.** That is the
+> configuration the harness runs in every other respect too:
+> `PGRST_COMPAT_MODE=true`, PostgREST's paths, verbatim database errors.
+
+**The machine ran out of disk mid-session.** `cargo test --workspace` failed
+with `ENOSPC`, and then so did every subsequent command — including `df`,
+because each command's output is written to a file before being read. A full
+disk takes the tools away at the same moment it takes the build away. Docker
+died with it. `target/debug` was 1.2 GB and had no reason to exist during a
+release-binary session.
+
+The lesson is scheduling, not cleanup: this project's builds are large, the
+harness keeps a fixture database and two containers alive, and a session that
+runs both has to leave room for both. Recorded because the failure mode is
+silent until it is total — the first symptom was an unrelated-looking test
+failure.
+
+## Part 2 — divergences kept on purpose
+
+**These cases fail by choice. Do not "fix" them without deciding to.**
+
+### PostgREST truncates a select at a stray `)`
+
+Probed against the reference directly:
+
+```
+/clients?select=id)ZZ,nameQQ   ->  200, and nameQQ never becomes a column
+/clients?select=name)))        ->  200
+/clients?select=name,,,        ->  400
+```
+
+Everything after the `)` is discarded silently. That is exactly the behaviour
+commit `f7c7b56` ("stop silently discarding half of a select") removed from
+this server, where `select=id, name, billing(address)` had been returning the
+id alone. Matching it means reintroducing a bug that was fixed on purpose.
+
+*Cost: 2 cases* (`AggregateFunctionsSpec.hs:34`, `SpreadQueriesSpec.hs:391`).
+
+### Upsert status codes
+
+`POST /articles` with an empty body returns 201 where PostgREST returns 200,
+and a `PUT` that replaced an existing row returns 201 where PostgREST returns
+200. The evidence is one case each; `mutation_status` carries comments
+recording earlier deliberation about exactly these lines; and UpsertSpec passes
+58/60. Changing the rule on this evidence risks the 58 to win the 2.
+
+*Cost: 2 cases.*
+
+### Unspecified row order
+
+`RelatedQueriesSpec.hs:183` and `:191` return the same two rows in the opposite
+order from PostgREST. Neither request specifies `order=`, so SQL guarantees
+nothing and both answers are correct. It shows as a failure only because bodies
+are compared exactly. Matching it would mean inventing an ordering PostgREST
+does not promise.
+
+*Cost: 2 cases. The harness is over-reporting here, not the server
+under-performing.*
+
+## Part 3 — known gaps, in the order worth doing them
+
+Real work, not corrections. Roughly 19 cases across five pieces.
+
+| # | gap | cases | needs | risk if left |
+|---|-----|-------|-------|--------------|
+| 1 | Ordering across an embed boundary | ~4 | resolve identifiers at the right nesting level | **silently wrong answers** |
+| 2 | Composite-key junctions | 4–5 | widen the embed path to tuple keys | missing embeds, loud |
+| 3 | Junctions through views | ~2 | derive junctions from views, not just tables | missing embeds, loud |
+| 4 | Parser error detail | ~3 | expectation sets in the query parser | poor diagnostics |
+| 5 | The OpenAPI document at `/` | 6 | a PostgREST-shaped generator | endpoint absent |
+
+Ordered by consequence rather than size: item 1 is first because it is the only
+one that answers wrongly instead of refusing, and item 5 is last because it is
+the only one that is a project rather than a change.
+
+### 1. Ordering and filtering across an embed boundary — ~4 cases
+
+Four failures, one shape: an identifier resolved at the wrong nesting level.
+
+- Ordering an embed by a column of *its* embed — `tasks.order=projects(id).desc`
+  returns the wrong row. **This is the one to fix first:** status 200, a
+  well-formed body, and a different row than asked for. Nothing signals it.
+- Ordering a spread by a column from a *deeper* spread —
+  `...processes(name,...process_costs(cost))&processes.order=process_costs(cost)`
+  → `column "cost" does not exist`. Single-level spread ordering works
+  (`SpreadQueriesSpec` `:302` and `:563` pass), so it is specifically the extra
+  level.
+- A two-level filter path — `child_entities.grandchild_entities=not.is.null`
+  → `PGRST204 Column not found`, when the last segment names an embedded
+  resource being existence-tested rather than a column. The one-level form
+  works.
+
+### 2. Composite-key junctions — 4–5 cases
+
+Every failing many-to-many junction has composite foreign keys: `touched_files`
+joins `files(project_id, filename)` to `users_tasks(user_id, task_id)`, and
+`car_models_car_dealers` joins two two-column keys. PostgREST embeds through
+both.
+
+The derivation was written and then **reverted deliberately**. `EmbedPlan`
+carries one `local_column` and one `foreign_column`, `EmbedJunction` one column
+per side, and `parent_keys` matches children to parents on a single scalar.
+Deriving the relationship without widening all of that joins a composite
+junction on the first column of each key and returns rows that are **wrong
+rather than absent** — and much harder to notice than the error it replaces.
+
+The reasoning is recorded in place at `add_junction_relationships`, and the
+column plumbing there is already generalised behind a `len() == 1` gate, so the
+remaining work is the embed layer:
+
+1. `EmbedPlan::{local_column, foreign_column}` → column lists
+2. `EmbedJunction::{parent_column, child_column}` → column lists
+3. the three correlated-subquery join sites in `embed.rs` (mechanical: AND the
+   conditions)
+4. `parent_keys` / `key_to_text` → tuple keys, for the batched path that matches
+   children to parents in Rust
+5. the same fields in `postrust-graphql`'s handler
+
+This comes before item 3: a view used as a junction over a composite key needs
+the widened path anyway.
+
+Note the same single-column assumption sits on the ordinary foreign-key embed
+path (`columns.first()` in `EmbedPlan::resolve`). That is latent rather than
+observed: no failing case pins it, but a composite-key embed is joining on one
+column today.
+
+### 3. Junctions through views — ~2 cases
+
+`sites` embeds `big_projects` through `jobs` and also through `main_jobs`, a
+view over it. We derive the first and not the second, so a hinted
+`big_projects!main_jobs` finds no relationship, and the ambiguity list
+`PGRST201` returns is short by one candidate.
+
+`substitute_hidden_junctions` already routes a many-to-many through the exposed
+view of a hidden junction; this is the other direction — a view that is *itself*
+usable as a junction alongside the table it selects from.
+
+### 4. Parser error detail — ~3 cases
+
+`?or=()` and some JSON-path failures answer
+`{"message":"Invalid request","details":null}` where PostgREST names the
+character and what would have been accepted:
+
+```
+"failed to parse logic tree (())" (line 1, column 4)
+unexpected ")" expecting field name (* or [a..z0..9_$]), negation operator (not)
+  or logic operator (and, or)
+```
+
+The machinery exists — `Error::UnparsableQuery`, built by `a5b6c94` for filters
+and used again for `?columns=`. What is left is carrying expectation sets
+through the select and logic-tree parsers so the message can be assembled.
+Matching PostgREST exactly means reproducing its parser combinator's
+expectation sets, which is why this is worth doing for its own sake rather than
+for the three cases.
+
+### 5. The OpenAPI document at `/` — 6 cases
+
+638 KB, 428 paths, 273 definitions, generated from every table, view, column
+and function in the schema, with `info` taken from the schema comment. Every
+column becomes a `rowFilter.<table>.<column>` parameter; every relation becomes
+a definition.
+
+Bodies are compared as exact JSON, so a 95%-correct generator scores **zero on
+all six cases**. There is no partial credit to collect, and no way to land it
+incrementally against this measurement — which is the argument for treating it
+as a project with its own tests rather than as conformance work.
+
+Note the admin surface already generates OpenAPI 3.0 via `utoipa`
+(`postrust-server/src/admin.rs`), which describes the admin endpoints and is
+not a starting point for this: PostgREST emits Swagger 2.0 describing the data
+API.
+
+## Part 4 — a note on where bugs hide
+
+Two patterns recurred often enough to be worth naming.
+
+**A permissive fallback turns a syntax error into a plausible success.**
+`?columns=` produced a column named `""` because `"".split(',')` yields one
+empty piece rather than none, and that name travelled to the schema cache and
+came back as "Could not find the '' column" — describing a schema problem when
+the URL named no field. `data->>--34` became a key literally named `--34` and
+answered 200 with nulls. Neither failed loudly.
+
+**A fix can be silently absorbed by the grammar it is fixing.** Rejecting
+`--34` with a recoverable nom `Error` did nothing visible: `alt` backtracked
+from `->>` to `->`, and the rest was re-read as a key beginning with `>` —
+still 200, now under a different name. It took `Err::Failure` to stop it, which
+is also the semantically correct signal: once `->>` is consumed, no other rule
+should get to reinterpret it. The test asserting `is_err()` mattered more than
+the code change did.

--- a/scripts/conformance/FINDINGS.md
+++ b/scripts/conformance/FINDINGS.md
@@ -23,7 +23,10 @@ Three things are recorded here that the commit history does not hold:
 ## Results
 
 Measured over 1499 replayed cases. "Strict" is the full contract: status, body,
-and every header including `Content-Range`.
+and the six headers that are part of the answer rather than of the transport —
+`Content-Type`, `Content-Range`, `Location`, `Preference-Applied`, `Allow`,
+`WWW-Authenticate`. Not *every* header: `Date`, `Server` and `Connection`
+differ between any two servers and say nothing about conformance.
 
 | run | status + body | strict | note |
 |-----|---------------|--------|------|
@@ -93,6 +96,35 @@ quietly measuring something other than what it claims. The harness now builds
 the binary itself rather than requiring one to exist, and asserts against the
 server's own startup warning once it is up, so neither half can drift again.
 
+**The replay client dropped everything after a `#`.** `run.py` builds requests
+with `urllib.request.Request`, which reads `#` as beginning a fragment and
+strips it and the rest of the URL:
+
+    Request('http://h/items?select=data->!@#$%^&*_d').full_url
+    -> 'http://h/items?select=data->!@'
+
+A fragment is a client-side notion that never appears in a request target, so
+in a PostgREST query the character is a literal — and `lenient_uri.rs` carries
+a paragraph about handling exactly that. It was never exercised. Both servers
+received the truncated URL, agreed, and the case scored as a pass on a request
+neither spec wrote. `encode_path` now sends `%23`, which both servers decode
+back to `#` at the parser. What that still does not exercise is a *raw* `#` on
+the wire; that needs a client that writes its own request line.
+
+**A case the candidate never answered was dropped from the denominator.**
+`report.py` skipped any reference case with no matching candidate record, which
+can only move every percentage up. It counts and names them now. The two halves
+replay the same file, so the count should always be zero — which is the point:
+a silent zero and a silent skip look identical until one of them isn't.
+
+**Non-compatibility mode is not measured at all.** The harness runs
+`PGRST_COMPAT_MODE=true`, where the REST surface answers at the root. In the
+default mode it is mounted under `/api`, and a bug that only shows there is
+invisible here however green the report is — as one was: every `OPTIONS`
+preflight outside compatibility mode answered `404 PGRST125`, because the
+`Allow` middleware read the path before the mount prefix was stripped off it.
+Found by review, not by the harness.
+
 ## Part 2 — divergences kept on purpose
 
 **These cases fail by choice. Do not "fix" them without deciding to.**
@@ -134,6 +166,26 @@ does not promise.
 
 *Cost: 2 cases. The harness is over-reporting here, not the server
 under-performing.*
+
+### Clock skew on `nbf` and `iat`, and none on `exp`
+
+PostgREST checks all three to the second. This server allows thirty seconds of
+slack on `nbf` and `iat` and none on `exp`, which is a deliberate asymmetry
+rather than an oversight in either direction.
+
+`nbf` and `iat` describe a token that is not valid *yet*. A client whose clock
+runs a little fast mints one a few seconds in the future through no fault of
+anyone's, and refusing it makes a working deployment fail intermittently and
+unreproducibly. Slack there costs nothing an attacker can use.
+
+`exp` is the other way round. Leniency about an expiry is leniency about a
+token that has been *withdrawn*: it keeps a session alive past the second its
+issuer said it ended, and hands anyone holding a stale token a window for free.
+The RFC permits leeway there; this does not take it.
+
+*Cost: 0 cases — no case in the suite mints a token near either boundary,
+which is why this is recorded here rather than left to be inferred from a
+green report.*
 
 ## Part 3 — known gaps, in the order worth doing them
 
@@ -284,3 +336,15 @@ still 200, now under a different name. It took `Err::Failure` to stop it, which
 is also the semantically correct signal: once `->>` is consumed, no other rule
 should get to reinterpret it. The test asserting `is_err()` mattered more than
 the code change did.
+
+**A measurement only covers the configuration it runs in.** Every number here
+is for compatibility mode. The `OPTIONS` bug above was a whole class of request
+answered `404` in the *default* configuration while the report said the `Allow`
+work had landed — because in compatibility mode the surface is at the root, and
+the middleware's mistake was reading a path that still had `/api` on the front
+of it. A 93% that does not say what it is 93% *of* invites exactly this.
+
+The general shape: `Router::layer` wraps each endpoint, and `nest` puts its
+prefix-stripping **inside** that endpoint. Anything added with `layer` sees the
+path the client wrote, not the path the handler reads. Middleware that parses
+the path has to account for the mount it is running above.

--- a/scripts/conformance/README.md
+++ b/scripts/conformance/README.md
@@ -4,12 +4,17 @@ Measures how closely Postrust's HTTP surface matches PostgREST's, using
 PostgREST's own test fixtures and its own test cases.
 
 ```bash
-cargo build --release -p postrust-server --features admin-ui
+cargo build --release -p postrust-server --features admin-ui,compat-key-order
 scripts/conformance/conformance.sh
 ```
 
 Takes about ten minutes, most of it restoring fixture data between mutating
 cases.
+
+[FINDINGS.md](FINDINGS.md) records what the runs have turned up: faults found
+in this harness itself, divergences kept on purpose, and the gaps still open.
+Read it before treating a failing case as a bug — some of them are failing
+because PostgREST is wrong and this server is not.
 
 ## Why this isn't just "run PostgREST's tests"
 

--- a/scripts/conformance/README.md
+++ b/scripts/conformance/README.md
@@ -1,0 +1,117 @@
+# PostgREST conformance harness
+
+Measures how closely Postrust's HTTP surface matches PostgREST's, using
+PostgREST's own test fixtures and its own test cases.
+
+```bash
+cargo build --release -p postrust-server --features admin-ui
+scripts/conformance/conformance.sh
+```
+
+Takes about ten minutes, most of it restoring fixture data between mutating
+cases.
+
+## Why this isn't just "run PostgREST's tests"
+
+PostgREST's spec suite can't be pointed at a different server. `test/spec`
+uses `Test.Hspec.Wai`, which drives the WAI `Application` in-process, and the
+specs import `PostgREST.Config` and construct an `AppConfig` directly — there
+is no HTTP boundary to intercept. (`test/io` does speak HTTP, but it tests
+PostgREST's CLI, logging, and config reloading, not the API contract.)
+
+Two parts of the suite are reusable:
+
+- **the fixture database** — `test/spec/fixtures/*.sql`, ~280 tables, plain SQL
+- **the request literals** — every example contains a method, path, headers,
+  and body written out in full
+
+So the harness lifts the requests out of the Haskell and replays them over
+HTTP against **both** stock PostgREST and Postrust, each on an identically
+loaded fixture database. Divergence is measured against the reference
+implementation's live response, which means we never have to interpret an
+hspec expectation — and any parsing mistake shows up as a case both servers
+answer the same way, not as a false failure.
+
+## Pieces
+
+| File | Role |
+|---|---|
+| `conformance.sh` | Driver: fetch, load fixtures, run both servers, report |
+| `extract.py` | Lifts request literals out of the `.hs` specs |
+| `run.py` | Replays a case file against one server, records raw responses |
+| `report.py` | Diffs two runs and classifies every divergence |
+
+Artifacts land in `scripts/conformance/.work/`, including `diff.json` with
+per-case detail for every divergence.
+
+## How state is kept identical
+
+Every case has to start from the same database, or one divergence cascades
+into phantom failures in everything after it.
+
+- **Reads run first**, as one block from a single clean load. None of them can
+  disturb the others.
+- **Each mutating case gets the fixture data restored immediately before it.**
+
+The restore truncates every fixture table and reloads a data-only `pg_dump`
+snapshot taken after the first full load. No DDL runs, so object OIDs never
+change and neither server has to be restarted to drop a stale schema cache.
+
+Two details make the snapshot necessary rather than just re-running
+`data.sql`: some fixture rows are inserted by `schema.sql` and are absent from
+`data.sql`, and `data.sql` is not idempotent — a few tables (`private.labels`
+among them) are inserted into with no preceding `TRUNCATE`, so a second run
+duplicates rows and its `(SELECT id FROM labels WHERE ...)` subqueries then
+fail.
+
+## Auth coverage
+
+Examples whose header lists call Haskell helpers are resolved rather than
+skipped. `extract.py` collects the `let` bindings in each spec file and
+handles three forms: a literal bearer token, `generateJWT` over a literal JSON
+payload (signed here with the suite's own HS256 secret from `SpecHelper.hs`),
+and a plain `("Name", "Value")` pair. 23 of 1,699 request sites still resist
+resolution.
+
+## Reading the output
+
+Agreement is reported at four strictness levels, split by reads and writes,
+because a single systemic gap would otherwise mask everything behind it:
+
+- **status code only** — would the client's error handling branch the same way?
+- **status + body** — does the client get the same data?
+- **+ headers, ignoring `Content-Range`** — isolates that one header's effect
+- **full contract** — strict
+
+## The raw `>` problem
+
+69 cases in the corpus send a JSON operator (`select=data->>id`) with the `>`
+unescaped, which is what `curl` does and what PostgREST's own documentation
+shows. warp accepts it; hyper rejects the request line before it reaches any
+routing or handler code, so Postrust answers 400 with an empty body.
+
+This is a real drop-in divergence, and it is counted as one — the harness
+sends what the spec suite sends. But it is a transport-layer difference with a
+single cause, so it masks whatever the query layer does with those cases. To
+see past it, re-run just those cases with the operator escaped:
+
+```bash
+python3 - .work/cases.json .work/cases-arrow.json <<'EOF'
+import json, sys
+cs = json.load(open(sys.argv[1]))
+json.dump([dict(c, path=c["path"].replace(">", "%3E")) for c in cs if "->" in c["path"]],
+          open(sys.argv[2], "w"), indent=1)
+EOF
+```
+
+## Known measurement limits
+
+- **The corpus is not representative traffic.** A test suite concentrates on
+  edge cases and error paths by design. Everyday CRUD scores far higher than
+  the suite average — measure both before quoting a number.
+- **Some divergences are intentional.** The root endpoint serving server info
+  rather than the OpenAPI spec, for one. They are counted, not excluded.
+- `Content-Type` is compared without its `charset` parameter.
+- Bodies are compared as parsed JSON where both sides parse, so object key
+  ordering never affects a result — build with `compat-key-order` if you want
+  to check ordering itself.

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Differential PostgREST conformance run.
+#
+# PostgREST's own spec suite (test/spec) cannot be pointed at another server:
+# it drives the WAI Application in-process via hspec-wai and imports
+# PostgREST.Config directly. What is reusable is (a) the fixture database and
+# (b) the request literals inside the examples.
+#
+# So we replay those requests against stock PostgREST and against Postrust,
+# both on an identical, freshly loaded fixture database, and diff the live
+# responses. The reference implementation is the oracle -- we never have to
+# interpret an hspec expectation, and a mistake in the extractor shows up as a
+# case both servers answer the same way rather than as a false failure.
+#
+# Usage:  scripts/conformance/conformance.sh [postgrest-version]
+set -euo pipefail
+
+PGRST_VERSION="${1:-v16.1}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${CONFORMANCE_WORK:-$HERE/.work}"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+
+DB=pgrst-conf-db
+REF=pgrst-conf-ref
+NET=pgrst-conf-net
+DB_PORT="${CONFORMANCE_DB_PORT:-55432}"
+REF_PORT="${CONFORMANCE_REF_PORT:-55001}"
+CAND_PORT="${CONFORMANCE_CAND_PORT:-55002}"
+
+# The fixtures need PostGIS; the stock postgres image cannot load schema.sql.
+DB_IMAGE="${CONFORMANCE_DB_IMAGE:-postgis/postgis:16-3.4}"
+
+# Matches PostgREST's own test configuration (test/spec/SpecHelper.hs).
+SCHEMA=test
+ANON_ROLE=postgrest_test_anonymous
+JWT_SECRET=reallyreallyreallyreallyverysafe
+
+mkdir -p "$WORK"
+say() { printf '\n==> %s\n' "$*"; }
+
+cleanup() {
+    pkill -f 'target/release/postrust' 2>/dev/null || true
+    docker rm -f "$REF" "$DB" >/dev/null 2>&1 || true
+    docker network rm "$NET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if [ ! -x "$REPO_ROOT/target/release/postrust" ]; then
+    echo "error: target/release/postrust not found." >&2
+    echo "       cargo build --release -p postrust-server --features admin-ui" >&2
+    exit 1
+fi
+
+say "Fetching PostgREST $PGRST_VERSION fixtures and specs"
+if [ ! -d "$WORK/pgrst" ]; then
+    curl -sL "https://github.com/PostgREST/postgrest/archive/refs/tags/$PGRST_VERSION.tar.gz" \
+        -o "$WORK/pgrst.tar.gz"
+    tar xzf "$WORK/pgrst.tar.gz" -C "$WORK"
+    mv "$WORK/postgrest-${PGRST_VERSION#v}" "$WORK/pgrst"
+    rm "$WORK/pgrst.tar.gz"
+fi
+
+say "Starting fixture database"
+cleanup
+docker network create "$NET" >/dev/null
+docker run -d --name "$DB" --network "$NET" \
+    -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=pgrst_conf \
+    -p "$DB_PORT:5432" "$DB_IMAGE" >/dev/null
+for _ in $(seq 1 60); do
+    docker exec "$DB" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break
+    sleep 1
+done
+docker cp "$WORK/pgrst/test" "$DB:/pgrst-test" >/dev/null
+
+psql_do() {
+    docker exec -e PGPASSWORD=postgres "$DB" \
+        psql -q -U postgres -d "$1" -v ON_ERROR_STOP=1 "${@:2}"
+}
+
+# Full reload, schema included. This drops and recreates the schemas, which
+# changes OIDs, so any running server must be restarted afterwards.
+full_load() {
+    psql_do postgres -c "DROP DATABASE IF EXISTS pgrst_conf WITH (FORCE);" \
+                     -c "CREATE DATABASE pgrst_conf;" >/dev/null
+    psql_do pgrst_conf -v DBNAME=pgrst_conf -v PGUSER=postgres \
+        -f /pgrst-test/spec/fixtures/load.sql >/dev/null
+}
+
+# Data-only restore, used between mutating cases. No DDL runs, so OIDs are
+# stable and neither server needs restarting.
+#
+# We reload a snapshot taken after the first full load rather than re-running
+# data.sql, for two reasons: some fixture rows come from schema.sql and are
+# absent from data.sql, and data.sql is not idempotent (a few tables are
+# inserted into with no preceding TRUNCATE, so a second run duplicates rows).
+write_reset_assets() {
+    cat > "$WORK/truncate-all.sql" <<'SQL'
+DO $$
+DECLARE tables text;
+BEGIN
+    -- Found by exclusion, not listed: the fixtures include schemas named
+    -- `تست` and `SPECIAL "@/\#~_-|`, and a missed schema surfaces later as a
+    -- duplicate-key error on reload.
+    SELECT string_agg(format('%I.%I', schemaname, tablename), ', ')
+      INTO tables FROM pg_tables
+     WHERE schemaname NOT IN ('pg_catalog', 'information_schema')
+       AND schemaname NOT LIKE 'pg\_%';
+    IF tables IS NOT NULL THEN
+        EXECUTE 'TRUNCATE TABLE ' || tables || ' CASCADE';
+    END IF;
+END $$;
+SQL
+    docker exec -e PGPASSWORD=postgres "$DB" pg_dump -U postgres -d pgrst_conf \
+        --data-only --disable-triggers --no-owner > "$WORK/snapshot.sql" 2>/dev/null
+    docker cp "$WORK/truncate-all.sql" "$DB:/truncate-all.sql" >/dev/null
+    docker cp "$WORK/snapshot.sql" "$DB:/snapshot.sql" >/dev/null
+}
+
+RESET_CMD="docker exec -e PGPASSWORD=postgres $DB psql -q -U postgres -d pgrst_conf \
+    -v ON_ERROR_STOP=1 -f /truncate-all.sql -f /snapshot.sql"
+
+say "Loading fixtures"
+full_load
+write_reset_assets
+
+say "Extracting request cases from the spec suite"
+python3 "$HERE/extract.py" "$WORK/pgrst/test/spec/Feature" "$WORK/cases.json"
+
+say "Replaying against PostgREST $PGRST_VERSION (reference)"
+docker rm -f "$REF" >/dev/null 2>&1 || true
+docker run -d --name "$REF" --network "$NET" -p "$REF_PORT:3000" \
+    -e PGRST_DB_URI="postgres://postgres:postgres@$DB:5432/pgrst_conf" \
+    -e PGRST_DB_SCHEMAS="$SCHEMA" -e PGRST_DB_ANON_ROLE="$ANON_ROLE" \
+    -e PGRST_JWT_SECRET="$JWT_SECRET" -e PGRST_SERVER_PORT=3000 \
+    "postgrest/postgrest:$PGRST_VERSION" >/dev/null
+sleep 9
+python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$REF_PORT" \
+    "$WORK/ref.json" "$RESET_CMD >/dev/null 2>&1"
+
+say "Replaying against Postrust (candidate)"
+full_load
+write_reset_assets
+pkill -f 'target/release/postrust' 2>/dev/null || true
+sleep 2
+DATABASE_URL="postgres://postgres:postgres@localhost:$DB_PORT/pgrst_conf" \
+PGRST_DB_SCHEMAS="$SCHEMA" PGRST_DB_ANON_ROLE="$ANON_ROLE" PGRST_JWT_SECRET="$JWT_SECRET" \
+PGRST_SERVER_PORT="$CAND_PORT" PGRST_SERVER_HOST=127.0.0.1 \
+PGRST_COMPAT_MODE=true PGRST_LOG_LEVEL=warn \
+    "$REPO_ROOT/target/release/postrust" >"$WORK/postrust.log" 2>&1 &
+sleep 9
+python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$CAND_PORT" \
+    "$WORK/cand.json" "$RESET_CMD >/dev/null 2>&1"
+
+say "Report"
+python3 "$HERE/report.py" "$WORK/ref.json" "$WORK/cand.json" "$WORK/diff.json" \
+    | tee "$WORK/report.txt"

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -206,6 +206,24 @@ assert_key_order
 python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$CAND_PORT" \
     "$WORK/cand.json" "$RESET_CMD >/dev/null 2>&1"
 
+# What was actually measured, written beside the diff so that anything
+# publishing these numbers reads it from the run rather than from whatever was
+# typed on a command line. The features are the ones this script built with a
+# few lines up, and `assert_key_order` has already confirmed the running binary
+# agrees; the commit is what produced it.
+#
+# Run 4 is why: it was measured with a binary `cargo test --workspace` had
+# quietly rebuilt without `compat-key-order`, and nothing in its output said so.
+cat > "$WORK/run-meta.json" <<META
+{
+  "postgrest": "$PGRST_VERSION",
+  "features": "admin-ui,compat-key-order",
+  "compatMode": true,
+  "commit": "$(git -C "$REPO_ROOT" rev-parse HEAD)",
+  "measured": "$(date -u +%Y-%m-%d)"
+}
+META
+
 say "Report"
 python3 "$HERE/report.py" "$WORK/ref.json" "$WORK/cand.json" "$WORK/diff.json" \
     | tee "$WORK/report.txt"

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -54,9 +54,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# `compat-key-order` is part of what is being measured, not an optimisation:
+# PostgREST returns object keys in the table's order and this server returns
+# them alphabetically without it. Invisible in JSON, since bodies are compared
+# as JSON -- but a CSV response puts its columns in key order, and there the
+# difference is the whole answer.
 if [ ! -x "$REPO_ROOT/target/release/postrust" ]; then
     echo "error: target/release/postrust not found." >&2
-    echo "       cargo build --release -p postrust-server --features admin-ui" >&2
+    echo "       cargo build --release -p postrust-server --features admin-ui,compat-key-order" >&2
     exit 1
 fi
 

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -54,16 +54,34 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# `compat-key-order` is part of what is being measured, not an optimisation:
-# PostgREST returns object keys in the table's order and this server returns
-# them alphabetically without it. Invisible in JSON, since bodies are compared
-# as JSON -- but a CSV response puts its columns in key order, and there the
-# difference is the whole answer.
-if [ ! -x "$REPO_ROOT/target/release/postrust" ]; then
-    echo "error: target/release/postrust not found." >&2
-    echo "       cargo build --release -p postrust-server --features admin-ui,compat-key-order" >&2
-    exit 1
-fi
+# Built here rather than required to exist, because which features it was built
+# with is part of what is being measured and cannot be read off the file.
+#
+# `compat-key-order` is one of them: PostgREST returns object keys in select
+# order and this server returns them alphabetically without it. Invisible in
+# JSON, since bodies are compared as parsed JSON -- and the whole answer in
+# CSV, which puts its columns in key order.
+#
+# The trap this closes: `cargo test --workspace` rebuilds this same binary with
+# default features and overwrites it, so a build, then a test run, then a
+# conformance run silently measured a binary with neither feature. Nothing said
+# so; the binary was simply 1.1 MB smaller.
+say "Building the candidate"
+cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" \
+    -p postrust-server --features admin-ui,compat-key-order >&2
+
+# The server says so itself when compatibility mode is on without the feature,
+# so the log is checked once it starts. Belt and braces: the build above should
+# make it impossible, and this catches it if anything else replaces the binary
+# between here and there.
+assert_key_order() {
+    if grep -q "features compat-key-order" "$WORK/postrust.log" 2>/dev/null; then
+        echo "error: the candidate was built without compat-key-order." >&2
+        echo "       Its object keys will be alphabetical and every CSV column" >&2
+        echo "       order case will diverge for a reason that is not a bug." >&2
+        exit 1
+    fi
+}
 
 say "Fetching PostgREST $PGRST_VERSION fixtures and specs"
 if [ ! -d "$WORK/pgrst" ]; then
@@ -184,6 +202,7 @@ PGRST_SERVER_PORT="$CAND_PORT" PGRST_SERVER_HOST=127.0.0.1 \
 PGRST_COMPAT_MODE=true PGRST_LOG_LEVEL=warn \
     "$REPO_ROOT/target/release/postrust" >"$WORK/postrust.log" 2>&1 &
 sleep 9
+assert_key_order
 python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$CAND_PORT" \
     "$WORK/cand.json" "$RESET_CMD >/dev/null 2>&1"
 

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -126,16 +126,23 @@ write_reset_assets
 say "Extracting request cases from the spec suite"
 python3 "$HERE/extract.py" "$WORK/pgrst/test/spec/Feature" "$WORK/cases.json"
 
-say "Replaying against PostgREST $PGRST_VERSION (reference)"
-docker rm -f "$REF" >/dev/null 2>&1 || true
-docker run -d --name "$REF" --network "$NET" -p "$REF_PORT:3000" \
-    -e PGRST_DB_URI="postgres://postgres:postgres@$DB:5432/pgrst_conf" \
-    -e PGRST_DB_SCHEMAS="$SCHEMA" -e PGRST_DB_ANON_ROLE="$ANON_ROLE" \
-    -e PGRST_JWT_SECRET="$JWT_SECRET" -e PGRST_SERVER_PORT=3000 \
-    "postgrest/postgrest:$PGRST_VERSION" >/dev/null
-sleep 9
-python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$REF_PORT" \
-    "$WORK/ref.json" "$RESET_CMD >/dev/null 2>&1"
+# The reference run is the expensive half and its answers only change when
+# PostgREST's version or the fixtures do, so a previous one can be reused
+# while iterating on the candidate. Set CONFORMANCE_REUSE_REF=1 to do that.
+if [ "${CONFORMANCE_REUSE_REF:-}" = "1" ] && [ -s "$WORK/ref.json" ]; then
+    say "Reusing the recorded PostgREST $PGRST_VERSION responses"
+else
+    say "Replaying against PostgREST $PGRST_VERSION (reference)"
+    docker rm -f "$REF" >/dev/null 2>&1 || true
+    docker run -d --name "$REF" --network "$NET" -p "$REF_PORT:3000" \
+        -e PGRST_DB_URI="postgres://postgres:postgres@$DB:5432/pgrst_conf" \
+        -e PGRST_DB_SCHEMAS="$SCHEMA" -e PGRST_DB_ANON_ROLE="$ANON_ROLE" \
+        -e PGRST_JWT_SECRET="$JWT_SECRET" -e PGRST_SERVER_PORT=3000 \
+        "postgrest/postgrest:$PGRST_VERSION" >/dev/null
+    sleep 9
+    python3 "$HERE/run.py" "$WORK/cases.json" "http://localhost:$REF_PORT" \
+        "$WORK/ref.json" "$RESET_CMD >/dev/null 2>&1"
+fi
 
 say "Replaying against Postrust (candidate)"
 full_load

--- a/scripts/conformance/conformance.sh
+++ b/scripts/conformance/conformance.sh
@@ -34,6 +34,15 @@ DB_IMAGE="${CONFORMANCE_DB_IMAGE:-postgis/postgis:16-3.4}"
 SCHEMA=test
 ANON_ROLE=postgrest_test_anonymous
 JWT_SECRET=reallyreallyreallyreallyverysafe
+# PostgREST's own suite runs each spec under its own configuration; this
+# harness runs one server for all of them, so the setting has to be the union
+# of what the specs ask for. `extensions` is where the fixtures install PostGIS
+# and isn, and without it on the path *both* servers answer 42883 to every
+# request that touches them -- which reads as agreement while measuring
+# nothing. The third entry is a schema whose name is mostly punctuation, and it
+# is here because ExtraSearchPathSpec puts it there.
+EXTRA_SEARCH_PATH='public, extensions, EXTRA "@/\#~_-'
+
 
 mkdir -p "$WORK"
 say() { printf '\n==> %s\n' "$*"; }
@@ -126,6 +135,19 @@ write_reset_assets
 say "Extracting request cases from the spec suite"
 python3 "$HERE/extract.py" "$WORK/pgrst/test/spec/Feature" "$WORK/cases.json"
 
+# A probe run: only the specs named, so a change can be measured in minutes
+# rather than in an hour. Point CONFORMANCE_WORK somewhere of its own when
+# using this -- a filtered `ref.json` must not be mistaken for a full one.
+if [ -n "${CONFORMANCE_SPECS:-}" ]; then
+    python3 - "$WORK/cases.json" "$CONFORMANCE_SPECS" <<'FILTER'
+import json, re, sys
+path, pattern = sys.argv[1], sys.argv[2]
+cases = [c for c in json.load(open(path)) if re.search(pattern, c["spec"])]
+json.dump(cases, open(path, "w"))
+print("  filtered to %d cases matching %s" % (len(cases), pattern))
+FILTER
+fi
+
 # The reference run is the expensive half and its answers only change when
 # PostgREST's version or the fixtures do, so a previous one can be reused
 # while iterating on the candidate. Set CONFORMANCE_REUSE_REF=1 to do that.
@@ -137,6 +159,7 @@ else
     docker run -d --name "$REF" --network "$NET" -p "$REF_PORT:3000" \
         -e PGRST_DB_URI="postgres://postgres:postgres@$DB:5432/pgrst_conf" \
         -e PGRST_DB_SCHEMAS="$SCHEMA" -e PGRST_DB_ANON_ROLE="$ANON_ROLE" \
+        -e PGRST_DB_EXTRA_SEARCH_PATH="$EXTRA_SEARCH_PATH" \
         -e PGRST_JWT_SECRET="$JWT_SECRET" -e PGRST_SERVER_PORT=3000 \
         "postgrest/postgrest:$PGRST_VERSION" >/dev/null
     sleep 9
@@ -151,6 +174,7 @@ pkill -f 'target/release/postrust' 2>/dev/null || true
 sleep 2
 DATABASE_URL="postgres://postgres:postgres@localhost:$DB_PORT/pgrst_conf" \
 PGRST_DB_SCHEMAS="$SCHEMA" PGRST_DB_ANON_ROLE="$ANON_ROLE" PGRST_JWT_SECRET="$JWT_SECRET" \
+PGRST_DB_EXTRA_SEARCH_PATH="$EXTRA_SEARCH_PATH" \
 PGRST_SERVER_PORT="$CAND_PORT" PGRST_SERVER_HOST=127.0.0.1 \
 PGRST_COMPAT_MODE=true PGRST_LOG_LEVEL=warn \
     "$REPO_ROOT/target/release/postrust" >"$WORK/postrust.log" 2>&1 &

--- a/scripts/conformance/extract.py
+++ b/scripts/conformance/extract.py
@@ -143,6 +143,19 @@ INLINE_JWT = re.compile(r'authHeaderJWT\s+"([^"]*)"')
 INLINE_JWT_GEN = re.compile(r'authHeaderJWT\s*\$\s*generateJWT\s*\[json\|(.*?)\|\]', re.S)
 
 
+def match_paren(src, start):
+    """Index just past the `)` closing the `(` at `start`, or -1."""
+    depth = 0
+    for k in range(start, len(src)):
+        if src[k] == "(":
+            depth += 1
+        elif src[k] == ")":
+            depth -= 1
+            if depth == 0:
+                return k + 1
+    return -1
+
+
 def parse_headers(chunk, binds):
     """Return list of [name, value], or None if some entry can't be resolved."""
     inner = chunk.strip()[1:-1].strip()
@@ -202,7 +215,24 @@ for dirpath, _, files in os.walk(SPEC_ROOT):
             headers, body = [], None
             j = skip_ws(src, i)
 
-            if j < len(src) and src[j] == "[" and not src.startswith("[json|", j):
+            # `request methodGet "/x" (acceptHdrs "text/csv") ""` passes its
+            # headers as a call rather than a list. Reading only the list form
+            # dropped the header and replayed the request without it -- against
+            # both servers, so it showed up as agreement on a request neither
+            # was asked to answer.
+            if src.startswith("(acceptHdrs", j):
+                end = match_paren(src, j)
+                if end < 0:
+                    stats["unresolved_headers"] += 1
+                    continue
+                mime = re.search(r'"((?:[^"\\]|\\.)*)"', src[j:end])
+                if not mime:
+                    stats["unresolved_headers"] += 1
+                    continue
+                headers = [["Accept", mime.group(1)]]
+                j = skip_ws(src, end)
+
+            elif j < len(src) and src[j] == "[" and not src.startswith("[json|", j):
                 end = match_bracket(src, j)
                 if end < 0:
                     continue

--- a/scripts/conformance/extract.py
+++ b/scripts/conformance/extract.py
@@ -156,6 +156,21 @@ def match_paren(src, start):
     return -1
 
 
+def unescape(text):
+    """Resolve the Haskell string escapes a raw regex capture leaves behind."""
+    out = []
+    i = 0
+    while i < len(text):
+        if text[i] == "\\" and i + 1 < len(text):
+            nxt = text[i + 1]
+            out.append({"n": "\n", "t": "\t", "\\": "\\", '"': '"'}.get(nxt, nxt))
+            i += 2
+        else:
+            out.append(text[i])
+            i += 1
+    return "".join(out)
+
+
 def parse_headers(chunk, binds):
     """Return list of [name, value], or None if some entry can't be resolved."""
     inner = chunk.strip()[1:-1].strip()
@@ -166,7 +181,13 @@ def parse_headers(chunk, binds):
     residue = inner
 
     for hname, hvalue in HDR_PAIR.findall(inner):
-        headers.append([hname, hvalue])
+        # The regex keeps a Haskell string literal's escapes, so a header
+        # written `"...for=\\"application/json\\""` arrived with the
+        # backslashes still in it. PostgREST's media-type parser then failed on
+        # the `\\` and fell back to defaults -- and since the candidate got the
+        # same mangled header, the two agreed on answering a question neither
+        # had been asked.
+        headers.append([unescape(hname), unescape(hvalue)])
     residue = HDR_PAIR.sub("", residue)
 
     for token in INLINE_JWT.findall(residue):
@@ -229,7 +250,7 @@ for dirpath, _, files in os.walk(SPEC_ROOT):
                 if not mime:
                     stats["unresolved_headers"] += 1
                     continue
-                headers = [["Accept", mime.group(1)]]
+                headers = [["Accept", unescape(mime.group(1))]]
                 j = skip_ws(src, end)
 
             elif j < len(src) and src[j] == "[" and not src.startswith("[json|", j):

--- a/scripts/conformance/extract.py
+++ b/scripts/conformance/extract.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+Extract HTTP request cases from PostgREST's hspec-wai specs.
+
+The specs cannot be executed against a foreign server (they drive the WAI
+Application in-process and import PostgREST.Config directly), but the request
+side of each example is a literal we can lift out and replay over HTTP.
+
+We deliberately do NOT try to interpret the hspec expectations. The comparison
+is differential: the same request goes to stock PostgREST and to Postrust, and
+the reference implementation's live response is the oracle.
+
+Header lists that name a binding (`[auth]`) are resolved against the `let`
+bindings in the same file, and `generateJWT` payloads are signed here with the
+suite's own secret, so auth-bearing examples are covered too.
+"""
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import sys
+
+SPEC_ROOT = sys.argv[1]
+OUT = sys.argv[2]
+
+# test/spec/SpecHelper.hs: baseCfg uses this as the HS256 signing key.
+JWT_SECRET = b"reallyreallyreallyreallyverysafe"
+
+VERB = {
+    "get": "GET", "post": "POST", "patch": "PATCH",
+    "put": "PUT", "delete": "DELETE", "head": "HEAD", "options": "OPTIONS",
+}
+
+SITE = re.compile(
+    r"""(?:(?P<req>request\s+method(?P<mc>[A-Z][a-z]+)\s+)|(?<![\w'])(?P<verb>get|post|patch|put|delete|head|options)\s+)"
+        (?P<path>(?:[^"\\]|\\.)*)"
+    """,
+    re.VERBOSE,
+)
+
+
+def b64url(raw):
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def make_jwt(payload_json):
+    """Sign a JWT the way SpecHelper's generateJWT does: HS256, no extra claims."""
+    header = b64url(b'{"alg":"HS256","typ":"JWT"}')
+    try:
+        compact = json.dumps(json.loads(payload_json), separators=(",", ":"))
+    except Exception:
+        return None
+    body = b64url(compact.encode())
+    signing_input = f"{header}.{body}".encode()
+    sig = hmac.new(JWT_SECRET, signing_input, hashlib.sha256).digest()
+    return f"{header}.{body}.{b64url(sig)}"
+
+
+def skip_ws(s, i):
+    """Advance past whitespace and Haskell line comments."""
+    while i < len(s):
+        if s[i] in " \t\r\n":
+            i += 1
+        elif s.startswith("--", i):
+            j = s.find("\n", i)
+            i = len(s) if j < 0 else j + 1
+        else:
+            break
+    return i
+
+
+def match_bracket(s, i):
+    """s[i] == '['. Return index just past the matching ']', respecting strings."""
+    depth = 0
+    while i < len(s):
+        c = s[i]
+        if c == '"':
+            i += 1
+            while i < len(s) and s[i] != '"':
+                i += 2 if s[i] == "\\" else 1
+        elif c == "[":
+            depth += 1
+        elif c == "]":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return -1
+
+
+def read_string(s, i):
+    """s[i] == '"'. Return (value, next_index) with Haskell escapes resolved."""
+    i += 1
+    buf = []
+    while i < len(s) and s[i] != '"':
+        if s[i] == "\\":
+            nxt = s[i + 1]
+            buf.append({"n": "\n", "t": "\t", "\\": "\\", '"': '"'}.get(nxt, nxt))
+            i += 2
+        else:
+            buf.append(s[i])
+            i += 1
+    return "".join(buf), i + 1
+
+
+HDR_PAIR = re.compile(r'\(\s*"((?:[^"\\]|\\.)*)"\s*,\s*"((?:[^"\\]|\\.)*)"\s*\)')
+# let auth = authHeaderJWT "<literal token>"
+BIND_JWT_LIT = re.compile(r'(?:let\s+)?(\w+)\s*=\s*authHeaderJWT\s+"([^"]*)"')
+# let auth = authHeaderJWT $ generateJWT [json| {...} |]
+BIND_JWT_GEN = re.compile(
+    r'(?:let\s+)?(\w+)\s*=\s*authHeaderJWT\s*\$\s*generateJWT\s*\[json\|(.*?)\|\]', re.S)
+# let single = ("Accept", "application/vnd.pgrst.object+json")
+BIND_PAIR = re.compile(r'(?:let\s+)?(\w+)\s*=\s*\(\s*"([^"]*)"\s*,\s*"([^"]*)"\s*\)')
+# jwtPayload = [json| {...} |]  -- referenced by generateJWT jwtPayload
+BIND_JSON = re.compile(r'(?:let\s+)?(\w+)\s*=\s*\[json\|(.*?)\|\]', re.S)
+BIND_JWT_REF = re.compile(r'(?:let\s+)?(\w+)\s*=\s*authHeaderJWT\s*\$\s*generateJWT\s+(\w+)')
+
+
+def collect_bindings(src):
+    """Map binding name -> (header-name, header-value) for the resolvable forms."""
+    binds = {}
+    json_vals = {name: body.strip() for name, body in BIND_JSON.findall(src)}
+
+    for name, token in BIND_JWT_LIT.findall(src):
+        binds[name] = ("Authorization", f"Bearer {token}")
+    for name, payload in BIND_JWT_GEN.findall(src):
+        token = make_jwt(payload.strip())
+        if token:
+            binds[name] = ("Authorization", f"Bearer {token}")
+    for name, ref in BIND_JWT_REF.findall(src):
+        token = make_jwt(json_vals.get(ref, ""))
+        if token:
+            binds[name] = ("Authorization", f"Bearer {token}")
+    for name, hname, hvalue in BIND_PAIR.findall(src):
+        binds.setdefault(name, (hname, hvalue))
+    return binds
+
+
+# authHeaderJWT "<token>" appearing inline inside a header list
+INLINE_JWT = re.compile(r'authHeaderJWT\s+"([^"]*)"')
+INLINE_JWT_GEN = re.compile(r'authHeaderJWT\s*\$\s*generateJWT\s*\[json\|(.*?)\|\]', re.S)
+
+
+def parse_headers(chunk, binds):
+    """Return list of [name, value], or None if some entry can't be resolved."""
+    inner = chunk.strip()[1:-1].strip()
+    if not inner:
+        return []
+
+    headers = []
+    residue = inner
+
+    for hname, hvalue in HDR_PAIR.findall(inner):
+        headers.append([hname, hvalue])
+    residue = HDR_PAIR.sub("", residue)
+
+    for token in INLINE_JWT.findall(residue):
+        headers.append(["Authorization", f"Bearer {token}"])
+    residue = INLINE_JWT.sub("", residue)
+
+    for payload in INLINE_JWT_GEN.findall(residue):
+        token = make_jwt(payload.strip())
+        if not token:
+            return None
+        headers.append(["Authorization", f"Bearer {token}"])
+    residue = INLINE_JWT_GEN.sub("", residue)
+
+    # Whatever is left should be bare binding names.
+    for word in re.findall(r"[A-Za-z_]\w*", residue):
+        if word not in binds:
+            return None
+        headers.append(list(binds[word]))
+    if re.sub(r"[A-Za-z_]\w*|[,\s]", "", residue):
+        return None
+
+    return headers
+
+
+cases = []
+stats = {"sites": 0, "extracted": 0, "unresolved_headers": 0, "auth_cases": 0}
+
+for dirpath, _, files in os.walk(SPEC_ROOT):
+    for fn in sorted(files):
+        if not fn.endswith(".hs"):
+            continue
+        full = os.path.join(dirpath, fn)
+        rel = os.path.relpath(full, SPEC_ROOT)
+        src = open(full, encoding="utf-8").read()
+        binds = collect_bindings(src)
+
+        for m in SITE.finditer(src):
+            stats["sites"] += 1
+            method = m.group("mc").upper() if m.group("req") else VERB[m.group("verb")]
+            path = m.group("path")
+            i = m.end()
+
+            if src[i:skip_ws(src, i) + 2].strip().startswith("<>"):
+                continue  # path built by concatenation -- not a literal
+
+            headers, body = [], None
+            j = skip_ws(src, i)
+
+            if j < len(src) and src[j] == "[" and not src.startswith("[json|", j):
+                end = match_bracket(src, j)
+                if end < 0:
+                    continue
+                parsed = parse_headers(src[j:end], binds)
+                if parsed is None:
+                    stats["unresolved_headers"] += 1
+                    continue
+                headers = parsed
+                j = skip_ws(src, end)
+
+            if src.startswith("[json|", j):
+                end = src.find("|]", j)
+                if end < 0:
+                    continue
+                body = src[j + 6:end].strip()
+            elif j < len(src) and src[j] == '"':
+                body, _ = read_string(src, j)
+
+            if "\\" in path:
+                path = path.encode().decode("unicode_escape")
+
+            if any(h[0].lower() == "authorization" for h in headers):
+                stats["auth_cases"] += 1
+
+            cases.append({
+                "id": f"{rel}:{src.count(chr(10), 0, m.start()) + 1}",
+                "spec": rel,
+                "method": method,
+                "path": path,
+                "headers": headers,
+                "body": body,
+                # Anything that isn't a plain read may change state, so the
+                # runner restores the fixture data before replaying it.
+                "mutating": method in ("POST", "PATCH", "PUT", "DELETE"),
+            })
+            stats["extracted"] += 1
+
+seen = {}
+for c in cases:
+    key = (c["method"], c["path"], tuple(map(tuple, c["headers"])), c["body"])
+    seen.setdefault(key, c)
+unique = [c for c in seen.values() if c["path"].startswith("/")]
+
+json.dump(unique, open(OUT, "w"), indent=1)
+stats["unique"] = len(unique)
+stats["mutating"] = sum(1 for c in unique if c["mutating"])
+print(json.dumps(stats, indent=2))

--- a/scripts/conformance/report.py
+++ b/scripts/conformance/report.py
@@ -14,6 +14,10 @@ ref = json.load(open(sys.argv[1]))
 cand = {r["id"] + "|" + r["method"] + r["path"]: r for r in json.load(open(sys.argv[2]))}
 OUT = sys.argv[3]
 
+# The headers that are part of the answer rather than of the transport.
+# Named rather than compared wholesale: `Date`, `Server` and `Connection`
+# differ between any two servers and say nothing about conformance. So "full
+# contract" below means status, body, and these six -- not every header.
 CONTRACT = ["content-type", "content-range", "location",
             "preference-applied", "allow", "www-authenticate"]
 
@@ -46,9 +50,15 @@ def code_of(body):
 
 
 rows = []
+missing = []
 for r in ref:
     c = cand.get(r["id"] + "|" + r["method"] + r["path"])
+    # A case the candidate has no answer for is not a case that passed, and
+    # dropping it from the denominator can only move every figure up. It is
+    # counted and named instead; the two runs replay the same file, so this
+    # should always be empty.
     if c is None:
+        missing.append(r["id"])
         continue
     hdr = {}
     for h in CONTRACT:
@@ -75,7 +85,7 @@ LEVELS = [
     ("status + body", lambda r: r["status_ok"] and r["body_ok"]),
     ("+ headers, ignoring Content-Range",
      lambda r: r["status_ok"] and r["body_ok"] and r["hdr_ok_excl_range"]),
-    ("full contract (strict)",
+    ("full contract (status, body, the six headers above)",
      lambda r: r["status_ok"] and r["body_ok"] and r["hdr_ok"]),
 ]
 
@@ -89,6 +99,11 @@ def table(subset, title):
         k = sum(1 for r in subset if fn(r))
         print(f"  {100*k/n:5.1f}%  {k:>4}/{n:<4} {'#' * round(30 * k / n):<30} {label}")
 
+
+if missing:
+    print(f"\n!! {len(missing)} of {len(ref)} reference cases have no candidate "
+          f"answer and are not counted below: {', '.join(missing[:10])}"
+          f"{' ...' if len(missing) > 10 else ''}")
 
 table(rows, "ALL")
 table([r for r in rows if not r["mutating"]], "READS (GET / HEAD / OPTIONS)")

--- a/scripts/conformance/report.py
+++ b/scripts/conformance/report.py
@@ -109,6 +109,17 @@ table(rows, "ALL")
 table([r for r in rows if not r["mutating"]], "READS (GET / HEAD / OPTIONS)")
 table([r for r in rows if r["mutating"]], "WRITES (POST / PATCH / PUT / DELETE)")
 
+# A request that got no answer at all is not a disagreement about the answer.
+# It counts as a failure, which is the safe direction, but it is called out so
+# that a flaky socket is not read as a conformance gap -- and so that a real
+# one is not read as a flaky socket.
+dead = [r for r in rows if r["cand_status"] is None]
+if dead:
+    print(f"\n!! {len(dead)} case(s) got no response from the candidate at all. "
+          f"Counted as failures, which understates the figures above by that much.")
+    for r in dead:
+        print(f"   {r['id']}  {r['method']} {r['path']}")
+
 print("\nwhere the divergences are")
 print(f"  status differs        {sum(1 for r in rows if not r['status_ok']):>4}")
 print(f"  body differs          {sum(1 for r in rows if not r['body_ok']):>4}")

--- a/scripts/conformance/report.py
+++ b/scripts/conformance/report.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Diff two replay runs and classify every divergence.
+
+Agreement is reported at four strictness levels. A single systemic gap -- one
+header never emitted, say -- would otherwise sink every case and hide the
+hundreds that differ in nothing else.
+"""
+import collections
+import json
+import sys
+
+ref = json.load(open(sys.argv[1]))
+cand = {r["id"] + "|" + r["method"] + r["path"]: r for r in json.load(open(sys.argv[2]))}
+OUT = sys.argv[3]
+
+CONTRACT = ["content-type", "content-range", "location",
+            "preference-applied", "allow", "www-authenticate"]
+
+
+def parse(b):
+    try:
+        return True, json.loads(b)
+    except Exception:
+        return False, b
+
+
+def same_body(a, b):
+    oka, va = parse(a)
+    okb, vb = parse(b)
+    if oka and okb:
+        return va == vb
+    if oka != okb:
+        return False
+    return a.strip() == b.strip()
+
+
+def ctype(h):
+    # charset is a harmless spelling difference; compare the essence.
+    return (h or "").split(";")[0].strip().lower()
+
+
+def code_of(body):
+    ok, v = parse(body)
+    return v.get("code") if ok and isinstance(v, dict) else None
+
+
+rows = []
+for r in ref:
+    c = cand.get(r["id"] + "|" + r["method"] + r["path"])
+    if c is None:
+        continue
+    hdr = {}
+    for h in CONTRACT:
+        rv, cv = r["headers"].get(h), c["headers"].get(h)
+        if h == "content-type":
+            rv, cv = ctype(rv), ctype(cv)
+        if rv != cv:
+            hdr[h] = [rv, cv]
+    rows.append({
+        "id": r["id"], "spec": r["spec"], "method": r["method"], "path": r["path"],
+        "mutating": r.get("mutating", False),
+        "ref_status": r["status"], "cand_status": c["status"],
+        "status_ok": r["status"] == c["status"],
+        "body_ok": same_body(r["body"], c["body"]),
+        "hdr_diffs": hdr,
+        "hdr_ok": not hdr,
+        "hdr_ok_excl_range": not {k: v for k, v in hdr.items() if k != "content-range"},
+        "ref_body": r["body"][:500], "cand_body": c["body"][:500],
+        "ref_code": code_of(r["body"]), "cand_code": code_of(c["body"]),
+    })
+
+LEVELS = [
+    ("status code only", lambda r: r["status_ok"]),
+    ("status + body", lambda r: r["status_ok"] and r["body_ok"]),
+    ("+ headers, ignoring Content-Range",
+     lambda r: r["status_ok"] and r["body_ok"] and r["hdr_ok_excl_range"]),
+    ("full contract (strict)",
+     lambda r: r["status_ok"] and r["body_ok"] and r["hdr_ok"]),
+]
+
+
+def table(subset, title):
+    n = len(subset)
+    if not n:
+        return
+    print(f"\n{title}  ({n} cases)")
+    for label, fn in LEVELS:
+        k = sum(1 for r in subset if fn(r))
+        print(f"  {100*k/n:5.1f}%  {k:>4}/{n:<4} {'#' * round(30 * k / n):<30} {label}")
+
+
+table(rows, "ALL")
+table([r for r in rows if not r["mutating"]], "READS (GET / HEAD / OPTIONS)")
+table([r for r in rows if r["mutating"]], "WRITES (POST / PATCH / PUT / DELETE)")
+
+print("\nwhere the divergences are")
+print(f"  status differs        {sum(1 for r in rows if not r['status_ok']):>4}")
+print(f"  body differs          {sum(1 for r in rows if not r['body_ok']):>4}")
+for h, k in collections.Counter(h for r in rows for h in r["hdr_diffs"]).most_common():
+    print(f"  header {h:<15}{k:>4}")
+
+print("\nstatus-code pairs")
+sp = collections.Counter((r["ref_status"], r["cand_status"]) for r in rows if not r["status_ok"])
+for (a, b), k in sp.most_common(10):
+    print(f"  PostgREST {a} -> Postrust {b}   {k}")
+
+print("\nagreement by spec file (status + body), worst first")
+by = collections.defaultdict(lambda: [0, 0])
+for r in rows:
+    by[r["spec"]][0] += 1
+    if r["status_ok"] and r["body_ok"]:
+        by[r["spec"]][1] += 1
+for spec, (t, p) in sorted(by.items(), key=lambda kv: (kv[1][1] / kv[1][0], -kv[1][0])):
+    if t >= 5:
+        print(f"  {100*p/t:5.1f}%  {p:>4}/{t:<4} {'#' * round(16 * p / t):<16} {spec}")
+
+json.dump(rows, open(OUT, "w"), indent=1)
+print(f"\nper-case detail: {OUT}")

--- a/scripts/conformance/run.py
+++ b/scripts/conformance/run.py
@@ -48,7 +48,17 @@ def send(c):
     # servers need one to parse them, and PostgREST's own default is JSON.
     if body and not any(h[0].lower() == "content-type" for h in c["headers"]):
         req.add_header("Content-Type", "application/json")
+    # `add_header` overwrites, so a case sending the same header twice --
+    # `Prefer: return=representation` and `Prefer: resolution=merge-duplicates`
+    # are separate headers in the spec suite -- would reach the server as only
+    # the last of them. Combining them into one comma-separated value is what
+    # RFC 7230 says a recipient may do, and it is the only spelling `urllib`
+    # can send.
+    combined = {}
     for name, value in c["headers"]:
+        key = name.lower()
+        combined[key] = f"{combined[key]}, {value}" if key in combined else value
+    for name, value in combined.items():
         req.add_header(name, value)
 
     rec = {k: c[k] for k in ("id", "spec", "method", "path", "mutating")}

--- a/scripts/conformance/run.py
+++ b/scripts/conformance/run.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+Replay extracted PostgREST cases against one server and record raw responses.
+
+Every case must start from the same database state, or one divergence
+cascades into phantom failures in everything after it. Reads cannot disturb
+that state, so they run first as a block. Each mutating case then gets the
+fixture data restored immediately before it.
+
+The restore reloads `data.sql` only. That file is data-only -- it truncates
+and re-inserts, with no DDL -- so object OIDs never change and neither server
+needs restarting to drop a stale schema cache.
+"""
+import json
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+
+CASES, BASE, OUT = sys.argv[1], sys.argv[2].rstrip("/"), sys.argv[3]
+# Optional: a shell command that restores the fixture data in place.
+RESET_CMD = sys.argv[4] if len(sys.argv) > 4 else None
+
+cases = json.load(open(CASES))
+reads = [c for c in cases if not c["mutating"]]
+writes = [c for c in cases if c["mutating"]]
+
+
+def encode_path(p):
+    """hspec-wai accepts raw spaces in a URL; urllib does not. Encode only the
+    characters that are illegal on the wire, leaving PostgREST's query syntax
+    (parens, commas, stars, dots) untouched."""
+    return "".join("%%%02X" % ord(ch) if ch == " " or ord(ch) < 0x21 else ch for ch in p)
+
+
+def reset():
+    if RESET_CMD:
+        subprocess.run(RESET_CMD, shell=True, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def send(c):
+    url = BASE + encode_path(c["path"])
+    body = c["body"].encode() if c["body"] else None
+    req = urllib.request.Request(url, data=body, method=c["method"])
+    # hspec-wai sends JSON bodies without an explicit content type; both
+    # servers need one to parse them, and PostgREST's own default is JSON.
+    if body and not any(h[0].lower() == "content-type" for h in c["headers"]):
+        req.add_header("Content-Type", "application/json")
+    for name, value in c["headers"]:
+        req.add_header(name, value)
+
+    rec = {k: c[k] for k in ("id", "spec", "method", "path", "mutating")}
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            rec.update(status=r.status,
+                       headers={k.lower(): v for k, v in r.headers.items()},
+                       body=r.read().decode("utf-8", "replace"))
+    except urllib.error.HTTPError as e:
+        rec.update(status=e.code,
+                   headers={k.lower(): v for k, v in e.headers.items()},
+                   body=e.read().decode("utf-8", "replace"))
+    except Exception as e:                       # connection reset, timeout, ...
+        rec.update(status=None, headers={}, body="",
+                   error=f"{type(e).__name__}: {e}")
+    return rec
+
+
+results = []
+t0 = time.time()
+
+# Reads first, from one pristine load: none of them can disturb the others.
+reset()
+for n, c in enumerate(reads, 1):
+    results.append(send(c))
+    if n % 250 == 0:
+        print(f"  reads  {n}/{len(reads)}  ({time.time() - t0:.0f}s)", flush=True)
+
+# Then writes, each from a freshly restored copy of the same data.
+for n, c in enumerate(writes, 1):
+    reset()
+    results.append(send(c))
+    if n % 50 == 0:
+        print(f"  writes {n}/{len(writes)}  ({time.time() - t0:.0f}s)", flush=True)
+
+json.dump(results, open(OUT, "w"))
+errs = sum(1 for r in results if r["status"] is None)
+print(f"done: {len(results)} requests "
+      f"({len(reads)} read, {len(writes)} write), "
+      f"{errs} transport failures, {time.time() - t0:.0f}s")

--- a/scripts/conformance/run.py
+++ b/scripts/conformance/run.py
@@ -30,8 +30,20 @@ writes = [c for c in cases if c["mutating"]]
 def encode_path(p):
     """hspec-wai accepts raw spaces in a URL; urllib does not. Encode only the
     characters that are illegal on the wire, leaving PostgREST's query syntax
-    (parens, commas, stars, dots) untouched."""
-    return "".join("%%%02X" % ord(ch) if ch == " " or ord(ch) < 0x21 else ch for ch in p)
+    (parens, commas, stars, dots) untouched.
+
+    `#` is encoded too, and for a different reason: urllib reads it as starting
+    a fragment and drops it and everything after it, so
+    `?select=data->!@#$%^&*_d` reached both servers as `?select=data->!@`.
+    They agreed, on a request neither spec wrote. A fragment is a client-side
+    notion that never appears in a request target, so the character is a
+    literal here and `%23` is how urllib can be made to send one.
+
+    Both servers percent-decode the query, so `%23` arrives as `#` at the
+    parser -- which is what the case means. What it does not exercise is a raw
+    `#` on the wire; that needs a client that writes its own request line.
+    """
+    return "".join("%%%02X" % ord(ch) if ch in " #" or ord(ch) < 0x21 else ch for ch in p)
 
 
 def reset():

--- a/scripts/gen-conformance.mjs
+++ b/scripts/gen-conformance.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Generates website/src/data/conformance.ts from a conformance run's diff.json.
+//
+// As with gen-measured.mjs: the website never has numbers typed into it by
+// hand. What is published is what was measured, and it is recomputed here from
+// the per-case detail rather than scraped from report.py's printed summary, so
+// the page and the report cannot drift apart.
+//
+// Usage:
+//   node scripts/gen-conformance.mjs scripts/conformance/.work/diff.json
+//
+// What was measured is read from run-meta.json beside the diff, written by
+// conformance.sh -- not from arguments, because a run measured with the wrong
+// build features produces a number that looks exactly like a good one.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const OUT = join(here, "..", "website", "src", "data", "conformance.ts");
+
+const argv = process.argv.slice(2);
+const positional = argv.filter((a) => !a.startsWith("--"));
+
+if (positional.length === 0) {
+  console.error("usage: node scripts/gen-conformance.mjs <diff.json>");
+  process.exit(1);
+}
+
+const rows = JSON.parse(readFileSync(positional[0], "utf8"));
+if (!Array.isArray(rows) || rows.length === 0) {
+  console.error(`${positional[0]} holds no cases`);
+  process.exit(1);
+}
+
+// The same four levels report.py prints, computed the same way. A single
+// systemic gap -- one header never emitted -- would otherwise sink every case
+// and hide the hundreds that differ in nothing else.
+const LEVELS = [
+  ["status", (r) => r.status_ok],
+  ["statusAndBody", (r) => r.status_ok && r.body_ok],
+  ["exceptContentRange", (r) => r.status_ok && r.body_ok && r.hdr_ok_excl_range],
+  ["fullContract", (r) => r.status_ok && r.body_ok && r.hdr_ok],
+];
+
+const score = (subset) => {
+  const out = { cases: subset.length };
+  for (const [name, ok] of LEVELS) {
+    const passed = subset.filter(ok).length;
+    out[name] = {
+      passed,
+      pct: subset.length ? Number(((100 * passed) / subset.length).toFixed(1)) : 0,
+    };
+  }
+  return out;
+};
+
+const groups = {
+  all: score(rows),
+  reads: score(rows.filter((r) => !r.mutating)),
+  writes: score(rows.filter((r) => r.mutating)),
+};
+
+// Which specs are furthest from agreement, for anyone wanting to know where
+// the remaining failures actually live rather than just how many there are.
+const bySpec = new Map();
+for (const r of rows) {
+  const e = bySpec.get(r.spec) ?? { total: 0, passed: 0 };
+  e.total += 1;
+  if (r.status_ok && r.body_ok) e.passed += 1;
+  bySpec.set(r.spec, e);
+}
+const worstSpecs = [...bySpec.entries()]
+  .filter(([, e]) => e.total >= 5)
+  .map(([spec, e]) => ({
+    spec,
+    total: e.total,
+    passed: e.passed,
+    pct: Number(((100 * e.passed) / e.total).toFixed(1)),
+  }))
+  .sort((a, b) => a.pct - b.pct || b.total - a.total)
+  .slice(0, 8);
+
+// Provenance comes from the run itself, not from what was typed on this
+// command line. conformance.sh writes run-meta.json beside diff.json with the
+// features it built, the reference version it measured against, and the commit
+// it was measuring -- the things that decide whether a number means anything.
+//
+// Run 4's diff.json is the reason this is not a flag. It was measured with a
+// binary that `cargo test --workspace` had quietly rebuilt without
+// `compat-key-order`, and nothing in the file says so; a `--features` flag
+// would have stamped it as correct.
+const metaPath = join(dirname(positional[0]), "run-meta.json");
+let runMeta;
+try {
+  runMeta = JSON.parse(readFileSync(metaPath, "utf8"));
+} catch {
+  console.error(
+    `error: ${metaPath} not found.\n` +
+      "       It records what was actually built and measured, and without it\n" +
+      "       there is no way to tell a good run from one measured with the\n" +
+      "       wrong binary. Re-run scripts/conformance/conformance.sh.",
+  );
+  process.exit(1);
+}
+
+if (!String(runMeta.features ?? "").includes("compat-key-order")) {
+  console.error(
+    "error: this run was measured without compat-key-order, so its object\n" +
+      "       key order -- and every CSV column order case -- diverged for a\n" +
+      "       reason that is not a bug. Not publishable.",
+  );
+  process.exit(1);
+}
+
+const meta = {
+  postgrest: runMeta.postgrest,
+  features: runMeta.features,
+  compatMode: runMeta.compatMode ?? true,
+  commit: runMeta.commit,
+  measured: runMeta.measured,
+  cases: rows.length,
+};
+
+const body = `// GENERATED FILE -- do not edit by hand.
+//
+// Produced by scripts/gen-conformance.mjs from a conformance run's diff.json.
+// Regenerate with:
+//
+//   scripts/conformance/conformance.sh
+//   node scripts/gen-conformance.mjs scripts/conformance/.work/diff.json
+//
+// Every figure here is a replay of PostgREST's own test cases against both
+// servers on identically loaded fixture databases, diffed against PostgREST's
+// live response. See docs/postgrest-conformance.md.
+
+export interface Level {
+  passed: number;
+  pct: number;
+}
+
+export interface Group {
+  cases: number;
+  /** Status code only. */
+  status: Level;
+  /** Status and body, compared as parsed JSON. */
+  statusAndBody: Level;
+  /** The above plus every compared header except Content-Range. */
+  exceptContentRange: Level;
+  /** Status, body, and all six compared headers. */
+  fullContract: Level;
+}
+
+/**
+ * The headers that count. Date, Server and Connection differ between any two
+ * servers and say nothing about conformance, so they are not compared.
+ */
+export const comparedHeaders = [
+  "Content-Type",
+  "Content-Range",
+  "Location",
+  "Preference-Applied",
+  "Allow",
+  "WWW-Authenticate",
+] as const;
+
+export const conformanceMeta = ${JSON.stringify(meta, null, 2)} as const;
+
+export const conformance: Record<"all" | "reads" | "writes", Group> = ${JSON.stringify(
+  groups,
+  null,
+  2,
+)};
+
+/** Where the remaining disagreement lives, worst first. */
+export const worstSpecs = ${JSON.stringify(worstSpecs, null, 2)};
+`;
+
+writeFileSync(OUT, body);
+console.log(`wrote ${OUT}`);
+console.log(
+  `  ${meta.cases} cases: ${groups.all.statusAndBody.pct}% status+body, ` +
+    `${groups.all.fullContract.pct}% full contract`,
+);

--- a/website/src/components/layout/footer.tsx
+++ b/website/src/components/layout/footer.tsx
@@ -17,6 +17,7 @@ export const Footer = component$(() => {
       { href: "/docs/api-reference", label: "API Reference" },
       { href: "/packages", label: "Packages" },
       { href: "/docs/benchmarks", label: "Benchmarks" },
+      { href: "/docs/conformance", label: "PostgREST Conformance" },
       { href: "/docs/deployment", label: "Deployment" },
     ],
     community: [

--- a/website/src/components/sections/hero.tsx
+++ b/website/src/components/sections/hero.tsx
@@ -31,8 +31,14 @@ export const HeroSection = component$(() => {
           {/* Subheadline */}
           <p class="text-lg md:text-xl text-neutral-600 max-w-2xl mx-auto mb-10">
             High-performance REST & GraphQL API server for PostgreSQL,
-            written in Rust. Native AWS Lambda support with ~50ms cold starts.
-            Drop-in PostgREST replacement.
+            written in Rust. Native AWS Lambda support with ~50ms cold starts.{" "}
+            <Link
+              href="/docs/conformance"
+              class="underline decoration-neutral-300 underline-offset-4 hover:decoration-primary-600 hover:text-primary-700"
+            >
+              Drop-in PostgREST replacement
+            </Link>
+            .
           </p>
 
           {/* CTAs */}

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -65,7 +65,7 @@ export const comparisons: Comparison[] = [
     versionTested: "v16.1",
     intro: [
       "PostgREST is the project that established this idea: point a server at a PostgreSQL schema and get a REST API, with permissions left to the database. Postrust follows its URL grammar deliberately, so `?select=`, `?order=`, the filter operators and the `Prefer` headers mean the same thing in both.",
-      "How closely is measured rather than asserted: replaying PostgREST's own test cases against both servers gives 96.1% agreement on status and body, and 94.3% once every header that is part of the answer is compared too. The [conformance report](/docs/conformance) says what that covers and where the two differ on purpose.",
+      "How closely is measured rather than asserted: replaying PostgREST's own test cases against both servers gives 96.7% agreement on status and body, and 94.9% once every header that is part of the answer is compared too. The [conformance report](/docs/conformance) says what that covers and where the two differ on purpose.",
       "The differences are not in the query language. They are in what ships in the process and what the deployment looks like.",
     ],
     features: [

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -65,6 +65,7 @@ export const comparisons: Comparison[] = [
     versionTested: "v16.1",
     intro: [
       "PostgREST is the project that established this idea: point a server at a PostgreSQL schema and get a REST API, with permissions left to the database. Postrust follows its URL grammar deliberately, so `?select=`, `?order=`, the filter operators and the `Prefer` headers mean the same thing in both.",
+      "How closely is measured rather than asserted: replaying PostgREST's own test cases against both servers gives 96.1% agreement on status and body, and 94.3% once every header that is part of the answer is compared too. The [conformance report](/docs/conformance) says what that covers and where the two differ on purpose.",
       "The differences are not in the query language. They are in what ships in the process and what the deployment looks like.",
     ],
     features: [
@@ -125,10 +126,13 @@ export const comparisons: Comparison[] = [
     migration: [
       "The URL grammar is the same, so existing query strings generally work unchanged.",
       "Configuration uses the same `PGRST_*` environment variable names, including `PGRST_DB_ANON_ROLE` and `PGRST_JWT_SECRET`.",
-      "Tables are mounted under `/api` by default rather than at the root. Check your base URL before assuming a 404 is something worse.",
+      "Tables are mounted under `/api` by default rather than at the root. Check your base URL before assuming a 404 is something worse. CORS preflight and the `Allow` header work at both mounts.",
       "NUMERIC columns come back as JSON numbers, as they do from PostgREST, though the scale can differ: 4.2000 where PostgREST gives 4.20. Both parse to the same value.",
       "Object keys come back alphabetically rather than in select order. Build with the compat-key-order feature to match PostgREST; it is off by default because it costs up to 15% on wide rows.",
-      "Verify the specific PostgREST features you depend on against Postrust's test suite before switching anything that matters.",
+      "`Location` is sent only for `Prefer: return=headers-only`, as PostgREST sends it. A caller taking the row back reads the key out of the body.",
+      "`Prefer: tx=rollback` is not implemented. It is no longer reported as applied either, which it briefly was while committing the write.",
+      "Postrust allows 30 seconds of clock skew on a token's `nbf` and `iat`, and none on its `exp`. PostgREST checks all three to the second.",
+      "Verify the specific PostgREST features you depend on against Postrust's test suite before switching anything that matters. The conformance report says what is measured and where the two disagree on purpose.",
     ],
     faq: [
       {

--- a/website/src/data/conformance.ts
+++ b/website/src/data/conformance.ts
@@ -1,0 +1,162 @@
+// GENERATED FILE -- do not edit by hand.
+//
+// Produced by scripts/gen-conformance.mjs from a conformance run's diff.json.
+// Regenerate with:
+//
+//   scripts/conformance/conformance.sh
+//   node scripts/gen-conformance.mjs scripts/conformance/.work/diff.json
+//
+// Every figure here is a replay of PostgREST's own test cases against both
+// servers on identically loaded fixture databases, diffed against PostgREST's
+// live response. See docs/postgrest-conformance.md.
+
+export interface Level {
+  passed: number;
+  pct: number;
+}
+
+export interface Group {
+  cases: number;
+  /** Status code only. */
+  status: Level;
+  /** Status and body, compared as parsed JSON. */
+  statusAndBody: Level;
+  /** The above plus every compared header except Content-Range. */
+  exceptContentRange: Level;
+  /** Status, body, and all six compared headers. */
+  fullContract: Level;
+}
+
+/**
+ * The headers that count. Date, Server and Connection differ between any two
+ * servers and say nothing about conformance, so they are not compared.
+ */
+export const comparedHeaders = [
+  "Content-Type",
+  "Content-Range",
+  "Location",
+  "Preference-Applied",
+  "Allow",
+  "WWW-Authenticate",
+] as const;
+
+export const conformanceMeta = {
+  "postgrest": "v16.1",
+  "features": "admin-ui,compat-key-order",
+  "compatMode": true,
+  "commit": "e38770f33f3ab6dab464177234e1dff77648996b",
+  "measured": "2026-08-29",
+  "cases": 1499
+} as const;
+
+export const conformance: Record<"all" | "reads" | "writes", Group> = {
+  "all": {
+    "cases": 1499,
+    "status": {
+      "passed": 1472,
+      "pct": 98.2
+    },
+    "statusAndBody": {
+      "passed": 1440,
+      "pct": 96.1
+    },
+    "exceptContentRange": {
+      "passed": 1417,
+      "pct": 94.5
+    },
+    "fullContract": {
+      "passed": 1413,
+      "pct": 94.3
+    }
+  },
+  "reads": {
+    "cases": 1068,
+    "status": {
+      "passed": 1045,
+      "pct": 97.8
+    },
+    "statusAndBody": {
+      "passed": 1021,
+      "pct": 95.6
+    },
+    "exceptContentRange": {
+      "passed": 1003,
+      "pct": 93.9
+    },
+    "fullContract": {
+      "passed": 1002,
+      "pct": 93.8
+    }
+  },
+  "writes": {
+    "cases": 431,
+    "status": {
+      "passed": 427,
+      "pct": 99.1
+    },
+    "statusAndBody": {
+      "passed": 419,
+      "pct": 97.2
+    },
+    "exceptContentRange": {
+      "passed": 414,
+      "pct": 96.1
+    },
+    "fullContract": {
+      "passed": 411,
+      "pct": 95.4
+    }
+  }
+};
+
+/** Where the remaining disagreement lives, worst first. */
+export const worstSpecs = [
+  {
+    "spec": "Query/ComputedRelsSpec.hs",
+    "total": 30,
+    "passed": 22,
+    "pct": 73.3
+  },
+  {
+    "spec": "Query/RelatedQueriesSpec.hs",
+    "total": 36,
+    "passed": 33,
+    "pct": 91.7
+  },
+  {
+    "spec": "Query/Preferences/MaxAffectedSpec.hs",
+    "total": 13,
+    "passed": 12,
+    "pct": 92.3
+  },
+  {
+    "spec": "Query/SpreadQueriesSpec.hs",
+    "total": 56,
+    "passed": 52,
+    "pct": 92.9
+  },
+  {
+    "spec": "Query/EmbedDisambiguationSpec.hs",
+    "total": 58,
+    "passed": 54,
+    "pct": 93.1
+  },
+  {
+    "spec": "Query/CustomMediaSpec.hs",
+    "total": 50,
+    "passed": 47,
+    "pct": 94
+  },
+  {
+    "spec": "Query/EmbedInnerJoinSpec.hs",
+    "total": 57,
+    "passed": 54,
+    "pct": 94.7
+  },
+  {
+    "spec": "Query/QuerySpec.hs",
+    "total": 301,
+    "passed": 286,
+    "pct": 95
+  }
+];

--- a/website/src/data/conformance.ts
+++ b/website/src/data/conformance.ts
@@ -44,7 +44,7 @@ export const conformanceMeta = {
   "postgrest": "v16.1",
   "features": "admin-ui,compat-key-order",
   "compatMode": true,
-  "commit": "e38770f33f3ab6dab464177234e1dff77648996b",
+  "commit": "c3026ad955b8ddcbfe5054431dae30a187ae8d1c",
   "measured": "2026-08-29",
   "cases": 1499
 } as const;
@@ -53,70 +53,64 @@ export const conformance: Record<"all" | "reads" | "writes", Group> = {
   "all": {
     "cases": 1499,
     "status": {
-      "passed": 1472,
-      "pct": 98.2
+      "passed": 1478,
+      "pct": 98.6
     },
     "statusAndBody": {
-      "passed": 1440,
-      "pct": 96.1
+      "passed": 1450,
+      "pct": 96.7
     },
     "exceptContentRange": {
-      "passed": 1417,
-      "pct": 94.5
+      "passed": 1427,
+      "pct": 95.2
     },
     "fullContract": {
-      "passed": 1413,
-      "pct": 94.3
+      "passed": 1423,
+      "pct": 94.9
     }
   },
   "reads": {
     "cases": 1068,
     "status": {
-      "passed": 1045,
-      "pct": 97.8
+      "passed": 1052,
+      "pct": 98.5
     },
     "statusAndBody": {
-      "passed": 1021,
-      "pct": 95.6
+      "passed": 1028,
+      "pct": 96.3
     },
     "exceptContentRange": {
-      "passed": 1003,
-      "pct": 93.9
+      "passed": 1010,
+      "pct": 94.6
     },
     "fullContract": {
-      "passed": 1002,
-      "pct": 93.8
+      "passed": 1009,
+      "pct": 94.5
     }
   },
   "writes": {
     "cases": 431,
     "status": {
-      "passed": 427,
-      "pct": 99.1
+      "passed": 426,
+      "pct": 98.8
     },
     "statusAndBody": {
-      "passed": 419,
-      "pct": 97.2
+      "passed": 422,
+      "pct": 97.9
     },
     "exceptContentRange": {
-      "passed": 414,
-      "pct": 96.1
+      "passed": 417,
+      "pct": 96.8
     },
     "fullContract": {
-      "passed": 411,
-      "pct": 95.4
+      "passed": 414,
+      "pct": 96.1
     }
   }
 };
 
 /** Where the remaining disagreement lives, worst first. */
 export const worstSpecs = [
-  {
-    "spec": "Query/ComputedRelsSpec.hs",
-    "total": 30,
-    "passed": 22,
-    "pct": 73.3
-  },
   {
     "spec": "Query/RelatedQueriesSpec.hs",
     "total": 36,
@@ -142,12 +136,6 @@ export const worstSpecs = [
     "pct": 93.1
   },
   {
-    "spec": "Query/CustomMediaSpec.hs",
-    "total": 50,
-    "passed": 47,
-    "pct": 94
-  },
-  {
     "spec": "Query/EmbedInnerJoinSpec.hs",
     "total": 57,
     "passed": 54,
@@ -158,5 +146,17 @@ export const worstSpecs = [
     "total": 301,
     "passed": 286,
     "pct": 95
+  },
+  {
+    "spec": "Query/UpsertSpec.hs",
+    "total": 60,
+    "passed": 57,
+    "pct": 95
+  },
+  {
+    "spec": "Query/InsertSpec.hs",
+    "total": 82,
+    "passed": 78,
+    "pct": 95.1
   }
 ];

--- a/website/src/routes/docs/api-reference/index.tsx
+++ b/website/src/routes/docs/api-reference/index.tsx
@@ -141,7 +141,7 @@ GET /orders?select=*,customer!inner(*)&customer.country=eq.US`}</code>
             <div class="space-y-4">
               {[
                 { header: "return=representation", desc: "Return created/updated records in response" },
-                { header: "return=headers-only", desc: "Return only headers (for count)" },
+                { header: "return=headers-only", desc: "No body. The only case that gets a Location header naming the created row." },
                 { header: "count=exact", desc: "Include exact row count in response" },
                 { header: "resolution=merge-duplicates", desc: "Upsert (insert or update)" },
               ].map((item) => (
@@ -153,6 +153,55 @@ GET /orders?select=*,customer!inner(*)&customer.country=eq.US`}</code>
                 </div>
               ))}
             </div>
+          </section>
+
+          {/* Response headers */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">Response Headers</h2>
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="border-b border-neutral-200">
+                    <th class="text-left py-2 pr-4 font-semibold text-neutral-900">Header</th>
+                    <th class="text-left py-2 pr-4 font-semibold text-neutral-900">When</th>
+                    <th class="text-left py-2 font-semibold text-neutral-900">Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[
+                    ["Content-Range", "Reads, and writes reporting a count", "The window returned and the total: 0-24/100"],
+                    ["Range-Unit", "With Content-Range", "Always items"],
+                    ["Location", "POST with Prefer: return=headers-only", "The created row's key: /users?id=eq.42"],
+                    ["Preference-Applied", "When a Prefer was honoured", "The preferences actually applied"],
+                    ["Allow", "OPTIONS", "The methods this resource answers"],
+                    ["WWW-Authenticate", "401", "Bearer, plus what was wrong with a token that was read and refused"],
+                  ].map(([header, when, desc]) => (
+                    <tr key={header} class="border-b border-neutral-100">
+                      <td class="py-2 pr-4"><code class="font-mono text-primary-700">{header}</code></td>
+                      <td class="py-2 pr-4 text-neutral-500">{when}</td>
+                      <td class="py-2 text-neutral-600">{desc}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* OPTIONS */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">OPTIONS and Allow</h2>
+            <p class="text-neutral-600 mb-4">
+              <code class="font-mono">OPTIONS</code> reports what a resource actually answers,
+              derived from the schema rather than fixed. A table offers what its grants allow; a
+              view offers what PostgreSQL can genuinely write through it, which is not the same as
+              what it has been granted. <code class="font-mono">PUT</code> replaces one row named
+              by its key, so a relation without a primary key does not offer it however writable
+              it otherwise is. A <code class="font-mono">VOLATILE</code> function is{" "}
+              <code class="font-mono">OPTIONS,POST</code>; a stable one adds{" "}
+              <code class="font-mono">GET,HEAD</code>.
+            </p>
+            <pre class="bg-neutral-900 text-neutral-100 rounded-lg p-4 text-sm overflow-x-auto"><code>{`curl -i -X OPTIONS http://localhost:3000/api/users
+# Allow: OPTIONS,GET,HEAD,POST,PUT,PATCH,DELETE`}</code></pre>
           </section>
 
           {/* Next */}

--- a/website/src/routes/docs/authentication/index.tsx
+++ b/website/src/routes/docs/authentication/index.tsx
@@ -53,6 +53,47 @@ export default component$(() => {
             </div>
           </section>
 
+          {/* How claims are checked */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">How the claims are checked</h2>
+            <p class="text-neutral-600 mb-4">
+              A claim that is absent is not a claim that is wrong: a token carrying no{" "}
+              <code class="font-mono">exp</code> does not expire, and one carrying no{" "}
+              <code class="font-mono">aud</code> is for anybody. Only a claim that is present and
+              is not the kind of thing that claim is gets rejected.
+            </p>
+            <ul class="space-y-3 text-neutral-600">
+              <li class="flex gap-3">
+                <span class="text-primary-600 font-mono text-sm mt-0.5">exp</span>
+                <span>
+                  Checked to the second. Forgiving an expiry keeps a session alive past the moment
+                  its issuer said it ended, so no slack is given here.
+                </span>
+              </li>
+              <li class="flex gap-3">
+                <span class="text-primary-600 font-mono text-sm mt-0.5">nbf, iat</span>
+                <span>
+                  Thirty seconds of clock skew allowed. These describe a token that is not valid
+                  yet, and a client whose clock runs slightly fast mints one through nobody's
+                  fault; refusing it makes a working deployment fail intermittently.
+                </span>
+              </li>
+              <li class="flex gap-3">
+                <span class="text-primary-600 font-mono text-sm mt-0.5">role</span>
+                <span>
+                  Must be a string. A role claim of any other shape names no role and falls back to
+                  the anonymous role, rather than asking PostgreSQL for a role of that spelling.
+                </span>
+              </li>
+            </ul>
+            <p class="text-neutral-600 mt-4">
+              A <code class="font-mono">401</code> names which refusal in its{" "}
+              <code class="font-mono">WWW-Authenticate</code> challenge, so a client can tell
+              &ldquo;rotate your key&rdquo; from &ldquo;fix your clock&rdquo; without reading the
+              body.
+            </p>
+          </section>
+
           {/* Configuration */}
           <section class="mb-12">
             <h2 class="text-2xl font-bold text-neutral-900 mb-4">Configuration</h2>

--- a/website/src/routes/docs/conformance/index.tsx
+++ b/website/src/routes/docs/conformance/index.tsx
@@ -1,0 +1,251 @@
+import { component$ } from "@builder.io/qwik";
+import type { DocumentHead } from "@builder.io/qwik-city";
+import { Link } from "@builder.io/qwik-city";
+import {
+  conformance,
+  conformanceMeta,
+  comparedHeaders,
+  worstSpecs,
+} from "~/data/conformance";
+
+const groups = [
+  { key: "all" as const, label: "All cases" },
+  { key: "reads" as const, label: "Reads (GET, HEAD, OPTIONS)" },
+  { key: "writes" as const, label: "Writes (POST, PATCH, PUT, DELETE)" },
+];
+
+const levels = [
+  { key: "status" as const, label: "Status code" },
+  { key: "statusAndBody" as const, label: "Status and body" },
+  { key: "exceptContentRange" as const, label: "…and headers, except Content-Range" },
+  { key: "fullContract" as const, label: "Full contract" },
+];
+
+const divergences = [
+  {
+    title: "PostgREST truncates a select at a stray )",
+    body: "Probed against the reference directly: /clients?select=id)ZZ,nameQQ returns 200 and nameQQ never becomes a column. Everything after the paren is discarded silently. Postrust rejects it, because matching this means reintroducing a bug that was fixed on purpose — select=id, name, billing(address) used to return the id alone.",
+  },
+  {
+    title: "Two upsert status codes",
+    body: "POST with an empty body, and a PUT that replaced an existing row, return 201 where PostgREST returns 200. The evidence is one case each, against 58 that pass.",
+  },
+  {
+    title: "Unspecified row order",
+    body: "Two cases return the same rows in a different order, and neither request specifies order=. SQL guarantees nothing there, so both answers are correct and the measurement is over-reporting.",
+  },
+  {
+    title: "Clock skew on nbf and iat, and none on exp",
+    body: "PostgREST checks all three to the second. Postrust allows thirty seconds on the two that describe a token not yet valid, and none on the one that describes a token withdrawn — forgiving an expiry keeps a session alive past the moment its issuer ended it.",
+  },
+];
+
+export default component$(() => {
+  return (
+    <div class="min-h-screen bg-white">
+      <div class="bg-gradient-to-b from-neutral-50 to-white border-b border-neutral-200">
+        <div class="container-wide py-12">
+          <div class="flex items-center gap-2 text-sm text-neutral-500 mb-4">
+            <Link href="/docs" class="hover:text-primary-600">Docs</Link>
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+            </svg>
+            <span class="text-neutral-900">PostgREST Conformance</span>
+          </div>
+          <h1 class="text-4xl font-bold text-neutral-900 mb-4">PostgREST conformance</h1>
+          <p class="text-lg text-neutral-600 max-w-2xl">
+            How closely the two agree, measured by replaying PostgREST&rsquo;s own test cases
+            against both servers and diffing the live responses.
+          </p>
+        </div>
+      </div>
+
+      <div class="container-wide py-12">
+        <div class="max-w-3xl">
+          {/* Numbers */}
+          <section class="mb-12">
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="border-b border-neutral-200">
+                    <th class="text-left py-2 pr-4 font-semibold text-neutral-900">Compared on</th>
+                    {groups.map((g) => (
+                      <th key={g.key} class="text-right py-2 pl-4 font-semibold text-neutral-900">
+                        {g.label}
+                        <span class="block font-normal text-neutral-400">
+                          {conformance[g.key].cases} cases
+                        </span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {levels.map((l) => (
+                    <tr key={l.key} class="border-b border-neutral-100">
+                      <td class="py-3 pr-4 text-neutral-600">{l.label}</td>
+                      {groups.map((g) => (
+                        <td key={g.key} class="py-3 pl-4 text-right">
+                          <span class="font-mono font-semibold text-neutral-900">
+                            {conformance[g.key][l.key].pct}%
+                          </span>
+                          <span class="block text-xs text-neutral-400">
+                            {conformance[g.key][l.key].passed}/{conformance[g.key].cases}
+                          </span>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p class="text-sm text-neutral-500 mt-4">
+              Measured {conformanceMeta.measured} against PostgREST{" "}
+              {conformanceMeta.postgrest}, on Postrust built with{" "}
+              <code class="font-mono">{conformanceMeta.features}</code> and running in
+              compatibility mode. Every figure is recomputed from the run&rsquo;s per-case output;
+              nothing on this page is typed by hand.
+            </p>
+          </section>
+
+          {/* What counts */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">What is compared</h2>
+            <p class="text-neutral-600 mb-4">
+              Agreement is reported at four strictness levels, because one systemic gap — a single
+              header never emitted — would otherwise sink every case and hide the hundreds that
+              differ in nothing else. The strictest is status, body, and these six headers:
+            </p>
+            <div class="flex flex-wrap gap-2 mb-4">
+              {comparedHeaders.map((h) => (
+                <code key={h} class="bg-neutral-100 text-neutral-800 px-2 py-1 rounded text-sm font-mono">
+                  {h}
+                </code>
+              ))}
+            </div>
+            <p class="text-neutral-600">
+              <code class="font-mono">Date</code>, <code class="font-mono">Server</code> and{" "}
+              <code class="font-mono">Connection</code> differ between any two servers and say
+              nothing about conformance, so they are not compared. Bodies are compared as parsed
+              JSON, which means object key order does not survive the comparison — but it does
+              survive into a CSV response, which puts its columns in key order.
+            </p>
+          </section>
+
+          {/* Method */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">How it is measured</h2>
+            <p class="text-neutral-600 mb-4">
+              PostgREST&rsquo;s spec suite cannot be pointed at another server: it drives the WAI
+              application in-process and imports its own config directly, so there is no HTTP
+              boundary to intercept. Two parts of it are reusable — the fixture database, around
+              280 tables of plain SQL, and the request literals inside the examples, each spelling
+              out a method, path, headers and body.
+            </p>
+            <p class="text-neutral-600 mb-4">
+              So the harness lifts those requests out of the Haskell and replays them over HTTP
+              against both stock PostgREST and Postrust, each on an identically loaded fixture
+              database, and diffs the live responses. The reference implementation is the oracle:
+              no hspec expectation is ever interpreted, which means a mistake in the extractor
+              shows up as a case both servers answer the same way rather than as a false failure.
+            </p>
+            <pre class="bg-neutral-900 text-neutral-100 rounded-lg p-4 text-sm overflow-x-auto"><code>{`scripts/conformance/conformance.sh`}</code></pre>
+          </section>
+
+          {/* Deliberate divergences */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">Where the two disagree on purpose</h2>
+            <p class="text-neutral-600 mb-6">
+              Some cases fail because PostgREST is wrong, or because neither answer is wrong. They
+              are listed so nobody later &ldquo;fixes&rdquo; one without deciding to.
+            </p>
+            <div class="space-y-4">
+              {divergences.map((d) => (
+                <div key={d.title} class="p-4 bg-neutral-50 rounded-lg">
+                  <h3 class="font-semibold text-neutral-900 mb-1">{d.title}</h3>
+                  <p class="text-sm text-neutral-600">{d.body}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {/* Where the rest lives */}
+          {worstSpecs.length > 0 && (
+            <section class="mb-12">
+              <h2 class="text-2xl font-bold text-neutral-900 mb-4">Where the remaining disagreement lives</h2>
+              <p class="text-neutral-600 mb-4">
+                By spec file, on status and body, worst first.
+              </p>
+              <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                  <thead>
+                    <tr class="border-b border-neutral-200">
+                      <th class="text-left py-2 pr-4 font-semibold text-neutral-900">Spec</th>
+                      <th class="text-right py-2 font-semibold text-neutral-900">Agreement</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {worstSpecs.map((s) => (
+                      <tr key={s.spec} class="border-b border-neutral-100">
+                        <td class="py-2 pr-4"><code class="font-mono text-neutral-700">{s.spec}</code></td>
+                        <td class="py-2 text-right">
+                          <span class="font-mono text-neutral-900">{s.pct}%</span>
+                          <span class="text-neutral-400"> ({s.passed}/{s.total})</span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )}
+
+          {/* Gaps */}
+          <section class="mb-12">
+            <h2 class="text-2xl font-bold text-neutral-900 mb-4">Known gaps</h2>
+            <p class="text-neutral-600 mb-4">
+              The largest is the OpenAPI document. PostgREST serves a 638 KB Swagger 2.0 document
+              at <code class="font-mono">/</code> — 428 paths, 273 definitions, 1035 parameters.
+              Postrust serves OpenAPI 3.0 for its own surface under{" "}
+              <code class="font-mono">/admin</code> and does not yet generate PostgREST&rsquo;s.
+              Bodies compare as exact JSON, so this is all-or-nothing rather than something to land
+              incrementally.
+            </p>
+            <p class="text-neutral-600">
+              Parse errors are the other: <code class="font-mono">?or=()</code> and some JSON-path
+              failures answer generically where PostgREST names the offending character.{" "}
+              <code class="font-mono">Prefer: tx=rollback</code> is not implemented, and is no
+              longer reported as applied.
+            </p>
+          </section>
+
+          <div class="flex items-center justify-between pt-8 border-t border-neutral-200">
+            <Link href="/docs/benchmarks" class="flex items-center gap-2 text-neutral-600 hover:text-primary-600">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+              </svg>
+              Benchmarks
+            </Link>
+            <Link href="/compare/postgrest" class="flex items-center gap-2 text-neutral-600 hover:text-primary-600">
+              Postrust vs PostgREST
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+              </svg>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+export const head: DocumentHead = {
+  title: "PostgREST Conformance - Postrust Documentation",
+  links: [{ rel: "canonical", href: "https://postrust.org/docs/conformance" }],
+  meta: [
+    {
+      name: "description",
+      content:
+        "How closely Postrust matches PostgREST, measured by replaying PostgREST's own test cases against both servers and diffing the live responses.",
+    },
+  ],
+};

--- a/website/src/routes/docs/index.tsx
+++ b/website/src/routes/docs/index.tsx
@@ -69,6 +69,13 @@ const docSections = [
     href: "/docs/benchmarks",
     icon: "chart",
   },
+  {
+    title: "PostgREST Conformance",
+    description:
+      "How closely the two agree, measured by replaying PostgREST's own test cases against both servers",
+    href: "/docs/conformance",
+    icon: "chart",
+  },
 ];
 
 const iconPaths: Record<string, string> = {


### PR DESCRIPTION
Measures this server's HTTP surface against PostgREST v16.1 by replaying
PostgREST's own test cases over HTTP at both servers, and closes the gaps that
turned up.

## What moved

Over 1499 replayed cases:

| | before | after |
|---|---|---|
| status + body | 90.3% | 96.7% |
| full contract | 83.0% | 94.9% |
| writes, full contract | 77.0% | 96.1% |

"Full contract" is status, body, and the six headers that are part of the
answer rather than of the transport: `Content-Type`, `Content-Range`,
`Location`, `Preference-Applied`, `Allow`, `WWW-Authenticate`. Not every
header -- `Date`, `Server` and `Connection` differ between any two servers and
say nothing about conformance.

## The harness measured itself wrong first

A differential harness measures two things at once and only one of them is the
server. Every fault in the instrument either invents work or hides it, and the
ones that hide it are indistinguishable from success. Five found here:

- **`db-extra-search-path` was never set.** Both servers answered "function
  does not exist" to every PostGIS and `isn` case, agreed perfectly, and an
  entire category scored as passing while measuring nothing.
- **Header literals kept their Haskell escapes**, so eight cases were replayed
  with a header the spec never wrote.
- **`cargo test --workspace` silently stripped the candidate's features.** It
  rebuilds the same `target/release/postrust` with default features and
  overwrites it, so *build, then test, then measure* measured a binary with
  neither `admin-ui` nor `compat-key-order`. The only visible sign was the file
  shrinking by 1.1 MB. The harness now builds the binary itself and asserts
  against the server's own startup warning.
- **The replay client dropped everything after a `#`.** `urllib` reads it as
  beginning a fragment, so `?select=data->!@#$%^&*_d` reached both servers as
  `?select=data->!@`. They agreed, on a request neither spec wrote -- and the
  `#` handling `lenient_uri.rs` documents at length was never exercised.
- **A case the candidate never answered was dropped from the denominator**,
  which can only move every percentage up. Counted and named now.

`scripts/conformance/FINDINGS.md` records these, and is the thing to read
before treating a failing case as a bug.

## Fixes

**Headers.** `Location` was sent on every insert; PostgREST sends it only for
`Prefer: return=headers-only` (9 of 9 with it, 0 of 67 without). `tx=` was
reported as applied while `Preferences::transaction` was written in three
places and read in none -- a client asking for a rollback was told its
preference was honoured and its write was committed. `Allow` was never sent at
all.

**An `OPTIONS` never reached the handler.** The CORS layer answers every
`OPTIONS` itself and never calls what it wraps, so the body was empty because
nothing built one and `Allow` was missing because the code that knows the
answer was never asked. Answered ahead of that layer now.

**A missing table was reported as a missing column.** `information_schema.tables`
lists every partition, so partitions were exposed as endpoints PostgREST does
not have, and naming one produced "Could not find the column" for a table that
was not there.

**Being granted INSERT on a view does not make it insertable.** Reading the
grant alone reported six methods for a view that answers three.

**A computed column could not name its own row.** The RPC call was left
unaliased, so `always_true(items)` over `FROM test.search(...)` was `column
"items" does not exist`; a mutation reads its rows out of a CTE, whose row is a
`record`, so an overloaded computed column could not be resolved.

**A computed relationship only worked where the row it needs was a table's.**
`ComputedRelsSpec` was the weakest spec at 22/30, in two clusters that are the
same sentence. Over a function, `?select=designer:computed_designers(name)`
answered `column "getallvideogames" does not exist`: aliasing the call `AS
<table>` (so a computed *column* could name its own row) moved the relation's
name, and the site that captures the parent row did not follow. After a
mutation the embed was dropped silently -- 201, well-formed body, the requested
thing absent -- because a mutation reads its rows from a CTE whose row type is
anonymous, and PostgreSQL will not cast a `record` to a composite. The row is
now taken inside the statement, where the table is still in scope and a bare
reference yields the composite, and carried out by `RETURNING`. 30/30.

**An order term was resolved one level up.** `OrderTerm::Relation` was matched
together with `OrderTerm::Field` and only its field kept, so
`tasks.order=projects(id).desc` ordered by `tasks.id` -- silently wrong where
the parent has a column of that name, and `column "cost" does not exist` where
it does not.

Also: composite-key junctions, junctions through views, `?columns=` and
JSON-path indices (both previously accepted as an empty or malformed name),
n-gram scoring for table suggestions, and parse detail for logic trees.

## What review of this branch then found

The last six commits are fixes for things the harness could not see, because
it runs one configuration and reads six headers.

**Every `OPTIONS` outside compatibility mode answered `404 PGRST125`**, CORS
headers stripped -- so a browser reported the whole API as blocked by CORS
rather than as anything it could go and fix. `Router::layer` wraps each
endpoint and `nest` puts its prefix-stripping *inside* that endpoint, so the
`Allow` middleware read `/api/items`, which names no table because a table is
one segment. Measured against fad5f83; `/api/*`, `/_/*`, `/admin/*` and
`/api/graphql` all affected. This is the reason FINDINGS.md now says out loud
that every number here is for compatibility mode.

**A `Range` header that did not begin at row 0 was silently ignored.**
`parse_range` matched the literal prefix `0-`; everything else fell through to
the default, so `Range: 1000-1999` returned the entire relation and a
`Content-Range` agreeing that was what had been asked for. Any range is read
now, plus open-ended `10-` and RFC-9110 `items=5-9`, and an inverted range is
`PGRST103` rather than all the rows. Underneath it, `?offset=0` could not be
told from no offset, so the query parameter could not beat the header the way
the rule says it does.

**JWT: thirty seconds of clock skew was allowed at both ends.** Forgiving
`nbf` and `iat` is the standard remedy for a clock nobody controls; forgiving
`exp` keeps a withdrawn token alive past the second its issuer ended it.
Checked to the second now. A role claim that was not a string was rendered
into one, so `"role": 42` asked PostgreSQL for a role named `42`.

**The lenient-URI adapter would have corrupted an HTTP/2 connection**, reading
its binary frames as request lines and percent-encoding the high-bit bytes
HPACK is full of. Not reachable today -- `hyper-util/http2` is off, so h2c is
refused before it starts -- but enabling that feature is the kind of thing
feature unification does without anyone deciding it, and the guard costs one
byte's comparison per connection.

## Docs and website

The last two commits carry the documentation, which turned up three places
where it described a server that did not exist:

- `Range: 100-149` was documented as working pagination. It returned the whole
  table.
- The response-header table listed `Content-Location`, which this server has
  never sent.
- `PGRST301` and `PGRST302` were swapped in the authentication docs, and
  `PGRST300` was undocumented.

New: `docs/postgrest-conformance.md` and a `/docs/conformance` page rendering
from generated data, an `OPTIONS`/`Allow` reference, and how JWT claims are
checked. `Drop-in PostgREST replacement` on the front page now links to the
report -- it was the one claim on the site with nothing behind it, and it can
be checked now rather than softened.

## Divergences kept on purpose

Documented with evidence in FINDINGS.md:

- **PostgREST truncates a select at a stray `)`.** Probed directly:
  `/clients?select=id)ZZ,nameQQ` returns 200 and `nameQQ` never becomes a
  column. Matching it means reintroducing what `f7c7b56` deliberately removed.
- **Upsert status codes** -- one data point each, against 58 passing cases.
- **Unspecified row order** -- two cases where neither request specifies
  `order=`, so both answers are correct and the measurement is over-reporting.
- **Clock skew on `nbf`/`iat` and none on `exp`**, per above. Costs no cases,
  which is exactly why it is written down.

## Still open

The OpenAPI document at `/` (6 cases): 638 KB, 428 paths, 273 definitions, 1035
parameters. Bodies compare as exact JSON, so a 95%-correct generator scores zero
on all six -- there is no partial credit and no incremental landing. Specced in
FINDINGS.md as its own change.

## For the reviewer

- The largest single commit is `060d4ee` (response headers); the rest are scoped
  by subsystem.
- `scripts/conformance/FINDINGS.md` is new and is where the reasoning for the
  deliberate divergences lives -- worth reading before "fixing" a failing case.
- Some commits carry changes that were already in the working tree when this work
  started (a `bytea` representation fix, a `jsonb` embed cast, `?or=` over
  embeds); they are described in their commit messages but are not part of this
  effort.
- **The percentages above are from run 9, which completed cleanly**: both
  halves, 1499 cases, zero transport failures, on a binary the harness built
  itself and then verified at runtime against the server's own startup warning.
  Its reference was re-recorded rather than reused, because the replay client
  changed. `scripts/conformance/.work/run-meta.json` records what produced it,
  and the generator that publishes these numbers refuses a run that cannot say.
