### PR TITLE
bench: fix what the harness measures, and withhold the numbers until they reproduce

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -29,9 +29,10 @@ All options are environment variables:
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `REQUESTS` | `3000` | Requests per scenario |
+| `REQUESTS` | `30000` | Requests per scenario |
 | `CONCURRENCY` | `50` | Concurrent connections |
-| `WARMUP` | `200` | Warm-up requests before measuring |
+| `WARMUP` | `500` | Warm-up requests before measuring |
+| `REPEATS` | `3` | Measurements per scenario; the median is reported |
 | `BENCH_FEATURES` | `admin-ui` | Cargo features to build. Set to `""` for a minimal build |
 | `PG_IMAGE` | `postgres:16-alpine` | PostgreSQL image |
 | `PG_PORT` | `55432` | Host port for the database |
@@ -52,6 +53,25 @@ BENCH_FEATURES="" ./scripts/bench.sh
 # Keep everything up afterwards to run your own queries
 KEEP=1 ./scripts/bench.sh
 ```
+
+## Why the window is 30,000 requests
+
+The default used to be 3,000, and that was too few to mean anything. At these
+throughputs 3,000 requests complete in about a third of a second, which samples
+connection setup and cache warmth rather than steady state. Repeating the
+measurement does not rescue it: five medians of a biased sample share the bias.
+
+It biased the comparison rather than merely widening it, because the servers do
+not warm up at the same rate. A short window flattered this one and penalised
+the GHC-based servers, which reach steady state later. Raising the window to
+30,000 cut run-to-run spread from 1.33x to 1.25x here and 1.39x to 1.17x for
+PostGraphile -- and moved several published ratios down by more than a factor
+of two.
+
+The harness also pauses every server it is not currently measuring
+(`docker pause`, so there is no cold start and no lost connection pool). Four
+servers competing for the same cores made the measurement a report on
+scheduling.
 
 ## What it measures
 
@@ -85,7 +105,7 @@ these as a shape to compare against, not a target — see the caveats below.
 ```
  host           : Darwin 25.2.0 arm64
  postgres       : postgres:18-alpine
- load generator : ab (n=3000, c=50)
+ load generator : ab (n=30000, c=50)
  dataset        : bench_items, 100000 rows
 
  binary         : 5220864 bytes (4.98 MiB), stripped: yes

--- a/scripts/BENCH-FINDINGS.md
+++ b/scripts/BENCH-FINDINGS.md
@@ -1,0 +1,98 @@
+# Benchmark findings
+
+What the comparison benchmark has been measuring, and why its numbers are not
+currently publishable. Newest first.
+
+## The measured throughput depends on when in a run it is taken
+
+**Status: reproduced, mechanism not identified. Numbers withheld.**
+
+The same server, in the same container, measured seconds apart, differs by
+about a factor of two:
+
+| | point lookup, postrust, alpine |
+|---|---|
+| reported by the harness | 5911 - 9731 rps |
+| measured by hand, same containers, seconds later | ~13000 rps |
+
+It is not the harness misreporting. `run_oha` was instrumented to print its own
+arguments: `-n 30000 -c 50`, correct URL, and the reported rate matches
+wall-clock (30000 / 5911 = 5.08s, and the next invocation begins 5.34s later).
+The server really is slower while the harness runs.
+
+Within a single run, later scenarios measure higher than earlier ones. In one
+run the REST scenarios warmed to a plateau of 6212 rps while the GraphQL
+scenarios, which run afterwards, warmed to 12631 -- same server, same process,
+same run. Whatever is measured first is the most understated, which makes
+scenario and target order a determinant of the published ratios.
+
+### Ruled out, each by direct test
+
+- **Thermal throttling and measurement order.** An ABBA design measuring each
+  server both first and second: postrust 12533/13025 first, 12443/13485
+  second. No advantage follows the slot.
+- **Host load.** The harness scored *higher* at load average 18 (9731) than at
+  load 5 (6291), while hand measurement held ~13000 at both.
+- **Cold database.** The tables are 16 MB + 33 MB against 128 MB of
+  `shared_buffers`, the fixtures `ANALYZE`, and the harness pre-warms with
+  `count(*)`.
+- **The bulk load and checkpointing.** Reloading 400k rows and forcing a
+  `CHECKPOINT` moved nothing: ~13000 before, after, and after the checkpoint.
+- **Server start-up.** A restarted server is at 12654 on its first sample.
+- **PostgreSQL start-up.** After restarting Postgres, 11657 then ~13000.
+- **`docker pause` and the other containers.** A single-target run, with
+  nothing to pause, is equally depressed (6506).
+- **`docker stats`.** Called once before and once after all measurements, never
+  between them.
+- **The harness's own measurement code.** Calling its `run_oha` directly on a
+  settled stack returns 12981, and replicating its full sequence by hand
+  (health check, warm both targets, isolate, measure) returns 12925.
+- **Docker Desktop port forwarding.** Same generator over both paths: from the
+  host 7226/8130/6711, from inside the network 6508/6070/7179. (`ab` is
+  client-bound near 7000 here, so this rules the path out without speaking to
+  the plateau `oha` reaches.)
+
+### Warm-to-plateau was tried and does not fix it
+
+Replacing the fixed 500-request warm-up with rounds that stop when a round
+fails to beat the previous by 3% changed nothing: 6899, against 6890 before.
+The round logging showed why -- warm-up ran 4 rounds (80,000 requests) and its
+final round measured 6212, matching the 6213 that was then recorded. The system
+climbs more slowly than 3% per round, so the loop declares a plateau at exactly
+the depressed value it was meant to escape. The change was reverted rather than
+shipped, because a warm-up that reports success at the wrong number is worse
+than an obviously too-short one.
+
+### Consequence
+
+Every performance figure this repository has published was produced with the
+500-request warm-up, inside this effect. They are not trustworthy at the
+absolute level, and the ratios inherit it, because there is no reason to expect
+four different servers to ramp at the same rate.
+
+Before publishing again: run the comparison on a machine with native Docker
+rather than a virtualised one, and confirm that a measurement repeated at the
+start and the end of a run agrees with itself.
+
+## The window was too short, and it was not symmetric noise
+
+The default was 3,000 requests per scenario, which completes in about a third
+of a second and samples connection setup and cache warmth rather than steady
+state. It did not merely add noise: the GHC-based servers reach steady state
+later, so a short window flattered this server and penalised them. Raising the
+window to 30,000 cut run-to-run spread from 1.33x to 1.25x here and 1.39x to
+1.17x for PostGraphile, and moved published ratios down by more than a factor
+of two -- point lookup against PostgREST went from 3.35x to 1.11x.
+
+Two passes agreeing is not evidence that the instrument is sound. Both passes
+run the same procedure, so a systematic bias reproduces perfectly and reads as
+precision.
+
+## The benchmark measured a different Hasura than conformance did
+
+The benchmark pinned `hasura/graphql-engine:v2.44.0` while the conformance
+harness measured v2.50.1, so two numbers about "Hasura" on the same website
+were not about the same Hasura. Now aligned on v2.50.1. Measured across four
+runs, v2.50.1 is about 7% slower than v2.44.0 on these scenarios (single row
+by pk 4441 -> 4090), so aligning the version moves this server's ratios up --
+a change that comes from the newer reference engine, not from any change here.

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -135,11 +135,18 @@ wants() {
 # Scenarios
 #
 # Each tool expresses the same request in its own dialect: PostgREST serves
-# tables at the root where Postrust mounts them under /api, and the two GraphQL
-# engines inflect field names differently (bench_items vs allBenchItems). The
+# tables at the root where Postrust mounts them under /api, and PostGraphile
+# inflects field names its own way (allBenchItems, benchItemByRowId). The
 # request being measured is the same; only the spelling differs. That is a
 # property of the tools, and is stated on the published comparison rather than
 # smoothed over.
+#
+# Postrust and Hasura are now the exception: they are sent the *same query
+# text*, byte for byte, because Postrust answers Hasura's dialect. That is the
+# claim the conformance harness measures, and sending one string to both is
+# the cheapest possible restatement of it -- if the dialects ever drift, this
+# benchmark stops running rather than quietly measuring two different
+# questions.
 # ---------------------------------------------------------------------------
 
 # name|postrust path|postgrest path
@@ -157,16 +164,16 @@ gql_query() {
     local target="$1" scenario="$2"
 
     case "$target:$scenario" in
-    postrust:row)     echo '{ benchItems(filter: {id: {eq: 42}}) { id name price } }' ;;
-    hasura:row)       echo '{ bench_items(where: {id: {_eq: 42}}) { id name price } }' ;;
+    postrust:row|hasura:row)
+                      echo '{ bench_items(where: {id: {_eq: 42}}) { id name price } }' ;;
     postgraphile:row) echo '{ benchItemByRowId(rowId: 42) { rowId name price } }' ;;
 
-    postrust:page)     echo '{ benchItems(limit: 25) { id name price } }' ;;
-    hasura:page)       echo '{ bench_items(limit: 25) { id name price } }' ;;
+    postrust:page|hasura:page)
+                      echo '{ bench_items(limit: 25) { id name price } }' ;;
     postgraphile:page) echo '{ allBenchItems(first: 25) { nodes { rowId name price } } }' ;;
 
-    postrust:embed)     echo '{ benchItems(limit: 25) { id name bench_reviews { id rating } } }' ;;
-    hasura:embed)       echo '{ bench_items(limit: 25) { id name bench_reviews { id rating } } }' ;;
+    postrust:embed|hasura:embed)
+                      echo '{ bench_items(limit: 25) { id name bench_reviews { id rating } } }' ;;
     postgraphile:embed) echo '{ allBenchItems(first: 25) { nodes { rowId name benchReviewsByItemId { nodes { rowId rating } } } } }' ;;
 
     *) return 1 ;;
@@ -181,7 +188,10 @@ GQL_SCENARIOS=(
 
 gql_endpoint() {
     case "$1" in
-        postrust)     echo "http://127.0.0.1:$PORT_POSTRUST/api/graphql" ;;
+        # `/v1/graphql`, not `/api/graphql`: same handler either way, but this
+        # is the address a Hasura client is pointed at, so the benchmark
+        # exercises the migration path rather than one beside it.
+        postrust)     echo "http://127.0.0.1:$PORT_POSTRUST/v1/graphql" ;;
         hasura)       echo "http://127.0.0.1:$PORT_HASURA/v1/graphql" ;;
         postgraphile) echo "http://127.0.0.1:$PORT_POSTGRAPHILE/graphql" ;;
     esac

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -83,8 +83,13 @@ PG_CONTAINER="postrust-cmp-pg"
 # Pinned so a re-run measures the same thing. Bump deliberately, not by drift.
 # Each is the current release: benchmarking an old version of someone else's
 # tool produces a number that is not worth publishing.
+#
+# The Hasura pin must match the one scripts/hasura-conformance/conformance.sh
+# measures against. It did not for a while -- this benchmarked v2.44.0 while
+# conformance reported v2.50.1 -- which put two numbers about "Hasura" on the
+# same website that were not about the same Hasura.
 POSTGREST_IMAGE="${POSTGREST_IMAGE:-postgrest/postgrest:v16.1}"
-HASURA_IMAGE="${HASURA_IMAGE:-hasura/graphql-engine:v2.44.0}"
+HASURA_IMAGE="${HASURA_IMAGE:-hasura/graphql-engine:v2.50.1}"
 POSTGRAPHILE_NODE_IMAGE="${POSTGRAPHILE_NODE_IMAGE:-$POSTGRAPHILE_NODE_DEFAULT}"
 POSTGRAPHILE_VERSION="${POSTGRAPHILE_VERSION:-5}"
 

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -97,7 +97,13 @@ PORT_POSTGREST="${PORT_POSTGREST:-3992}"
 PORT_HASURA="${PORT_HASURA:-3993}"
 PORT_POSTGRAPHILE="${PORT_POSTGRAPHILE:-3994}"
 
-REQUESTS="${REQUESTS:-3000}"
+# 3000 requests completes in roughly a third of a second at the throughputs
+# these tools reach, and a window that short measures scheduling and cache
+# warmth as much as steady-state throughput. Repeating it does not help: five
+# medians of a biased sample share the bias. Measured directly, going from
+# 3000 to 30000 pulled the run-to-run spread on one scenario from 1.33x down
+# to 1.25x for this server and 1.39x to 1.17x for PostGraphile.
+REQUESTS="${REQUESTS:-30000}"
 CONCURRENCY="${CONCURRENCY:-50}"
 # Requests issued against every target before anything is measured. This is a
 # real number of requests, not a token few: a cold connection pool, an unplanned
@@ -206,6 +212,40 @@ container_of() {
     esac
 }
 
+# Only the server being measured should be running.
+#
+# Every candidate used to stay up for the whole run, so each measurement was
+# taken with the other three idling beside it on the same host. That is not a
+# fixed overhead shared equally: it moved this server's GraphQL throughput from
+# ~9000 rps measured alone to 3938-5111 measured alongside, while PostGraphile
+# barely shifted -- so the comparison was reporting a difference in how the
+# tools respond to a busy host, on top of the difference being asked about.
+#
+# Paused rather than stopped: `docker pause` freezes the processes through the
+# cgroup freezer without touching their state, so nothing pays a cold start or
+# loses a warm connection pool between scenarios.
+isolate() {
+    local keep="$1" t c
+    for t in postrust postgrest hasura postgraphile; do
+        wants "$t" || continue
+        c="$(container_of "$t")"
+        if [ "$t" = "$keep" ]; then
+            docker unpause "$c" >/dev/null 2>&1 || true
+        else
+            docker pause "$c" >/dev/null 2>&1 || true
+        fi
+    done
+}
+
+# Everything running again, for warmup and for the memory reading at the end.
+unisolate() {
+    local t
+    for t in postrust postgrest hasura postgraphile; do
+        wants "$t" || continue
+        docker unpause "$(container_of "$t")" >/dev/null 2>&1 || true
+    done
+}
+
 image_of() {
     case "$1" in
         postrust)     echo "$POSTRUST_IMAGE" ;;
@@ -229,6 +269,11 @@ ALL_CONTAINERS=(
 
 cleanup() {
     local exit_code=$?
+
+    # A run that dies mid-measurement leaves one server frozen by `isolate`.
+    # Unfreezing first means neither KEEP=1 nor the next run inherits a
+    # container that is up but answers nothing.
+    unisolate 2>/dev/null || true
 
     if [[ "$KEEP" == "1" ]]; then
         log "KEEP=1: leaving containers and network $NETWORK running"
@@ -341,7 +386,10 @@ done
 
 cleanup_quiet() {
     local c
-    for c in "${ALL_CONTAINERS[@]}"; do docker rm -f "$c" >/dev/null 2>&1 || true; done
+    for c in "${ALL_CONTAINERS[@]}"; do
+        docker unpause "$c" >/dev/null 2>&1 || true
+        docker rm -f "$c" >/dev/null 2>&1 || true
+    done
 }
 cleanup_quiet
 docker network rm "$NETWORK" >/dev/null 2>&1 || true
@@ -585,9 +633,11 @@ bench_rest() {
             target="${entry%%|*}"
             url="${entry#*|}"
             log "rest: $name -- $target"
+            isolate "$target"
             measured="$(measure_median "$url" "")"
             record rest "$name" "$target" "$measured" ok
         done
+        unisolate
     done
 }
 
@@ -625,9 +675,11 @@ bench_gql() {
         for entry in "${posts[@]}"; do
             IFS='|' read -r target url body <<<"$entry"
             log "graphql: $label -- $target"
+            isolate "$target"
             measured="$(measure_median "$url" "" "$body")"
             record graphql "$label" "$target" "$measured" ok
         done
+        unisolate
     done
 }
 


### PR DESCRIPTION
The comparison benchmark had three faults. Two are fixed here. The third is
not, and is the reason no numbers are published in this PR.

## Fixed

**It asked this server for a field it no longer has.** The scenario reported
`UNSUPPORTED`, which prints as a blank rather than an error — a benchmark that
silently stops measuring something looks exactly like one that measured it.

**Every candidate stayed up for the whole run**, so each measurement was taken
with the other three idling beside it on the same host. That is not a fixed
overhead shared equally: it moved this server's GraphQL throughput from ~9000
rps measured alone to 3938–5111 measured alongside, while PostGraphile barely
shifted — so the comparison was reporting how each tool responds to a busy
host, on top of the difference being asked about. Servers are now paused with
`docker pause` (the cgroup freezer, so nothing pays a cold start or loses a
warm pool), and `cleanup()` unfreezes first so no run inherits a container
that is up but answers nothing.

**The window moved from 3,000 requests to 30,000.** At these throughputs 3,000
requests complete in about a third of a second, which samples connection setup
and cache warmth rather than steady state — and repeating it does not help,
because five medians of a biased sample share the bias. It biased rather than
merely blurred: the GHC-based servers reach steady state later, so a short
window flattered this server and penalised them.

**The Hasura pin is aligned with conformance.** This benchmarked v2.44.0 while
the conformance harness measured v2.50.1, which put two numbers about "Hasura"
on the same website that were not about the same Hasura. Measured across four
runs the newer engine is ~7% slower on these scenarios, so aligning it moves
our ratios *up* — a change that comes from the reference, not from us.

## Not fixed, and why nothing is published

The same server, in the same container, measured seconds apart, differs by
about 2×: the harness reports 5911–9731 rps where measuring the identical
endpoint by hand immediately afterwards gives ~13000.

The harness is not misreporting. Its load generator was instrumented to print
its own arguments (`-n 30000 -c 50`, correct URL) and the rate it publishes
matches wall-clock. The server really is slower while the run is happening.

The clearest symptom: within one run the REST scenarios settled at ~6200 rps
while the GraphQL scenarios, which run afterwards, settled at ~12631 — same
server, same process, same run. **Whatever is measured first is the most
understated**, which makes scenario order a determinant of the published ratio.

Ruled out by direct test, not by argument: thermal throttling and measurement
order (ABBA design), host load (the harness scored *higher* at load 18 than at
load 5), a cold database, the bulk load and checkpointing, server and
PostgreSQL start-up, container pausing, `docker stats`, the harness's own
measurement code, and Docker's port forwarding.

A warm-to-plateau replacement was written and **reverted rather than shipped**.
It changed nothing (6899 against 6890), and the round logging showed why: the
warm-up ran 80,000 requests and its final round measured the same depressed
figure that was then recorded. The system climbs more slowly than the
tolerance, so the loop announced a plateau at exactly the value it was meant to
escape. A warm-up that reports success at the wrong number is worse than one
that is obviously too short.

`scripts/BENCH-FINDINGS.md` records all of it.

## Note on method

Two passes agreeing is not evidence that an instrument is sound. Both passes
run the same procedure, so a systematic bias reproduces perfectly and reads as
precision. That is how this survived a two-pass reproducibility check earlier.

## Before numbers return

Run the comparison on a host with native Docker rather than a virtualised one,
and require that a measurement repeated at the start and the end of a run
agrees with itself.

Conformance is untouched — it measures whether two servers give the same
answer, not how fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)