### PR TITLE
ci: a prerelease must not publish as the latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,14 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # A semver prerelease always carries a hyphen (1.0.0-alpha.1). Without
+          # these two, the release publishes as a normal one and GitHub shows it
+          # as `Latest` -- so an alpha becomes what `releases/latest` returns and
+          # what the repository front page offers. Both had to be corrected by
+          # hand after 1.0.0-alpha.1 shipped. Same test as the `latest` container
+          # tag below uses, and for the same reason.
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           body: |
             Container image published to GHCR:
 


### PR DESCRIPTION
Found while releasing 1.0.0-alpha.1.

The container tag was already guarded — `latest` is applied only when the tag
name carries no hyphen — but the GitHub Release step was not. The alpha
published as a normal release and GitHub marked it `Latest`, which is both what
`GET /releases/latest` returns and what the repository front page offers a
visitor. I corrected the shipped release by hand
(`gh release edit --prerelease --latest=false`); this stops the next one needing
that.

Applies the same hyphen test the container tag already uses to `prerelease` and
`make_latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)