### PR TITLE
docs: correct the Autobahn figures in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,11 @@ the hop-by-hop defect. 7 of 7 probes correct.
 
 **h2spec** -- 146 tests, 145 passed, 1 skipped, 0 failed.
 
-**Autobahn** -- 517 cases, 502 OK, 0 failed, and no case worse than a baseline
-run that bypasses the proxy. The baseline matters: postrust splices WebSocket
-streams rather than parsing frames, so most of what Autobahn scores belongs to
-the origin behind it.
+**Autobahn** -- 517 cases, 501 OK, and no case worse than a baseline run that
+bypasses the proxy. One case fails, and fails identically with no proxy in the
+path. The baseline matters: postrust splices WebSocket streams rather than
+parsing frames, so most of what Autobahn scores belongs to the origin behind
+it.
 
 ## 1.0.0-alpha.1
 


### PR DESCRIPTION
The 1.0.0-alpha.2 changelog says the Autobahn run was **502 OK, 0 failed**. The generated artifact says otherwise:

```
"cases": 517, "ok": 501, "nonStrict": 12, "informational": 3, "failed": 1,
"baselineCases": 517, "baselineFailed": 1, "regressions": []
```

501 OK, and one case that fails — the same case the baseline fails with no proxy in the path, which is why `regressions` is empty. The zero that matters is the regression count, not the failure count.

The website release page was already right: it reads every figure out of `transport-conformance.ts` rather than restating them. Only this hand-typed changelog line was wrong. Caught while pre-flighting the `v1.0.0-alpha.2` tag, which is why it is worth fixing before that tag becomes the permanent record.

Docs only, no code change.