### PR TITLE
chore: put postrust-proxy on its own 0.x version line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,14 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
-          version=$(cargo metadata --no-deps --format-version 1 \
-            | jq -r '.packages[] | select(.name == "postrust-core") | .version')
+          metadata=$(cargo metadata --no-deps --format-version 1)
+          version=$(jq -r '.packages[] | select(.name == "postrust-core") | .version' <<<"${metadata}")
           echo "Workspace version: ${version}"
 
           # The tag is the source of truth for a release; refuse to publish if
           # the workspace version wasn't bumped to match it (e.g. tagging
-          # v0.2.3 while Cargo.toml still says 0.2.2).
+          # v0.2.3 while Cargo.toml still says 0.2.2). Anchored on
+          # postrust-core, which carries [workspace.package] version.
           tag_version="${GITHUB_REF_NAME#v}"
           if [ "${tag_version}" != "${version}" ]; then
             echo "::error::Tag ${GITHUB_REF_NAME} does not match workspace version ${version}." \
@@ -50,16 +51,30 @@ jobs:
             exit 1
           fi
 
-          # Dependency order: leaves first.
+          # Each crate is published at the version *it* declares, not at the
+          # workspace version: postrust-proxy sets its own, on a 0.x line that
+          # carries no stability promise (see docs/stability.md). A tag ships
+          # whatever every crate currently declares and skips what is already
+          # published, so the proxy releases on the same tags without being
+          # dragged along to 1.0.0.
+          #
+          # Dependency order: leaves first. Nothing depends on postrust-proxy,
+          # so no 1.0.0 crate carries a 0.x dependency.
           for crate in postrust-sql postrust-auth postrust-core postrust-response \
                        postrust-graphql postrust-server postrust-lambda postrust-worker \
                        postrust-proxy; do
+            crate_version=$(jq -r --arg c "${crate}" \
+              '.packages[] | select(.name == $c) | .version' <<<"${metadata}")
+            if [ -z "${crate_version}" ] || [ "${crate_version}" = "null" ]; then
+              echo "::error::No version found for ${crate} in cargo metadata."
+              exit 1
+            fi
             if curl -fsS -A "postrust-release-workflow (github.com/${GITHUB_REPOSITORY})" \
-                 "https://crates.io/api/v1/crates/${crate}/${version}" >/dev/null 2>&1; then
-              echo "${crate} ${version} already on crates.io, skipping"
+                 "https://crates.io/api/v1/crates/${crate}/${crate_version}" >/dev/null 2>&1; then
+              echo "${crate} ${crate_version} already on crates.io, skipping"
               continue
             fi
-            echo "Publishing ${crate} ${version}"
+            echo "Publishing ${crate} ${crate_version}"
             cargo publish -p "${crate}" --locked
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Notable changes, newest first. This file starts at 1.0.0-alpha.1; earlier
 releases are described by their tags and the pull requests behind them.
 
+## Unreleased
+
+### Changed
+
+**`postrust-proxy` moved to its own `0.x` version line** and no longer shares
+the workspace version. The rest of the workspace is heading for 1.0.0 and a
+semver promise; this crate is not ready to make one. Turning `missing_docs` on
+for it produces 306 warnings, and parts of its public surface answer
+successfully without doing anything -- `config::database` returns an empty
+route set instead of querying, and the admin API's route and upstream mutations
+change only the in-memory config while replying `200`/`201`. Nothing depends on
+`postrust-proxy`, so no crate that makes a semver promise carries a dependency
+that cannot keep one.
+
+Both lines still release on the same git tags: the publish step now reads each
+crate's own declared version rather than assuming one across the workspace, and
+skips what is already on crates.io.
+
+New: [docs/stability.md](docs/stability.md), stating what a version number
+covers and what it does not.
+
 ## 1.0.0-alpha.2
 
 A release about the front door rather than the dialects. The HTTP proxy was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "postrust-proxy"
-version = "1.0.0-alpha.2"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,6 @@ postrust-sql = { version = "1.0.0-alpha.2", path = "crates/postrust-sql" }
 postrust-auth = { version = "1.0.0-alpha.2", path = "crates/postrust-auth" }
 postrust-response = { version = "1.0.0-alpha.2", path = "crates/postrust-response" }
 postrust-graphql = { version = "1.0.0-alpha.2", path = "crates/postrust-graphql" }
-postrust-proxy = { version = "1.0.0-alpha.2", path = "crates/postrust-proxy" }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -472,7 +472,14 @@ Postrust crates at the same version work together. Browse them at
 | `postrust-graphql` | GraphQL API with dynamic schema generation | [crates.io](https://crates.io/crates/postrust-graphql) · [docs](https://docs.rs/postrust-graphql) |
 | `postrust-lambda` | AWS Lambda adapter | [crates.io](https://crates.io/crates/postrust-lambda) · [docs](https://docs.rs/postrust-lambda) |
 | `postrust-worker` | Cloudflare Workers adapter | [crates.io](https://crates.io/crates/postrust-worker) · [docs](https://docs.rs/postrust-worker) |
-| `postrust-proxy` | Reverse proxy with load balancing and automatic TLS | [crates.io](https://crates.io/crates/postrust-proxy) · [docs](https://docs.rs/postrust-proxy) |
+| `postrust-proxy` | Reverse proxy with load balancing and automatic TLS — **`0.x`, no stability promise** | [crates.io](https://crates.io/crates/postrust-proxy) · [docs](https://docs.rs/postrust-proxy) |
+
+Every crate above except `postrust-proxy` shares one version and one semver
+promise. `postrust-proxy` is on its own `0.x` line: it is useful and it is
+measured against h2spec, Autobahn and the HTTP Garden differential fuzzer, but
+parts of its public surface are undocumented or not yet wired up, and a shared
+version number would promise a stability it cannot keep. Nothing else depends
+on it. See [Stability and Versioning](docs/stability.md).
 
 ## Development
 

--- a/crates/postrust-proxy/Cargo.toml
+++ b/crates/postrust-proxy/Cargo.toml
@@ -4,7 +4,10 @@ description = "Reverse proxy for Postrust with load balancing and automatic TLS 
 homepage.workspace = true
 readme = "README.md"
 keywords = ["proxy", "load-balancer", "tls", "acme", "http"]
-version.workspace = true
+# Deliberately NOT `version.workspace = true`. The rest of the workspace is
+# heading for 1.0.0; this crate is not, and a shared version number would
+# promise a stability this crate cannot keep. See docs/stability.md.
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/postrust-proxy/src/lib.rs
+++ b/crates/postrust-proxy/src/lib.rs
@@ -35,9 +35,17 @@
 //! ```
 
 #![warn(clippy::all)]
-// `postrust-proxy` is a beta module with wiring still in progress. The following
-// lints are relaxed until it stabilizes (tighten before GA):
-// - missing_docs / dead_code: some public items and scaffolding are not yet wired up.
+// `postrust-proxy` is on its own 0.x version line, separate from the rest of the
+// workspace, and carries no stability promise. That is not a formality: turning
+// `missing_docs` and `dead_code` on here produces 306 and 4 warnings
+// respectively, and parts of the public surface answer successfully without
+// doing anything (see `config::database`, and the admin API's route and
+// upstream mutations). Freezing that under semver would be a promise the crate
+// cannot keep, so it does not go to 1.0.0 with the others. See docs/stability.md.
+//
+// The relaxed lints, and what each is waiting on:
+// - missing_docs / dead_code: public items and scaffolding not yet wired up.
+//   Tighten as the surface is documented and the stubs are resolved.
 // - result_large_err / large_enum_variant: rooted in the rich `ProxyError` enum.
 // - type_complexity: a few internal signatures pending refactor into type aliases.
 #![allow(missing_docs)]

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Welcome to the Postrust documentation. Postrust is a high-performance, serverles
 - [Custom Routes](./custom-routes.md) - Add webhooks, health checks, and custom endpoints
 - [SaaS Domain Management](./saas-domains.md) - Multi-tenant custom domains with automatic SSL (Beta)
 - [Deployment](./deployment.md) - Deploy to various platforms
+- [Stability and Versioning](./stability.md) - What a version number promises, and which crates it covers
 - [Benchmarking](./benchmarking.md) - The method, and why the throughput figures are currently withdrawn
 - [PostgREST Conformance](./postgrest-conformance.md) - How closely the two agree, measured against PostgREST itself
 - [Hasura Conformance](./hasura-conformance.md) - How closely the GraphQL dialects agree, measured against graphql-engine itself

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,123 @@
+# Stability and versioning
+
+What a Postrust version number promises, and what it does not.
+
+## Two version lines
+
+The workspace does not ship at a single version. There are two lines, because
+the crates in them are at genuinely different stages and one number cannot
+honestly describe both.
+
+| Line | Crates | Promise |
+| --- | --- | --- |
+| **Stable** | `postrust-core`, `postrust-sql`, `postrust-auth`, `postrust-response`, `postrust-graphql`, `postrust-server`, `postrust-lambda`, `postrust-worker` | Semver. A breaking change to the public Rust API needs a major bump. |
+| **Unstable** | `postrust-proxy` | None. On its own `0.x`, where a minor bump may break anything. |
+
+Nothing in the stable line depends on `postrust-proxy`, so no crate that makes
+a semver promise carries a dependency that cannot keep one. The proxy depends
+on `postrust-core`, not the other way round.
+
+Both lines release on the same git tags. A tag publishes whatever version each
+crate currently declares and skips what is already on crates.io, so the proxy
+is not dragged along to a version it has not earned.
+
+One wrinkle from the transition: `postrust-proxy` was published at
+`1.0.0-alpha.1` and `1.0.0-alpha.2` before the split, and that `1.0.0` line
+will never get a stable successor. Both are prereleases, so Cargo will not
+select either by default — `cargo add postrust-proxy` resolves to the newest
+`0.x`. Only an explicit request for one of those versions reaches code that
+predates the split.
+
+## Why the proxy is held back
+
+Not caution for its own sake. Three specific things:
+
+**The public surface is largely undocumented.** Turning `missing_docs` on for
+`postrust-proxy` produces 306 warnings — 266 struct fields, 25 enum variants,
+8 associated functions, 5 structs, 2 methods. `dead_code` adds 4 more. A 1.0.0
+would freeze all of it as-is.
+
+**Parts of it answer successfully without doing anything.**
+`config::database::load_from_database` returns an empty route set rather than
+querying, so a proxy configured against a database starts, logs nothing wrong,
+and refuses every request. The admin API's route and upstream mutations return
+`200`/`201` after changing only the in-memory config; a restart discards them.
+SaaS domain provisioning does not trigger ACME. These are marked in the source,
+and each needs to be implemented, made to fail loudly, or removed before the
+crate can promise anything.
+
+**It has only just grown its transport layer.** TLS, HTTP/2, WebSocket and
+RFC 8441 extended CONNECT all landed in `1.0.0-alpha.2`. They are measured, by
+h2spec and Autobahn and the HTTP Garden differential fuzzer — see
+`scripts/h2spec/`, `scripts/autobahn/` and `scripts/http-garden/` — but
+measured is not the same as lived with.
+
+The crate is useful and it is tested. It is not finished, and its version
+number says so.
+
+## What semver covers in the stable line
+
+Covered — a breaking change here requires a major bump:
+
+- The public Rust API of each stable crate: exported types, traits, functions,
+  their signatures, and public enum variants and struct fields.
+- The HTTP surface of `postrust-server`: routes, request grammar, status codes,
+  and the response shapes the conformance suites replay.
+- Configuration keys and their meanings.
+- The minimum supported Rust version.
+
+Not covered:
+
+- `postrust-proxy`, entirely.
+- Anything reachable only through a `#[doc(hidden)]` item or a private module.
+- The exact wording of error messages, and log output.
+- Behaviour under configurations the documentation calls unsupported.
+- Test fixtures, benchmark harnesses, and everything under `scripts/`.
+- Generated data files under `website/src/data/`.
+
+## Conformance is measured, not promised
+
+Postrust answers PostgREST's REST dialect and Hasura's GraphQL dialect. How
+closely it answers each is a measurement, taken by replaying the other
+project's own test corpus against both servers and diffing the live responses.
+
+Those percentages are **not** a semver commitment. They move when the upstream
+projects change, when the corpus grows, and when we fix things. What semver
+covers is that we will not break a documented behaviour of our own without a
+major bump; it does not promise a particular agreement figure with a third
+party whose releases we do not control.
+
+See [PostgREST conformance](./postgrest-conformance.md) and
+[Hasura conformance](./hasura-conformance.md) for the method and the current
+numbers, and for the cases where the two deliberately disagree.
+
+## What is measured
+
+Every figure the project publishes is generated from a run's own artifacts
+rather than typed by hand, and the generator refuses to emit a partial file.
+If a number cannot account for itself, it does not ship.
+
+Throughput figures are currently **withdrawn**. The benchmark that produced the
+previous ones was found to report the order of a run as much as the speed of a
+server; see [benchmarking](./benchmarking.md) and `scripts/BENCH-FINDINGS.md`.
+They return when the harness can be trusted, and not before.
+
+## Prereleases
+
+A prerelease carries a hyphen (`1.0.0-alpha.2`) and no stability promise of any
+kind. Cargo excludes prereleases from default version resolution, so
+`cargo add postrust-server` will not pick one up unless asked.
+
+## Deprecation
+
+A stable item that is going away is marked `#[deprecated]` with a note saying
+what to use instead, and stays for at least one minor release before removal in
+the next major.
+
+## Reporting a problem
+
+Bugs and questions: [GitHub Issues](https://github.com/postrust/postrust/issues).
+
+For anything with a security impact, please report it privately through
+[GitHub's security advisory form](https://github.com/postrust/postrust/security/advisories/new)
+rather than opening a public issue.


### PR DESCRIPTION
Part of the run-up to 1.0.0. The workspace is heading for a stable release and the semver promise that comes with it; `postrust-proxy` is not ready to make one, and sharing a version number would have made the promise on its behalf.

## Why this crate specifically

Not caution for its own sake — three measurable things:

**306 undocumented public items.** Flipping `#![allow(missing_docs)]` to `warn` on the crate produces 306 warnings (266 struct fields, 25 enum variants, 8 associated functions, 5 structs, 2 methods); `dead_code` adds 4. A 1.0.0 freezes all of that as it stands.

**Parts of the public surface answer successfully without doing anything.**

- `config::database::load_from_database` returns `Ok((vec![], vec![]))` behind a `// TODO: Implement database query`. A proxy configured against a database starts, logs nothing wrong, and 503s every request — the same shape as the routing bug fixed in `1.0.0-alpha.2`.
- The admin API's route and upstream create/update/delete reply `201`/`200` after mutating only the in-memory config. A restart discards them. Eight `// TODO: Persist to database` sites.
- SaaS domain provisioning never triggers ACME.

**The transport layer is one release old.** TLS, h2c, WebSocket and RFC 8441 all landed in `1.0.0-alpha.2`. They are measured — h2spec 145/146, Autobahn 517 cases with no regression against a proxy-less baseline, HTTP Garden 7/7 — but measured is not the same as lived with.

## Why the split is clean

**Nothing depends on `postrust-proxy`.** It consumes `postrust-core` and no member crate consumes it, so no crate making a semver promise ends up carrying a `0.x` dependency that cannot keep one. That is what makes this a real separation rather than a bookkeeping trick.

## Changes

- `postrust-proxy` declares `version = "0.5.0"` instead of `version.workspace = true` (its last stable release was `0.4.0`).
- The release workflow now reads **each crate's own declared version** rather than assuming one across the workspace, and skips what is already on crates.io. Both lines keep releasing on the same git tags. I dry-ran the new loop against real `cargo metadata`: the eight stable crates resolve to `1.0.0-alpha.2` and report "already published", `postrust-proxy` resolves to `0.5.0` and reports "would publish".
- Dropped the `[workspace.dependencies]` entry for `postrust-proxy` — no member crate referenced it.
- New `docs/stability.md`: what a version number covers, what it does not, and why conformance percentages are a measurement rather than a semver commitment.
- The crate-level comment in `lib.rs` said "tighten before GA". It now says what is actually true, with the numbers.

## One wrinkle, documented

`postrust-proxy` was published at `1.0.0-alpha.1` and `1.0.0-alpha.2` before this split, and that `1.0.0` line will never get a stable successor. Both are prereleases, so Cargo excludes them from default resolution — `cargo add postrust-proxy` will pick the newest `0.x`. Only an explicit request reaches them. Noted in `docs/stability.md`; yanking the two is an option if you'd rather close it off entirely.

## Verification

Ran the full CI pipeline locally: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p postrust-server --features admin-ui --all-targets -- -D warnings`, and `cargo test --workspace` — all clean, 0 failures. Not covered locally: the database-backed `-- --ignored` suite, which CI runs.