### PR TITLE
chore: put postrust-worker on its own 0.x version line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ releases are described by their tags and the pull requests behind them.
 
 ### Changed
 
+**`postrust-worker` moved to its own `0.x` version line** as well, for a
+blunter reason: it is a stub. Its fetch handler answers `{"status": "stub"}`
+and does not parse requests, reach a database, or return data. It is built as
+a `cdylib`, so it cannot be a Rust library dependency at all.
+
 **`postrust-proxy` moved to its own `0.x` version line** and no longer shares
 the workspace version. The rest of the workspace is heading for 1.0.0 and a
 semver promise; this crate is not ready to make one. Turning `missing_docs` on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "postrust-worker"
-version = "1.0.0-alpha.2"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/README.md
+++ b/README.md
@@ -471,15 +471,22 @@ Postrust crates at the same version work together. Browse them at
 | `postrust-response` | Response formatting (JSON, CSV, OpenAPI) | [crates.io](https://crates.io/crates/postrust-response) · [docs](https://docs.rs/postrust-response) |
 | `postrust-graphql` | GraphQL API with dynamic schema generation | [crates.io](https://crates.io/crates/postrust-graphql) · [docs](https://docs.rs/postrust-graphql) |
 | `postrust-lambda` | AWS Lambda adapter | [crates.io](https://crates.io/crates/postrust-lambda) · [docs](https://docs.rs/postrust-lambda) |
-| `postrust-worker` | Cloudflare Workers adapter | [crates.io](https://crates.io/crates/postrust-worker) · [docs](https://docs.rs/postrust-worker) |
+| `postrust-worker` | Cloudflare Workers adapter — **stub; `0.x`, no stability promise** | [crates.io](https://crates.io/crates/postrust-worker) · [docs](https://docs.rs/postrust-worker) |
 | `postrust-proxy` | Reverse proxy with load balancing and automatic TLS — **`0.x`, no stability promise** | [crates.io](https://crates.io/crates/postrust-proxy) · [docs](https://docs.rs/postrust-proxy) |
 
-Every crate above except `postrust-proxy` shares one version and one semver
-promise. `postrust-proxy` is on its own `0.x` line: it is useful and it is
-measured against h2spec, Autobahn and the HTTP Garden differential fuzzer, but
-parts of its public surface are undocumented or not yet wired up, and a shared
-version number would promise a stability it cannot keep. Nothing else depends
-on it. See [Stability and Versioning](docs/stability.md).
+The first seven crates share one version and one semver promise. The last two
+are each on their own `0.x` line and carry none:
+
+- `postrust-proxy` is useful and measured — h2spec, Autobahn, and the HTTP
+  Garden differential fuzzer — but parts of its public surface are
+  undocumented, and a shared version number would promise a stability it
+  cannot keep.
+- `postrust-worker` is a stub. It answers `{"status": "stub"}` and needs
+  Cloudflare Hyperdrive and a KV-backed schema cache before it does anything
+  else.
+
+Nothing in the stable line depends on either. See
+[Stability and Versioning](docs/stability.md).
 
 ## Development
 

--- a/crates/postrust-worker/Cargo.toml
+++ b/crates/postrust-worker/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "postrust-worker"
-version.workspace = true
+# Deliberately NOT `version.workspace = true`. This adapter is a stub, and the
+# rest of the workspace is heading for 1.0.0. See docs/stability.md.
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/postrust-worker/src/lib.rs
+++ b/crates/postrust-worker/src/lib.rs
@@ -2,8 +2,14 @@
 //!
 //! Deploys Postrust as a Cloudflare Worker.
 //!
-//! Note: This is a stub implementation. Full implementation requires
-//! Cloudflare-specific features like Hyperdrive for database connections.
+//! **This is a stub.** The fetch handler answers with a JSON body saying so;
+//! it does not parse requests, reach a database, or return data. A real
+//! implementation needs Cloudflare-specific pieces that are not here yet:
+//! Hyperdrive for database connections, and KV or Durable Objects for the
+//! schema cache.
+//!
+//! Because of that the crate is on its own 0.x version line rather than the
+//! workspace's, and carries no stability promise. See docs/stability.md.
 
 use worker::*;
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -10,23 +10,35 @@ honestly describe both.
 
 | Line | Crates | Promise |
 | --- | --- | --- |
-| **Stable** | `postrust-core`, `postrust-sql`, `postrust-auth`, `postrust-response`, `postrust-graphql`, `postrust-server`, `postrust-lambda`, `postrust-worker` | Semver. A breaking change to the public Rust API needs a major bump. |
-| **Unstable** | `postrust-proxy` | None. On its own `0.x`, where a minor bump may break anything. |
+| **Stable** | `postrust-core`, `postrust-sql`, `postrust-auth`, `postrust-response`, `postrust-graphql`, `postrust-server`, `postrust-lambda` | Semver. A breaking change to the public Rust API needs a major bump. |
+| **Unstable** | `postrust-proxy`, `postrust-worker` | None. Each on its own `0.x`, where a minor bump may break anything. |
 
-Nothing in the stable line depends on `postrust-proxy`, so no crate that makes
-a semver promise carries a dependency that cannot keep one. The proxy depends
-on `postrust-core`, not the other way round.
+Nothing in the stable line depends on either unstable crate, so no crate that
+makes a semver promise carries a dependency that cannot keep one.
+`postrust-proxy` depends on `postrust-core`, not the other way round, and
+`postrust-worker` is built as a `cdylib`, which cannot be a Rust library
+dependency at all.
 
 Both lines release on the same git tags. A tag publishes whatever version each
 crate currently declares and skips what is already on crates.io, so the proxy
 is not dragged along to a version it has not earned.
 
-One wrinkle from the transition: `postrust-proxy` was published at
+One wrinkle from the transition: both unstable crates were published at
 `1.0.0-alpha.1` and `1.0.0-alpha.2` before the split, and that `1.0.0` line
-will never get a stable successor. Both are prereleases, so Cargo will not
-select either by default — `cargo add postrust-proxy` resolves to the newest
-`0.x`. Only an explicit request for one of those versions reaches code that
-predates the split.
+will never get a stable successor for either. Both are prereleases, so Cargo
+will not select them by default — `cargo add postrust-proxy` resolves to the
+newest `0.x`. Only an explicit request reaches code that predates the split.
+
+## Why the worker is held back
+
+`postrust-worker` is a stub, and says so in its own response body: the fetch
+handler answers `{"status": "stub"}` and nothing else. It does not parse
+requests, reach a database, or return data. Finishing it needs Cloudflare
+pieces that are not written yet -- Hyperdrive for database connections, KV or
+Durable Objects for the schema cache.
+
+A 1.0.0 on that would be a promise to keep an interface that does not do
+anything yet.
 
 ## Why the proxy is held back
 
@@ -68,7 +80,7 @@ Covered — a breaking change here requires a major bump:
 
 Not covered:
 
-- `postrust-proxy`, entirely.
+- `postrust-proxy` and `postrust-worker`, entirely.
 - Anything reachable only through a `#[doc(hidden)]` item or a private module.
 - The exact wording of error messages, and log output.
 - Behaviour under configurations the documentation calls unsupported.


### PR DESCRIPTION
Follows [#17](https://github.com/postrust/postrust/pull/17), which did the same for `postrust-proxy`. The reason here is blunter: the crate is a stub.

Its entire fetch handler reads environment variables into `_`-prefixed bindings and returns:

```json
{"message": "Postrust Worker is running", "status": "stub",
 "note": "Full implementation requires Hyperdrive configuration"}
```

It does not parse requests, reach a database, or return data. The two functions that would (`process_request`, `get_schema_cache`) are `#[allow(dead_code)]` placeholders. Finishing it needs Cloudflare pieces that are not written yet — Hyperdrive for database connections, KV or Durable Objects for the schema cache.

A 1.0.0 on that is a promise to keep an interface that does not do anything yet.

## Why the split costs nothing

`postrust-worker` is built as `crate-type = ["cdylib"]`, so it cannot be a Rust library dependency at all — "nothing in the stable line depends on it" is structurally guaranteed rather than merely true today.

The release workflow already publishes each crate at the version it declares (changed in #17), so this needs no workflow change. Its last stable release was `0.4.0`, so it starts at `0.5.0`, matching the proxy.

## Changes

- `postrust-worker` declares `version = "0.5.0"` instead of `version.workspace = true`.
- The crate docs now say what the stub actually does, rather than "Note: This is a stub implementation".
- `docs/stability.md` and the README crates table updated for two unstable crates rather than one.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo check --workspace` all clean.

## Not in this PR

While reading the proxy for the stub work, I found that `saas/handlers/wellknown.rs::handle_verification_challenge` returns valid challenge content for **any** token, with no database lookup and no host check. Combined with `verify_http`, which fetches exactly that path on the domain being claimed, HTTP domain verification always succeeds for any domain whose DNS points at the proxy — it proves nothing, which is the entire purpose of the check.

I first read this as a two-tenant domain-takeover path and it is not: `proxy_domains.domain` is `UNIQUE` globally, so a second tenant cannot register a domain another tenant already holds. It is a broken control rather than a demonstrated takeover. Fixing it separately and next, so it is reviewable on its own.
