### PR TITLE
fix(proxy): make HTTP domain verification actually verify something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ releases are described by their tags and the pull requests behind them.
 
 ## Unreleased
 
+### Fixed
+
+**HTTP domain verification proved nothing.** The endpoint serving the
+challenge, `/.well-known/postrust-verification/{token}`, computed
+`postrust-verify={token}` from whatever token was in the path and returned it.
+No database lookup, no host check -- so every token verified, for every
+domain. It now answers only for a challenge that is in the database, is not
+expired, is not already resolved, and whose domain matches the request's
+`Host`, and it returns the value stored when the challenge was issued rather
+than one recomputed at serve time.
+
+This was a broken control rather than a demonstrated takeover:
+`proxy_domains.domain` is globally unique, so a second tenant cannot register
+a domain another tenant already holds.
+
+**A verified domain asking for ACME was marked `provisioning`** when nothing
+would ever provision it, leaving it mid-issuance forever with no way to tell
+slow from never. It is now left `pending`, with a warning saying a certificate
+has to be supplied manually.
+
+**Documentation described endpoints that do not exist.**
+`docs/saas-domains.md` documented `PUT /domains/:id`,
+`POST /domains/:id/ssl/provision` and `POST /domains/:id/ssl/upload`, none of
+which are in the router, and omitted `enable` and `disable`, which are. It
+also advertised automatic ACME provisioning as a feature. Corrected against
+the router, and the SSL section now says plainly that no ACME client exists.
+
 ### Changed
 
 **`postrust-worker` moved to its own `0.x` version line** as well, for a

--- a/crates/postrust-proxy/src/saas/db.rs
+++ b/crates/postrust-proxy/src/saas/db.rs
@@ -144,6 +144,46 @@ pub async fn create_verification_challenge(
     Ok(())
 }
 
+/// A live HTTP verification challenge, with the domain it was issued for.
+pub struct HttpChallenge {
+    /// The domain the challenge belongs to. The endpoint serving the challenge
+    /// must refuse to answer for any other host.
+    pub domain: String,
+    /// The content the verifier expects, as stored when the challenge was
+    /// issued. Never recomputed from the token at serve time.
+    pub expected_value: String,
+}
+
+/// Look up a live HTTP verification challenge by its token.
+///
+/// Returns `None` for a token that does not exist, one that has expired, and
+/// one whose challenge is already resolved. The caller must additionally check
+/// that the request arrived for [`HttpChallenge::domain`]: a token is a
+/// bearer secret for exactly one domain, and answering with it on any other
+/// host hands that secret to whoever asked.
+pub async fn find_live_http_challenge(
+    pool: &PgPool,
+    token: &str,
+) -> ProxyResult<Option<HttpChallenge>> {
+    let row = sqlx::query(
+        "SELECT d.domain, c.expected_value \
+         FROM proxy_verification_challenges c \
+         JOIN proxy_domains d ON d.id = c.domain_id \
+         WHERE c.token = $1 \
+           AND c.challenge_type = 'http' \
+           AND c.status IN ('pending', 'checking') \
+           AND c.expires_at > NOW()",
+    )
+    .bind(token)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(|row| HttpChallenge {
+        domain: row.get("domain"),
+        expected_value: row.get("expected_value"),
+    }))
+}
+
 /// Fetch a domain scoped to a tenant.
 pub async fn get_domain_for_tenant(
     pool: &PgPool,

--- a/crates/postrust-proxy/src/saas/handlers/wellknown.rs
+++ b/crates/postrust-proxy/src/saas/handlers/wellknown.rs
@@ -1,44 +1,69 @@
 //! Well-known endpoint handlers for domain verification.
 
 use crate::saas::handlers::SaasState;
+use crate::saas::wellknown_host::host_matches;
 use axum::{
     extract::{Path, State},
-    http::StatusCode,
+    http::{header::HOST, HeaderMap, StatusCode},
     response::IntoResponse,
 };
 
-/// Handle HTTP verification challenge.
+/// What an unknown, expired, resolved, or wrong-host token gets.
 ///
-/// This endpoint serves the verification content for HTTP domain verification.
-/// It responds at `/.well-known/postrust-verification/{token}` with the expected
-/// verification content.
+/// The same answer for all of them on purpose: distinguishing "no such token"
+/// from "that token is for another domain" would confirm a token's existence
+/// to whoever is probing.
+const NOT_FOUND: (StatusCode, &str) = (StatusCode::NOT_FOUND, "no such challenge");
+
+/// Serve an HTTP domain-verification challenge.
+///
+/// Responds at `/.well-known/postrust-verification/{token}` with the content
+/// recorded when the challenge was issued, and only for the domain it was
+/// issued for.
+///
+/// This used to compute `postrust-verify={token}` from whatever token was in
+/// the path and return it, with no database lookup and no host check -- so
+/// every token verified, for every domain, and the check proved nothing. It
+/// now answers only for a challenge that is in the database, is not expired,
+/// is not already resolved, and whose domain matches the request's `Host`.
+///
+/// The host check is what keeps a token scoped. A token is a bearer secret for
+/// exactly one domain; answering with it on some other host hands that secret
+/// to whoever asked for it.
+///
+/// A caveat worth stating plainly, because no amount of care here removes it:
+/// HTTP verification asks the claimant to serve content at a path on the
+/// domain, and once that domain's DNS points at this proxy, this proxy is what
+/// serves that path. Passing therefore shows the domain resolves here and a
+/// challenge was issued for it -- not that the claimant controls the domain.
+/// DNS verification does show that, which is why it is the default
+/// (`verification_method` defaults to `dns`). Prefer it.
 pub async fn handle_verification_challenge(
-    State(_state): State<SaasState>,
+    State(state): State<SaasState>,
+    headers: HeaderMap,
     Path(token): Path<String>,
 ) -> impl IntoResponse {
-    // Note: We need direct pool access, which isn't available through domain_manager
-    // For now, return a placeholder. In production, this would query the challenge.
+    let challenge = match state.domain_manager.find_live_http_challenge(&token).await {
+        Ok(Some(challenge)) => challenge,
+        Ok(None) => return NOT_FOUND.into_response(),
+        Err(error) => {
+            // A lookup failure is ours, not the caller's, and must not be
+            // reported as "no such challenge" -- that would read as a failed
+            // verification rather than an outage.
+            tracing::error!(%error, "verification challenge lookup failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "lookup failed").into_response();
+        }
+    };
 
-    // For HTTP verification, the challenge expected_value is: postrust-verify={token}
-    // We need to verify the token exists and is valid
+    let host = headers.get(HOST).and_then(|value| value.to_str().ok());
+    if !host_matches(host, &challenge.domain) {
+        tracing::warn!(
+            host = host.unwrap_or("<none>"),
+            expected = %challenge.domain,
+            "verification challenge requested on the wrong host"
+        );
+        return NOT_FOUND.into_response();
+    }
 
-    // Simplified implementation - in production you'd look up the challenge in DB
-    let expected_content = format!("postrust-verify={}", token);
-
-    // Return the verification content
-    // In a real implementation, you'd verify the token exists in the database first
-    (StatusCode::OK, expected_content)
-}
-
-/// Handle ACME HTTP-01 challenge.
-///
-/// This endpoint serves ACME HTTP-01 challenges for automatic certificate provisioning.
-/// It responds at `/.well-known/acme-challenge/{token}`.
-pub async fn handle_acme_challenge(
-    State(_state): State<SaasState>,
-    Path(_token): Path<String>,
-) -> impl IntoResponse {
-    // ACME challenges would be handled by the ACME module
-    // This is a placeholder for integration
-    (StatusCode::NOT_FOUND, "ACME challenge not found")
+    (StatusCode::OK, challenge.expected_value).into_response()
 }

--- a/crates/postrust-proxy/src/saas/manager.rs
+++ b/crates/postrust-proxy/src/saas/manager.rs
@@ -158,10 +158,24 @@ impl DomainManager {
                 db::update_verification_status(&self.pool, id, VerificationStatus::Verified)
                     .await?;
 
-                // If ACME is enabled, trigger SSL provisioning
+                // A domain asking for ACME stays `pending`, not `provisioning`.
+                //
+                // Nothing here has ever talked to a CA: no order is placed and
+                // `/.well-known/acme-challenge/{token}` has no authorization to
+                // serve. Writing `provisioning` claimed work was under way, so
+                // the API reported a domain as mid-issuance forever and an
+                // operator watching that field had no way to tell the
+                // difference between slow and never. `pending` is what is
+                // actually true -- verified, and waiting for a certificate
+                // somebody still has to supply.
                 if domain.ssl_provider == SslProvider::Acme {
-                    // TODO: Trigger ACME certificate provisioning
-                    db::update_ssl_status(&self.pool, id, SslStatus::Provisioning, None).await?;
+                    tracing::warn!(
+                        domain = %domain.domain,
+                        "domain verified with ssl_provider=acme, but automatic \
+                         provisioning is not implemented; certificate must be \
+                         supplied manually"
+                    );
+                    db::update_ssl_status(&self.pool, id, SslStatus::Pending, None).await?;
                 }
 
                 tracing::info!(domain = %domain.domain, "Domain verified successfully");
@@ -173,6 +187,18 @@ impl DomainManager {
         }
 
         Ok(result)
+    }
+
+    /// Look up a live HTTP verification challenge by its token.
+    ///
+    /// Exposed so the well-known endpoint can answer challenges without
+    /// reaching past this service for the pool. The caller must still check
+    /// that the request arrived for the returned domain.
+    pub async fn find_live_http_challenge(
+        &self,
+        token: &str,
+    ) -> ProxyResult<Option<db::HttpChallenge>> {
+        db::find_live_http_challenge(&self.pool, token).await
     }
 
     /// Enable a verified domain.

--- a/crates/postrust-proxy/src/saas/mod.rs
+++ b/crates/postrust-proxy/src/saas/mod.rs
@@ -7,8 +7,24 @@
 //! - Domain ownership verification (DNS TXT and HTTP challenge)
 //! - Multi-tenant API key authentication
 //! - Dynamic route management per verified domain
-//! - Automatic SSL certificate provisioning via ACME
 //! - Manual certificate upload support
+//!
+//! ## Not yet implemented
+//!
+//! **Automatic SSL provisioning via ACME.** A domain can be configured with
+//! `ssl_provider = "acme"` and the schema tracks an `ssl_status`, but nothing
+//! here has ever talked to a CA: no order is placed, and
+//! `/.well-known/acme-challenge/{token}` has no authorization to serve.
+//! Verifying such a domain leaves it `pending` rather than claiming to be
+//! provisioning. Use `manual` and upload a certificate until this lands.
+//!
+//! ## Prefer DNS verification
+//!
+//! HTTP verification asks the claimant to serve content at a path on the
+//! domain -- but once that domain points at this proxy, this proxy is what
+//! serves that path. Passing shows the domain resolves here, not that the
+//! claimant controls it. DNS verification does show control, and is the
+//! default.
 
 pub mod api_keys;
 pub mod auth;
@@ -17,6 +33,7 @@ pub mod handlers;
 pub mod manager;
 pub mod types;
 pub mod verification;
+pub mod wellknown_host;
 
 pub use api_keys::ApiKeyService;
 pub use auth::{AuthContext, AuthType, SaasAuthLayer};

--- a/crates/postrust-proxy/src/saas/wellknown_host.rs
+++ b/crates/postrust-proxy/src/saas/wellknown_host.rs
@@ -1,0 +1,148 @@
+//! Host-header matching for the well-known challenge endpoints.
+//!
+//! Split out from the handler so it can be tested without a database or a
+//! running listener, which is most of what there is to get wrong here.
+
+/// Whether a request's `Host` header names `domain`.
+///
+/// The comparison has to be deliberate rather than `==`, because a `Host`
+/// header is not a bare domain:
+///
+/// - it may carry a port (`example.com:8443`), which is not part of the name;
+/// - it is case-insensitive, per RFC 9110 section 4.2.3;
+/// - it may be an IPv6 literal in brackets (`[::1]:8443`), where the colons
+///   inside the brackets are not a port separator;
+/// - it may carry a fully-qualified trailing dot (`example.com.`), which names
+///   the same host as `example.com`.
+///
+/// Anything that does not parse as a host is not a match. Returning `false` on
+/// doubt is the safe direction: the caller uses this to decide whether to hand
+/// out a challenge secret.
+pub fn host_matches(host_header: Option<&str>, domain: &str) -> bool {
+    let Some(host) = host_header else {
+        return false;
+    };
+    let Some(name) = strip_port(host.trim()) else {
+        return false;
+    };
+    if name.is_empty() || domain.is_empty() {
+        return false;
+    }
+    normalize(name) == normalize(domain)
+}
+
+/// Drop a `:port` suffix, leaving the host name.
+///
+/// Returns `None` for input that is not a plausible host, including an
+/// unterminated IPv6 literal and a port that is not digits.
+fn strip_port(host: &str) -> Option<&str> {
+    if let Some(rest) = host.strip_prefix('[') {
+        // IPv6 literal: the colons before the closing bracket are part of the
+        // address, so the port can only follow the bracket.
+        let end = rest.find(']')?;
+        match rest[end + 1..].strip_prefix(':') {
+            // A bracketed address followed by anything that is not a port.
+            Some(port) if !is_port(port) => return None,
+            None if end + 1 != rest.len() => return None,
+            _ => {}
+        }
+        // Keep the brackets: that is how the authority form names the address,
+        // and how a configured domain would have to be written to match.
+        return Some(&host[..end + 2]);
+    }
+
+    match host.split_once(':') {
+        // A second colon outside brackets is not a valid authority.
+        Some((_, port)) if !is_port(port) => None,
+        Some((name, _)) => Some(name),
+        None => Some(host),
+    }
+}
+
+/// The digits of a port, with the `:` already removed. At least one, all ASCII.
+fn is_port(port: &str) -> bool {
+    !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Lowercase, and drop one fully-qualified trailing dot.
+fn normalize(name: &str) -> String {
+    name.strip_suffix('.').unwrap_or(name).to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_match() {
+        assert!(host_matches(Some("example.com"), "example.com"));
+    }
+
+    #[test]
+    fn mismatch_is_refused() {
+        assert!(!host_matches(Some("evil.test"), "example.com"));
+    }
+
+    #[test]
+    fn missing_header_is_refused() {
+        assert!(!host_matches(None, "example.com"));
+    }
+
+    #[test]
+    fn port_is_not_part_of_the_name() {
+        assert!(host_matches(Some("example.com:8443"), "example.com"));
+        assert!(host_matches(Some("example.com:80"), "example.com"));
+    }
+
+    #[test]
+    fn comparison_is_case_insensitive() {
+        assert!(host_matches(Some("ExAmPlE.CoM"), "example.com"));
+        assert!(host_matches(Some("example.com"), "EXAMPLE.COM"));
+    }
+
+    #[test]
+    fn trailing_dot_names_the_same_host() {
+        assert!(host_matches(Some("example.com."), "example.com"));
+        assert!(host_matches(Some("example.com.:443"), "example.com"));
+    }
+
+    #[test]
+    fn ipv6_literal_keeps_its_brackets() {
+        assert!(host_matches(Some("[::1]:8443"), "[::1]"));
+        assert!(host_matches(Some("[::1]"), "[::1]"));
+    }
+
+    #[test]
+    fn unterminated_ipv6_literal_is_refused() {
+        assert!(!host_matches(Some("[::1:8443"), "[::1]"));
+    }
+
+    #[test]
+    fn non_numeric_port_is_refused() {
+        assert!(!host_matches(Some("example.com:https"), "example.com"));
+    }
+
+    #[test]
+    fn a_second_colon_is_refused() {
+        assert!(!host_matches(Some("example.com:80:80"), "example.com"));
+    }
+
+    #[test]
+    fn empty_inputs_are_refused() {
+        assert!(!host_matches(Some(""), "example.com"));
+        assert!(!host_matches(Some("example.com"), ""));
+        assert!(!host_matches(Some(":8443"), "example.com"));
+    }
+
+    #[test]
+    fn surrounding_whitespace_is_tolerated() {
+        assert!(host_matches(Some("  example.com  "), "example.com"));
+    }
+
+    #[test]
+    fn a_prefix_of_the_domain_is_not_a_match() {
+        // The bug this guards against is a `starts_with` implementation.
+        assert!(!host_matches(Some("example.com.evil.test"), "example.com"));
+        assert!(!host_matches(Some("notexample.com"), "example.com"));
+    }
+}

--- a/docs/saas-domains.md
+++ b/docs/saas-domains.md
@@ -2,12 +2,20 @@
 
 > **Beta Feature** - This feature is currently in beta and will move to stable in Q2 2026. APIs may change before the stable release.
 
-Multi-tenant domain management API for SaaS applications. Allow your customers to bring their own custom domains with automatic SSL, domain verification, and reverse proxy routing.
+Multi-tenant domain management API for SaaS applications. Allow your customers to bring their own custom domains, with domain verification and reverse proxy routing.
+
+> **Automatic SSL is not implemented.** The schema tracks an `ssl_status` and a
+> domain can be configured with `ssl_provider = "acme"`, but nothing in the
+> proxy has ever talked to a certificate authority: no ACME order is placed and
+> no certificate is issued or renewed. Serve TLS from a certificate on disk
+> (`tls.cert_file` / `tls.key_file`) until this lands. See
+> [Stability and Versioning](./stability.md) — `postrust-proxy` is on a `0.x`
+> line precisely because of gaps like this one.
 
 ## Features
 
 - **Domain Verification**: DNS TXT and HTTP challenge methods
-- **SSL/TLS**: Automatic ACME (Let's Encrypt) + manual certificate upload
+- **SSL/TLS**: Not implemented — see the note above
 - **Authentication**: JWT + API Key dual authentication
 - **Multi-tenant**: Complete tenant isolation with quotas
 - **Dynamic Routing**: Per-domain routes without server restart
@@ -65,11 +73,10 @@ API keys are prefixed with `pk_` for identification and can have restricted scop
 | `GET` | `/api/v1/domains` | List domains |
 | `POST` | `/api/v1/domains` | Add domain |
 | `GET` | `/api/v1/domains/:id` | Get domain details |
-| `PUT` | `/api/v1/domains/:id` | Update domain |
 | `DELETE` | `/api/v1/domains/:id` | Remove domain |
 | `POST` | `/api/v1/domains/:id/verify` | Trigger verification |
-| `POST` | `/api/v1/domains/:id/ssl/provision` | Provision SSL via ACME |
-| `POST` | `/api/v1/domains/:id/ssl/upload` | Upload manual certificate |
+| `POST` | `/api/v1/domains/:id/enable` | Enable a verified domain |
+| `POST` | `/api/v1/domains/:id/disable` | Disable a domain |
 
 ### Routes
 
@@ -98,7 +105,6 @@ API keys are prefixed with `pk_` for identification and can have restricted scop
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/.well-known/postrust-verification/:token` | HTTP verification challenge |
-| `GET` | `/.well-known/acme-challenge/:token` | ACME challenge (Let's Encrypt) |
 
 ## Domain Verification
 
@@ -157,30 +163,45 @@ curl -X POST http://localhost:8080/api/v1/domains \
   }'
 ```
 
-2. Serve the verification file at:
+2. The proxy serves the challenge itself, at:
 
 ```
 https://app.example.com/.well-known/postrust-verification/<token>
 ```
 
-Content: `postrust-verify=<token>`
+It answers only for a challenge that is in the database, unexpired, unresolved,
+and whose domain matches the request's `Host`.
 
 3. Trigger verification (same as DNS method).
 
+### Prefer DNS verification
+
+HTTP verification asks the claimant to serve content at a path on the domain —
+but once that domain's DNS points at this proxy, this proxy is what serves that
+path. Passing therefore shows that the domain resolves here and that a
+challenge was issued for it. It does not show that the claimant controls the
+domain.
+
+DNS verification does show control, because the TXT record can only be placed
+by whoever holds the zone. It is the default (`verification_method` defaults to
+`dns`), and it is the one to use for anything that matters.
+
 ## SSL/TLS Certificates
 
-### Automatic ACME Provisioning
+### Automatic ACME Provisioning — not implemented
 
-After domain verification, provision SSL automatically:
+There is no ACME client here. A domain with `ssl_provider = "acme"` that passes
+verification is left with `ssl_status = "pending"` and a warning in the log; it
+is not queued for issuance, because there is nothing to queue it with.
 
-```bash
-curl -X POST http://localhost:8080/api/v1/domains/<id>/ssl/provision \
-  -H "Authorization: ApiKey pk_live_abc123..."
-```
+Serve TLS from a certificate on disk instead — set `tls.cert_file` and
+`tls.key_file`, which also gives you ALPN, so HTTP/2 and `wss://` work.
 
-This uses Let's Encrypt to issue and automatically renew certificates.
+`docker-compose.yml` carries a Pebble and challtestsrv pair behind the `acme`
+profile, ready for when an issuance flow is written against a CA that
+deliberately misbehaves.
 
-### Manual Certificate Upload
+### Manual Certificate Upload — not implemented
 
 For custom certificates:
 
@@ -408,24 +429,20 @@ DOMAIN_ID=$(curl -s -X POST http://localhost:8080/api/v1/domains \
 curl -X POST "http://localhost:8080/api/v1/domains/$DOMAIN_ID/verify" \
   -H "Authorization: ApiKey $API_KEY"
 
-# 4. Provision SSL
-curl -X POST "http://localhost:8080/api/v1/domains/$DOMAIN_ID/ssl/provision" \
-  -H "Authorization: ApiKey $API_KEY"
-
-# 5. Create upstream
+# 4. Create upstream
 UPSTREAM_ID=$(curl -s -X POST http://localhost:8080/api/v1/upstreams \
   -H "Authorization: ApiKey $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"name": "backend", "lb_strategy": "round_robin"}' \
   | jq -r '.data.id')
 
-# 6. Add backend server
+# 5. Add backend server
 curl -X POST "http://localhost:8080/api/v1/upstreams/$UPSTREAM_ID/backends" \
   -H "Authorization: ApiKey $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"address": "10.0.0.1:8080", "scheme": "http"}'
 
-# 7. Create route
+# 6. Create route
 curl -X POST "http://localhost:8080/api/v1/domains/$DOMAIN_ID/routes" \
   -H "Authorization: ApiKey $API_KEY" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
Found while auditing the proxy's stubs for the 1.0.0 run-up.

## The defect

`saas/handlers/wellknown.rs::handle_verification_challenge` served the domain-ownership challenge like this:

```rust
// Simplified implementation - in production you'd look up the challenge in DB
let expected_content = format!("postrust-verify={}", token);
(StatusCode::OK, expected_content)
```

No database lookup. No host check. And `verification.rs::verify_http` fetches exactly that path on the domain being claimed, comparing against exactly that string:

```rust
let url = format!("https://{}/.well-known/postrust-verification/{}", domain, token);
let expected_content = format!("postrust-verify={}", token);
```

So HTTP verification succeeded for **any** domain whose DNS pointed at the proxy, regardless of who was claiming it. The control proved nothing.

**Scope, stated accurately:** this is a broken control, not a demonstrated takeover. `proxy_domains.domain` is `UNIQUE` globally, so a second tenant cannot register a domain another tenant already holds. I initially read it as a two-tenant takeover path and corrected that in [#18](https://github.com/postrust/postrust/pull/18) once I checked the schema.

## The fix

The handler now answers only for a challenge that:

- exists in `proxy_verification_challenges`,
- is `challenge_type = 'http'`,
- has status `pending` or `checking` (not already resolved),
- has not passed `expires_at`,
- and whose domain matches the request's `Host`.

It returns the `expected_value` **stored when the challenge was issued**, never one recomputed from the path. Unknown, expired, resolved and wrong-host tokens all get the same 404, so the response does not confirm whether a token exists. A database error returns 500, not 404 — an outage must not read as a failed verification.

## Host matching, and why it is its own module

A `Host` header is not a bare domain, so `==` is wrong and `starts_with` is dangerous (`example.com.evil.test`). `saas/wellknown_host.rs` handles ports, case-insensitivity per RFC 9110 §4.2.3, bracketed IPv6 literals, and the fully-qualified trailing dot, with **13 unit tests** that need no database or listener.

Two of those tests failed on the first run and caught a real bug in my own code: `split_once(':')` had already consumed the colon that the port check was still looking for, so every `host:port` was rejected.

## The caveat that no amount of care removes

HTTP verification asks the claimant to serve content at a path on the domain — but once that domain's DNS points at this proxy, **this proxy is what serves that path**. Passing shows the domain resolves here and a challenge was issued for it; it does not show the claimant controls the domain. DNS verification does show that, and is already the default (`verification_method` defaults to `dns`). Now stated in the handler docs, the module docs, and `docs/saas-domains.md`.

## Two other "claims to do what it does not" fixes

**`ssl_status` claimed provisioning.** A verified domain with `ssl_provider = "acme"` was written as `provisioning` behind a `// TODO: Trigger ACME certificate provisioning`. Nothing here has ever talked to a CA, so the domain sat mid-issuance forever and an operator watching that field could not tell slow from never. Now `pending`, with a warning saying a certificate must be supplied manually.

**`handle_acme_challenge` was dead.** Defined, never mounted in any router. Removed rather than left standing in for a feature that does not exist; the module docs now say what is missing, and `docker-compose.yml` already has the Pebble harness ready for when issuance is written.

## Documentation corrected against the router

`docs/saas-domains.md` documented three endpoints that do not exist — `PUT /domains/:id`, `POST /domains/:id/ssl/provision`, `POST /domains/:id/ssl/upload` — omitted two that do (`enable`, `disable`), listed an unmounted `/.well-known/acme-challenge/:token`, and advertised automatic ACME provisioning in its feature list and end-to-end walkthrough. All corrected against the actual router.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test -p postrust-proxy` at **66 passed, 0 failed** (up from 53).

Not covered locally: the database-backed `-- --ignored` suite, which CI runs. The new query is runtime sqlx, matching the house style in `saas/db.rs`, so it is not compile-time checked against a live schema — it is checked against the columns in `migrations/20240115000001_saas_domains.sql`.