### PR TITLE
feat(proxy): implement database-backed configuration and admin persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ releases are described by their tags and the pull requests behind them.
 
 ## Unreleased
 
+### Added
+
+**Database-backed proxy configuration actually reads and writes.**
+`config::load_from_database` was two `// TODO: Implement database query`
+comments returning `Ok(Vec::new())`, so a proxy pointed at a database started,
+logged nothing wrong, and answered every request with 503 -- the same failure
+that file-configured routing had before `1.0.0-alpha.2`. It now loads real
+routes and upstreams from three new tables
+(`migrations/20260901000001_proxy_config.sql`), and `postrust-proxy` merges
+them into a file-bootstrapped config when `DATABASE_URL` is set.
+
+**The admin API persists.** Its route, upstream and backend mutations replied
+`200`/`201` after changing only the in-memory config, behind eight
+`// TODO: Persist to database` comments, so every change vanished on restart
+while reporting success. They now write through before touching the running
+config, and report a failure to persist as a 500 rather than a success. With
+`server.database_config = false` -- an explicit "this proxy is configured from
+a file" -- edits stay in memory as before.
+
 ### Fixed
 
 **HTTP domain verification proved nothing.** The endpoint serving the

--- a/crates/postrust-proxy/Cargo.toml
+++ b/crates/postrust-proxy/Cargo.toml
@@ -106,3 +106,7 @@ postrust-core.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros"] }
+# The database-backed tests in tests/ connect and assert on raw rows, so they
+# need these in their own right rather than through the library.
+sqlx.workspace = true
+uuid.workspace = true

--- a/crates/postrust-proxy/migrations/20260901000001_proxy_config.sql
+++ b/crates/postrust-proxy/migrations/20260901000001_proxy_config.sql
@@ -1,0 +1,113 @@
+-- Global proxy configuration: one proxy's own route table.
+--
+-- Distinct from the proxy_domain_* tables in 20240115000001_saas_domains.sql,
+-- which are the multi-tenant SaaS module's per-domain configuration scoped to a
+-- tenant. These three hold the configuration that `config::load_from_database`
+-- reads at startup and the admin API edits at runtime -- the database-backed
+-- equivalent of the `[[routes]]` and `[[upstreams]]` tables in a TOML config.
+--
+-- The columns mirror `config::types::{Route, Upstream, Backend}` field for
+-- field, so that a config loaded from here and one parsed from TOML are the
+-- same value. Where a Rust type has no direct SQL equivalent the mapping is
+-- called out in a comment on the column.
+
+-- Upstreams: a named group of backend servers.
+CREATE TABLE IF NOT EXISTS proxy_upstreams (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Routes reference an upstream by name, and `Upstream::resolved_id`
+    -- derives a stable UUID from it, so the name has to be unique.
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+    lb_strategy VARCHAR(20) NOT NULL DEFAULT 'round_robin'
+        CHECK (lb_strategy IN ('round_robin', 'least_connections', 'weighted', 'random', 'sticky')),
+    -- HealthCheckConfig, flattened. It is a fixed set of scalars with no
+    -- identity of its own, so a child table would buy nothing.
+    health_check_enabled BOOLEAN NOT NULL DEFAULT true,
+    health_check_path VARCHAR(500) NOT NULL DEFAULT '/health',
+    health_check_interval_secs INTEGER NOT NULL DEFAULT 30 CHECK (health_check_interval_secs > 0),
+    health_check_timeout_secs INTEGER NOT NULL DEFAULT 5 CHECK (health_check_timeout_secs > 0),
+    healthy_threshold INTEGER NOT NULL DEFAULT 2 CHECK (healthy_threshold > 0),
+    unhealthy_threshold INTEGER NOT NULL DEFAULT 3 CHECK (unhealthy_threshold > 0),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Backends belonging to an upstream.
+CREATE TABLE IF NOT EXISTS proxy_upstream_backends (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    upstream_id UUID NOT NULL REFERENCES proxy_upstreams(id) ON DELETE CASCADE,
+    address VARCHAR(255) NOT NULL,
+    scheme VARCHAR(10) NOT NULL DEFAULT 'http' CHECK (scheme IN ('http', 'https')),
+    weight INTEGER NOT NULL DEFAULT 1 CHECK (weight > 0),
+    -- UpstreamHttpVersion. Stored as the serde-canonical form of each variant,
+    -- not the aliases, so there is one spelling in the database.
+    http_version VARCHAR(10) NOT NULL DEFAULT 'http11'
+        CHECK (http_version IN ('http11', 'h2c')),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- One entry per address within an upstream: two rows for the same backend
+    -- would silently double its share of round-robin.
+    UNIQUE (upstream_id, address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_proxy_upstream_backends_upstream
+    ON proxy_upstream_backends(upstream_id);
+
+-- Routes: which requests go to which upstream.
+CREATE TABLE IF NOT EXISTS proxy_routes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    description TEXT,
+
+    -- RouteMatch, flattened with a match_ prefix.
+    match_host VARCHAR(253),
+    match_path VARCHAR(500),
+    match_path_type VARCHAR(10) NOT NULL DEFAULT 'prefix'
+        CHECK (match_path_type IN ('prefix', 'exact', 'regex')),
+    -- HashMap<String, String>. JSONB rather than hstore: no extension needed,
+    -- and it round-trips through serde_json without a custom type.
+    match_headers JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Option<Vec<String>>: NULL means "any method", which is not the same as
+    -- an empty list, so this is nullable rather than defaulting to '{}'.
+    match_methods TEXT[],
+
+    priority INTEGER NOT NULL DEFAULT 100,
+    -- Upstream *name*, matching `Route::upstream`. Not a foreign key: a TOML
+    -- config can name an upstream that is not in the database, and refusing to
+    -- load a route because its upstream lives elsewhere would be wrong.
+    upstream VARCHAR(255) NOT NULL,
+    strip_path BOOLEAN NOT NULL DEFAULT false,
+    add_headers JSONB NOT NULL DEFAULT '{}'::jsonb,
+    remove_headers TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+
+    -- Option<RouteRateLimit>. RateLimitKey is an enum with a payload
+    -- (`Header(String)`), so the discriminant and the header name get a column
+    -- each rather than being packed into one string that has to be parsed.
+    rate_limit_requests INTEGER CHECK (rate_limit_requests > 0),
+    rate_limit_window_secs INTEGER CHECK (rate_limit_window_secs > 0),
+    rate_limit_key VARCHAR(20) CHECK (rate_limit_key IN ('client_ip', 'header', 'route')),
+    rate_limit_header VARCHAR(255),
+
+    timeout_secs INTEGER NOT NULL DEFAULT 30 CHECK (timeout_secs > 0),
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    enabled BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- `Option<RouteRateLimit>` is all-or-nothing. Without this a half-written
+    -- rate limit would load as no rate limit at all, which is the failure mode
+    -- where a limit silently stops applying.
+    CONSTRAINT proxy_routes_rate_limit_whole CHECK (
+        num_nonnulls(rate_limit_requests, rate_limit_window_secs, rate_limit_key) IN (0, 3)
+    ),
+
+    -- `RateLimitKey::Header` carries a name; the other two variants do not.
+    CONSTRAINT proxy_routes_rate_limit_header CHECK (
+        (rate_limit_key = 'header') = (rate_limit_header IS NOT NULL)
+    )
+);
+
+-- Routes are matched highest priority first, which is also the load order.
+CREATE INDEX IF NOT EXISTS idx_proxy_routes_priority ON proxy_routes(priority DESC);
+CREATE INDEX IF NOT EXISTS idx_proxy_routes_upstream ON proxy_routes(upstream);

--- a/crates/postrust-proxy/src/admin/api.rs
+++ b/crates/postrust-proxy/src/admin/api.rs
@@ -42,6 +42,31 @@ impl<T: Serialize> ApiResponse<T> {
     }
 }
 
+/// A 500 for a persistence failure.
+///
+/// The distinction from a 404 matters: "the database refused this" and "there
+/// is no such route" are different answers, and returning success for either
+/// is what this module used to do.
+fn persistence_failed(error: crate::error::ProxyError) -> axum::response::Response {
+    tracing::error!(%error, "admin API could not persist a configuration change");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ApiResponse::<()>::error(format!(
+            "could not persist the change: {error}"
+        ))),
+    )
+        .into_response()
+}
+
+/// Whether edits go to the database as well as to the running config.
+///
+/// `server.database_config` defaults to true. Setting it false is an explicit
+/// "this proxy is configured from a file", and edits then last as long as the
+/// process -- which is what was asked for, rather than a silent loss.
+async fn persists(state: &ProxyState) -> bool {
+    state.config.read().await.server.database_config
+}
+
 /// Create the admin API router.
 pub fn admin_router() -> Router<Arc<ProxyState>> {
     Router::new()
@@ -134,11 +159,19 @@ async fn create_route(
         enabled: true,
     };
 
-    // TODO: Persist to database
+    if persists(&state).await {
+        // Write through before touching the running config: a create that
+        // answers 201 and is gone after a restart is worse than one that
+        // fails now and says why.
+        if let Err(error) = crate::config::save_route(&state.pool, &route).await {
+            return persistence_failed(error);
+        }
+    }
+
     let mut config = state.config.write().await;
     config.routes.push(route.clone());
 
-    (StatusCode::CREATED, Json(ApiResponse::success(route)))
+    (StatusCode::CREATED, Json(ApiResponse::success(route))).into_response()
 }
 
 async fn update_route(
@@ -146,30 +179,58 @@ async fn update_route(
     Path(id): Path<Uuid>,
     Json(req): Json<CreateRouteRequest>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
-
-    if let Some(route) = config.routes.iter_mut().find(|r| r.id == Some(id)) {
-        route.name = req.name;
-        route.match_.host = req.host;
-        route.match_.path = req.path;
-        route.upstream = req.upstream;
-        route.strip_path = req.strip_path.unwrap_or(false);
-        route.priority = req.priority.unwrap_or(100);
-        if let Some(add_headers) = req.add_headers {
-            route.add_headers = add_headers;
-        }
-        if let Some(remove_headers) = req.remove_headers {
-            route.remove_headers = remove_headers;
-        }
-
-        // TODO: Persist to database
-        Json(ApiResponse::success(route.clone())).into_response()
-    } else {
-        (
+    // Build the updated route from a snapshot rather than mutating in place,
+    // so the running config is only touched once the database has accepted it.
+    let Some(mut updated) = state
+        .config
+        .read()
+        .await
+        .routes
+        .iter()
+        .find(|r| r.id == Some(id))
+        .cloned()
+    else {
+        return (
             StatusCode::NOT_FOUND,
             Json(ApiResponse::<()>::error("Route not found")),
         )
-            .into_response()
+            .into_response();
+    };
+
+    updated.name = req.name;
+    updated.match_.host = req.host;
+    updated.match_.path = req.path;
+    updated.upstream = req.upstream;
+    updated.strip_path = req.strip_path.unwrap_or(false);
+    updated.priority = req.priority.unwrap_or(100);
+    if let Some(add_headers) = req.add_headers {
+        updated.add_headers = add_headers;
+    }
+    if let Some(remove_headers) = req.remove_headers {
+        updated.remove_headers = remove_headers;
+    }
+
+    if persists(&state).await {
+        if let Err(error) = crate::config::save_route(&state.pool, &updated).await {
+            return persistence_failed(error);
+        }
+    }
+
+    let mut config = state.config.write().await;
+    match config.routes.iter_mut().find(|r| r.id == Some(id)) {
+        Some(route) => {
+            *route = updated.clone();
+            Json(ApiResponse::success(updated)).into_response()
+        }
+        // Deleted while we were writing. The database now holds it and the
+        // running config does not; say so rather than reporting success.
+        None => (
+            StatusCode::CONFLICT,
+            Json(ApiResponse::<()>::error(
+                "Route was removed while the update was being saved",
+            )),
+        )
+            .into_response(),
     }
 }
 
@@ -177,20 +238,38 @@ async fn delete_route(
     State(state): State<Arc<ProxyState>>,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
-    let len_before = config.routes.len();
-    config.routes.retain(|r| r.id != Some(id));
-
-    if config.routes.len() < len_before {
-        // TODO: Delete from database
-        Json(ApiResponse::success(())).into_response()
-    } else {
-        (
+    if !state
+        .config
+        .read()
+        .await
+        .routes
+        .iter()
+        .any(|r| r.id == Some(id))
+    {
+        return (
             StatusCode::NOT_FOUND,
             Json(ApiResponse::<()>::error("Route not found")),
         )
-            .into_response()
+            .into_response();
     }
+
+    if persists(&state).await {
+        // A `false` here is not an error: a route that came from a TOML config
+        // has no row to delete. The 404 above already established that the
+        // route existed in the running config, which is what was asked about.
+        if let Err(error) = crate::config::delete_route(&state.pool, id).await {
+            return persistence_failed(error);
+        }
+    }
+
+    state
+        .config
+        .write()
+        .await
+        .routes
+        .retain(|r| r.id != Some(id));
+
+    Json(ApiResponse::success(())).into_response()
 }
 
 // Upstream handlers
@@ -257,11 +336,16 @@ async fn create_upstream(
         enabled: true,
     };
 
-    // TODO: Persist to database
+    if persists(&state).await {
+        if let Err(error) = crate::config::save_upstream(&state.pool, &upstream).await {
+            return persistence_failed(error);
+        }
+    }
+
     let mut config = state.config.write().await;
     config.upstreams.push(upstream.clone());
 
-    (StatusCode::CREATED, Json(ApiResponse::success(upstream)))
+    (StatusCode::CREATED, Json(ApiResponse::success(upstream))).into_response()
 }
 
 async fn update_upstream(
@@ -269,21 +353,49 @@ async fn update_upstream(
     Path(id): Path<Uuid>,
     Json(req): Json<CreateUpstreamRequest>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
-
-    if let Some(upstream) = config.upstreams.iter_mut().find(|u| u.id == Some(id)) {
-        upstream.name = req.name;
-        upstream.lb_strategy = req.lb_strategy.unwrap_or_default();
-        // Note: backends update would need more sophisticated handling
-
-        // TODO: Persist to database
-        Json(ApiResponse::success(upstream.clone())).into_response()
-    } else {
-        (
+    let Some(mut updated) = state
+        .config
+        .read()
+        .await
+        .upstreams
+        .iter()
+        .find(|u| u.id == Some(id))
+        .cloned()
+    else {
+        return (
             StatusCode::NOT_FOUND,
             Json(ApiResponse::<()>::error("Upstream not found")),
         )
-            .into_response()
+            .into_response();
+    };
+
+    updated.name = req.name;
+    updated.lb_strategy = req.lb_strategy.unwrap_or_default();
+    // `req.backends` is deliberately not applied. CreateUpstreamRequest cannot
+    // express a backend's id, so treating its list as the new set would
+    // re-create every backend under a fresh id on each update, and an empty
+    // list -- which is what a caller sends when it only means to rename --
+    // would silently remove every backend. Use the backend endpoints instead.
+
+    if persists(&state).await {
+        if let Err(error) = crate::config::save_upstream(&state.pool, &updated).await {
+            return persistence_failed(error);
+        }
+    }
+
+    let mut config = state.config.write().await;
+    match config.upstreams.iter_mut().find(|u| u.id == Some(id)) {
+        Some(upstream) => {
+            *upstream = updated.clone();
+            Json(ApiResponse::success(updated)).into_response()
+        }
+        None => (
+            StatusCode::CONFLICT,
+            Json(ApiResponse::<()>::error(
+                "Upstream was removed while the update was being saved",
+            )),
+        )
+            .into_response(),
     }
 }
 
@@ -291,20 +403,35 @@ async fn delete_upstream(
     State(state): State<Arc<ProxyState>>,
     Path(id): Path<Uuid>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
-    let len_before = config.upstreams.len();
-    config.upstreams.retain(|u| u.id != Some(id));
-
-    if config.upstreams.len() < len_before {
-        // TODO: Delete from database
-        Json(ApiResponse::success(())).into_response()
-    } else {
-        (
+    if !state
+        .config
+        .read()
+        .await
+        .upstreams
+        .iter()
+        .any(|u| u.id == Some(id))
+    {
+        return (
             StatusCode::NOT_FOUND,
             Json(ApiResponse::<()>::error("Upstream not found")),
         )
-            .into_response()
+            .into_response();
     }
+
+    if persists(&state).await {
+        if let Err(error) = crate::config::delete_upstream(&state.pool, id).await {
+            return persistence_failed(error);
+        }
+    }
+
+    state
+        .config
+        .write()
+        .await
+        .upstreams
+        .retain(|u| u.id != Some(id));
+
+    Json(ApiResponse::success(())).into_response()
 }
 
 // Backend handlers
@@ -332,32 +459,57 @@ async fn add_backend(
     Path(upstream_id): Path<Uuid>,
     Json(req): Json<BackendRequest>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
+    let Some(mut updated) = state
+        .config
+        .read()
+        .await
+        .upstreams
+        .iter()
+        .find(|u| u.id == Some(upstream_id))
+        .cloned()
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ApiResponse::<()>::error("Upstream not found")),
+        )
+            .into_response();
+    };
 
-    if let Some(upstream) = config
+    let backend = Backend {
+        id: Some(Uuid::new_v4()),
+        address: req.address,
+        weight: req.weight.unwrap_or(100),
+        scheme: req.scheme.unwrap_or_else(|| "http".to_string()),
+        enabled: true,
+        http_version: Default::default(),
+    };
+    updated.backends.push(backend.clone());
+
+    if persists(&state).await {
+        // `save_upstream` writes the whole backend set in one transaction, so
+        // the upstream is never briefly left without backends.
+        if let Err(error) = crate::config::save_upstream(&state.pool, &updated).await {
+            return persistence_failed(error);
+        }
+    }
+
+    let mut config = state.config.write().await;
+    match config
         .upstreams
         .iter_mut()
         .find(|u| u.id == Some(upstream_id))
     {
-        let backend = Backend {
-            id: Some(Uuid::new_v4()),
-            address: req.address,
-            weight: req.weight.unwrap_or(100),
-            scheme: req.scheme.unwrap_or_else(|| "http".to_string()),
-            enabled: true,
-            http_version: Default::default(),
-        };
-
-        upstream.backends.push(backend.clone());
-
-        // TODO: Persist to database
-        (StatusCode::CREATED, Json(ApiResponse::success(backend))).into_response()
-    } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiResponse::<()>::error("Upstream not found")),
+        Some(upstream) => {
+            *upstream = updated;
+            (StatusCode::CREATED, Json(ApiResponse::success(backend))).into_response()
+        }
+        None => (
+            StatusCode::CONFLICT,
+            Json(ApiResponse::<()>::error(
+                "Upstream was removed while the backend was being saved",
+            )),
         )
-            .into_response()
+            .into_response(),
     }
 }
 
@@ -365,32 +517,55 @@ async fn remove_backend(
     State(state): State<Arc<ProxyState>>,
     Path((upstream_id, backend_id)): Path<(Uuid, Uuid)>,
 ) -> impl IntoResponse {
-    let mut config = state.config.write().await;
+    let Some(mut updated) = state
+        .config
+        .read()
+        .await
+        .upstreams
+        .iter()
+        .find(|u| u.id == Some(upstream_id))
+        .cloned()
+    else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ApiResponse::<()>::error("Upstream not found")),
+        )
+            .into_response();
+    };
 
-    if let Some(upstream) = config
+    let before = updated.backends.len();
+    updated.backends.retain(|b| b.id != Some(backend_id));
+    if updated.backends.len() == before {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(ApiResponse::<()>::error("Backend not found")),
+        )
+            .into_response();
+    }
+
+    if persists(&state).await {
+        if let Err(error) = crate::config::save_upstream(&state.pool, &updated).await {
+            return persistence_failed(error);
+        }
+    }
+
+    let mut config = state.config.write().await;
+    match config
         .upstreams
         .iter_mut()
         .find(|u| u.id == Some(upstream_id))
     {
-        let len_before = upstream.backends.len();
-        upstream.backends.retain(|b| b.id != Some(backend_id));
-
-        if upstream.backends.len() < len_before {
-            // TODO: Delete from database
+        Some(upstream) => {
+            *upstream = updated;
             Json(ApiResponse::success(())).into_response()
-        } else {
-            (
-                StatusCode::NOT_FOUND,
-                Json(ApiResponse::<()>::error("Backend not found")),
-            )
-                .into_response()
         }
-    } else {
-        (
-            StatusCode::NOT_FOUND,
-            Json(ApiResponse::<()>::error("Upstream not found")),
+        None => (
+            StatusCode::CONFLICT,
+            Json(ApiResponse::<()>::error(
+                "Upstream was removed while the backend was being deleted",
+            )),
         )
-            .into_response()
+            .into_response(),
     }
 }
 

--- a/crates/postrust-proxy/src/bin/postrust-proxy.rs
+++ b/crates/postrust-proxy/src/bin/postrust-proxy.rs
@@ -15,11 +15,18 @@
 //! lazily-connected pool to a database that does not exist is fine for
 //! file-configured runs. `HealthChecker::is_healthy` treats an unknown backend
 //! as healthy, so backends are used as configured.
+//!
+//! When `DATABASE_URL` *is* set and `server.database_config` is left at its
+//! default of true, the routes and upstreams in the database are loaded and
+//! added to whatever the file declared. The trigger is the variable rather
+//! than the flag alone: `database_config` defaults to true, so keying off it
+//! by itself would make every file-configured proxy -- the conformance
+//! harnesses included -- try to reach a database that is not there.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use postrust_proxy::config::{load_from_file, ProxyConfig};
+use postrust_proxy::config::{load_from_database, load_from_file, ProxyConfig};
 use postrust_proxy::health::HealthChecker;
 use postrust_proxy::ratelimit::RateLimiter;
 use postrust_proxy::vendored::ProxyService;
@@ -53,12 +60,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map_err(|e| format!("bad listen address in {config_path}: {e}"))?;
 
     // Lazy: no connection is attempted here, and none is needed unless the
-    // health checker's background task runs.
-    let pool =
-        PgPoolOptions::new()
-            .connect_lazy(&std::env::var("DATABASE_URL").unwrap_or_else(|_| {
-                "postgres://postgres:postgres@127.0.0.1:5432/postgres".into()
-            }))?;
+    // health checker's background task runs or the database holds config.
+    let database_url = std::env::var("DATABASE_URL").ok();
+    let pool = PgPoolOptions::new().connect_lazy(
+        database_url
+            .as_deref()
+            .unwrap_or("postgres://postgres:postgres@127.0.0.1:5432/postgres"),
+    )?;
+
+    let mut config = config;
+    if config.server.database_config && database_url.is_some() {
+        let (routes, upstreams) = load_from_database(&pool).await?;
+        tracing::info!(
+            routes = routes.len(),
+            upstreams = upstreams.len(),
+            "loaded configuration from the database"
+        );
+        merge_from_database(&mut config, routes, upstreams)?;
+    }
+    let config = config;
 
     let rate_limiter = Arc::new(RateLimiter::new(config.rate_limit.clone()));
     let health_checker = Arc::new(HealthChecker::new(pool));
@@ -127,5 +147,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tls.await
             .map_err(|e| format!("https listener panicked: {e}"))??;
     }
+    Ok(())
+}
+
+/// Add database-held routes and upstreams to a file-bootstrapped config.
+///
+/// Names have to stay unique across both sources. `Upstream::resolved_id`
+/// derives a UUID from the name when there is no id, and the routing tables are
+/// keyed by it -- so two upstreams sharing a name would collide there, and one
+/// would silently take the other's traffic. Refusing to start is the right
+/// answer to a configuration that cannot be represented.
+fn merge_from_database(
+    config: &mut ProxyConfig,
+    routes: Vec<postrust_proxy::config::Route>,
+    upstreams: Vec<postrust_proxy::config::Upstream>,
+) -> Result<(), String> {
+    for upstream in &upstreams {
+        if config.upstreams.iter().any(|u| u.name == upstream.name) {
+            return Err(format!(
+                "upstream {:?} is declared in both the config file and the database",
+                upstream.name
+            ));
+        }
+    }
+    for route in &routes {
+        if config.routes.iter().any(|r| r.name == route.name) {
+            return Err(format!(
+                "route {:?} is declared in both the config file and the database",
+                route.name
+            ));
+        }
+    }
+    config.upstreams.extend(upstreams);
+    config.routes.extend(routes);
     Ok(())
 }

--- a/crates/postrust-proxy/src/config/database.rs
+++ b/crates/postrust-proxy/src/config/database.rs
@@ -1,24 +1,614 @@
-//! Database-backed configuration loading.
+//! Database-backed configuration loading and persistence.
+//!
+//! The database equivalent of `config::file`: the same [`Route`] and
+//! [`Upstream`] values a TOML config parses into, read from and written to the
+//! tables in `migrations/20260901000001_proxy_config.sql`.
+//!
+//! These are the *global* proxy configuration tables, distinct from the
+//! `proxy_domain_*` tables the multi-tenant SaaS module owns, which are scoped
+//! to a tenant and a domain.
+//!
+//! Queries use runtime sqlx (`query`) rather than the compile-time-checked
+//! macros, matching `saas::db`, so the crate builds without a live database.
+//!
+//! # Decoding is strict
+//!
+//! Every enum column has a `CHECK` constraint, so an unrecognised value should
+//! be impossible. When one turns up anyway -- a hand-edited row, a database
+//! restored from a newer schema -- these functions return an error rather than
+//! substituting a default. A silent default here means a route quietly matching
+//! differently, or a rate limit quietly not applying, which is worse than
+//! refusing to start.
 
-use crate::config::{Route, Upstream};
-use crate::error::ProxyResult;
-use sqlx::PgPool;
+use std::collections::HashMap;
 
-/// Load routes from the database.
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::config::{
+    Backend, HealthCheckConfig, LoadBalanceStrategy, PathMatchType, RateLimitKey, Route,
+    RouteMatch, RouteRateLimit, Upstream, UpstreamHttpVersion,
+};
+use crate::error::{ProxyError, ProxyResult};
+
+// ============================================================================
+// Enum <-> string
+//
+// The stored spelling is the serde-canonical form of each variant, so what is
+// in the database matches what a TOML config would say.
+// ============================================================================
+
+fn lb_strategy_str(strategy: &LoadBalanceStrategy) -> &'static str {
+    match strategy {
+        LoadBalanceStrategy::RoundRobin => "round_robin",
+        LoadBalanceStrategy::LeastConnections => "least_connections",
+        LoadBalanceStrategy::Weighted => "weighted",
+        LoadBalanceStrategy::Random => "random",
+        LoadBalanceStrategy::Sticky => "sticky",
+    }
+}
+
+fn lb_strategy_from(value: &str) -> ProxyResult<LoadBalanceStrategy> {
+    Ok(match value {
+        "round_robin" => LoadBalanceStrategy::RoundRobin,
+        "least_connections" => LoadBalanceStrategy::LeastConnections,
+        "weighted" => LoadBalanceStrategy::Weighted,
+        "random" => LoadBalanceStrategy::Random,
+        "sticky" => LoadBalanceStrategy::Sticky,
+        other => return Err(unknown("lb_strategy", other)),
+    })
+}
+
+fn path_type_str(path_type: &PathMatchType) -> &'static str {
+    match path_type {
+        PathMatchType::Prefix => "prefix",
+        PathMatchType::Exact => "exact",
+        PathMatchType::Regex => "regex",
+    }
+}
+
+fn path_type_from(value: &str) -> ProxyResult<PathMatchType> {
+    Ok(match value {
+        "prefix" => PathMatchType::Prefix,
+        "exact" => PathMatchType::Exact,
+        "regex" => PathMatchType::Regex,
+        other => return Err(unknown("match_path_type", other)),
+    })
+}
+
+fn http_version_str(version: &UpstreamHttpVersion) -> &'static str {
+    match version {
+        UpstreamHttpVersion::Http11 => "http11",
+        UpstreamHttpVersion::H2c => "h2c",
+    }
+}
+
+fn http_version_from(value: &str) -> ProxyResult<UpstreamHttpVersion> {
+    Ok(match value {
+        "http11" => UpstreamHttpVersion::Http11,
+        "h2c" => UpstreamHttpVersion::H2c,
+        other => return Err(unknown("http_version", other)),
+    })
+}
+
+/// `RateLimitKey` split into the two columns that hold it: a discriminant, and
+/// the header name that only the `Header` variant carries.
+fn rate_limit_key_columns(key: &RateLimitKey) -> (&'static str, Option<&str>) {
+    match key {
+        RateLimitKey::ClientIp => ("client_ip", None),
+        RateLimitKey::Header(name) => ("header", Some(name.as_str())),
+        RateLimitKey::Route => ("route", None),
+    }
+}
+
+fn rate_limit_key_from(kind: &str, header: Option<String>) -> ProxyResult<RateLimitKey> {
+    Ok(match (kind, header) {
+        ("client_ip", _) => RateLimitKey::ClientIp,
+        ("route", _) => RateLimitKey::Route,
+        ("header", Some(name)) => RateLimitKey::Header(name),
+        // The schema's `proxy_routes_rate_limit_header` constraint makes this
+        // unreachable through normal writes; say so rather than inventing a
+        // header name to limit on.
+        ("header", None) => {
+            return Err(ProxyError::Config(
+                "rate_limit_key is 'header' but rate_limit_header is NULL".into(),
+            ))
+        }
+        (other, _) => return Err(unknown("rate_limit_key", other)),
+    })
+}
+
+fn unknown(column: &str, value: &str) -> ProxyError {
+    ProxyError::Config(format!(
+        "unrecognised {column} value {value:?} in the proxy configuration tables"
+    ))
+}
+
+/// Widen a stored `INTEGER` into the `u32` the config types use.
+///
+/// The schema forbids negatives on every column this is applied to, so a
+/// failure here means the row was written around the constraints.
+fn positive(column: &str, value: i32) -> ProxyResult<u32> {
+    u32::try_from(value)
+        .map_err(|_| ProxyError::Config(format!("{column} is negative ({value}) in the database")))
+}
+
+/// Narrow a `u32` from the config types into a storable `INTEGER`.
+fn storable(column: &str, value: u32) -> ProxyResult<i32> {
+    i32::try_from(value).map_err(|_| {
+        ProxyError::Validation(format!(
+            "{column} is too large to store ({value} > 2147483647)"
+        ))
+    })
+}
+
+// ============================================================================
+// Loading
+// ============================================================================
+
+/// Load the whole proxy configuration: every route and every upstream.
+///
+/// Rows are returned whether or not they are `enabled`; that flag is part of
+/// the configuration, and the caller decides what to do with it, exactly as it
+/// would for a TOML config.
 pub async fn load_from_database(pool: &PgPool) -> ProxyResult<(Vec<Route>, Vec<Upstream>)> {
     let routes = load_routes(pool).await?;
     let upstreams = load_upstreams(pool).await?;
     Ok((routes, upstreams))
 }
 
-async fn load_routes(_pool: &PgPool) -> ProxyResult<Vec<Route>> {
-    // TODO: Implement database query
-    // For now, return empty
-    Ok(Vec::new())
+/// Load every route, highest priority first.
+///
+/// The ordering is not cosmetic: routes are matched in priority order, so
+/// loading them in that order means the in-memory table is already in matching
+/// order. `name` breaks ties so that two runs against an unchanged database
+/// produce the same table.
+pub async fn load_routes(pool: &PgPool) -> ProxyResult<Vec<Route>> {
+    let rows = sqlx::query(
+        "SELECT id, name, description, match_host, match_path, match_path_type, \
+                match_headers, match_methods, priority, upstream, strip_path, \
+                add_headers, remove_headers, rate_limit_requests, \
+                rate_limit_window_secs, rate_limit_key, rate_limit_header, \
+                timeout_secs, retry_count, enabled \
+         FROM proxy_routes \
+         ORDER BY priority DESC, name ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(route_from_row).collect()
 }
 
-async fn load_upstreams(_pool: &PgPool) -> ProxyResult<Vec<Upstream>> {
-    // TODO: Implement database query
-    // For now, return empty
-    Ok(Vec::new())
+/// Load every upstream, each with its backends.
+///
+/// Two queries rather than one per upstream: the backends come back in a single
+/// pass and are grouped in memory. A proxy with a hundred upstreams should not
+/// make a hundred and one round trips to start.
+pub async fn load_upstreams(pool: &PgPool) -> ProxyResult<Vec<Upstream>> {
+    let rows = sqlx::query(
+        "SELECT id, name, description, lb_strategy, health_check_enabled, \
+                health_check_path, health_check_interval_secs, \
+                health_check_timeout_secs, healthy_threshold, \
+                unhealthy_threshold, enabled \
+         FROM proxy_upstreams \
+         ORDER BY name ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut backends = load_all_backends(pool).await?;
+
+    rows.into_iter()
+        .map(|row| {
+            let id: Uuid = row.try_get("id")?;
+            Ok(Upstream {
+                id: Some(id),
+                name: row.try_get("name")?,
+                description: row.try_get("description")?,
+                lb_strategy: lb_strategy_from(row.try_get("lb_strategy")?)?,
+                backends: backends.remove(&id).unwrap_or_default(),
+                health_check: HealthCheckConfig {
+                    enabled: row.try_get("health_check_enabled")?,
+                    path: row.try_get("health_check_path")?,
+                    interval_secs: positive(
+                        "health_check_interval_secs",
+                        row.try_get("health_check_interval_secs")?,
+                    )?,
+                    timeout_secs: positive(
+                        "health_check_timeout_secs",
+                        row.try_get("health_check_timeout_secs")?,
+                    )?,
+                    healthy_threshold: positive(
+                        "healthy_threshold",
+                        row.try_get("healthy_threshold")?,
+                    )?,
+                    unhealthy_threshold: positive(
+                        "unhealthy_threshold",
+                        row.try_get("unhealthy_threshold")?,
+                    )?,
+                },
+                enabled: row.try_get("enabled")?,
+            })
+        })
+        .collect()
+}
+
+/// Every backend in the database, grouped by the upstream it belongs to.
+async fn load_all_backends(pool: &PgPool) -> ProxyResult<HashMap<Uuid, Vec<Backend>>> {
+    let rows = sqlx::query(
+        "SELECT id, upstream_id, address, scheme, weight, http_version, enabled \
+         FROM proxy_upstream_backends \
+         ORDER BY address ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let mut grouped: HashMap<Uuid, Vec<Backend>> = HashMap::new();
+    for row in rows {
+        let upstream_id: Uuid = row.try_get("upstream_id")?;
+        grouped.entry(upstream_id).or_default().push(Backend {
+            id: Some(row.try_get("id")?),
+            address: row.try_get("address")?,
+            scheme: row.try_get("scheme")?,
+            weight: positive("weight", row.try_get("weight")?)?,
+            enabled: row.try_get("enabled")?,
+            http_version: http_version_from(row.try_get("http_version")?)?,
+        });
+    }
+    Ok(grouped)
+}
+
+fn route_from_row(row: sqlx::postgres::PgRow) -> ProxyResult<Route> {
+    // All three columns are present or none are, enforced by
+    // `proxy_routes_rate_limit_whole`; read the discriminant and let the other
+    // two follow it rather than assembling a partial limit.
+    let rate_limit = match row.try_get::<Option<String>, _>("rate_limit_key")? {
+        Some(kind) => Some(RouteRateLimit {
+            requests: positive(
+                "rate_limit_requests",
+                row.try_get::<Option<i32>, _>("rate_limit_requests")?
+                    .ok_or_else(|| {
+                        ProxyError::Config("rate_limit_requests is NULL with a key set".into())
+                    })?,
+            )?,
+            window_secs: positive(
+                "rate_limit_window_secs",
+                row.try_get::<Option<i32>, _>("rate_limit_window_secs")?
+                    .ok_or_else(|| {
+                        ProxyError::Config("rate_limit_window_secs is NULL with a key set".into())
+                    })?,
+            )?,
+            key: rate_limit_key_from(&kind, row.try_get("rate_limit_header")?)?,
+        }),
+        None => None,
+    };
+
+    let match_headers: sqlx::types::Json<HashMap<String, String>> = row.try_get("match_headers")?;
+    let add_headers: sqlx::types::Json<HashMap<String, String>> = row.try_get("add_headers")?;
+
+    Ok(Route {
+        id: Some(row.try_get("id")?),
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        match_: RouteMatch {
+            host: row.try_get("match_host")?,
+            path: row.try_get("match_path")?,
+            path_type: path_type_from(row.try_get("match_path_type")?)?,
+            headers: match_headers.0,
+            methods: row.try_get("match_methods")?,
+        },
+        priority: row.try_get("priority")?,
+        upstream: row.try_get("upstream")?,
+        strip_path: row.try_get("strip_path")?,
+        add_headers: add_headers.0,
+        remove_headers: row.try_get("remove_headers")?,
+        rate_limit,
+        timeout_secs: positive("timeout_secs", row.try_get("timeout_secs")?)?,
+        retry_count: positive("retry_count", row.try_get("retry_count")?)?,
+        enabled: row.try_get("enabled")?,
+    })
+}
+
+// ============================================================================
+// Persistence
+// ============================================================================
+
+/// Insert a route, or replace it if one with the same id is already stored.
+///
+/// Returns the route as stored, with `id` filled in. A route arriving without
+/// one gets a fresh id rather than being rejected: the admin API generates ids
+/// itself, but a caller building a `Route` by hand should not have to.
+pub async fn save_route(pool: &PgPool, route: &Route) -> ProxyResult<Route> {
+    let id = route.id.unwrap_or_else(Uuid::new_v4);
+    let (rate_limit_key, rate_limit_header) = match &route.rate_limit {
+        Some(limit) => {
+            let (kind, header) = rate_limit_key_columns(&limit.key);
+            (Some(kind), header.map(str::to_owned))
+        }
+        None => (None, None),
+    };
+    let (rate_limit_requests, rate_limit_window_secs) = match &route.rate_limit {
+        Some(limit) => (
+            Some(storable("rate_limit_requests", limit.requests)?),
+            Some(storable("rate_limit_window_secs", limit.window_secs)?),
+        ),
+        None => (None, None),
+    };
+
+    sqlx::query(
+        "INSERT INTO proxy_routes \
+            (id, name, description, match_host, match_path, match_path_type, \
+             match_headers, match_methods, priority, upstream, strip_path, \
+             add_headers, remove_headers, rate_limit_requests, \
+             rate_limit_window_secs, rate_limit_key, rate_limit_header, \
+             timeout_secs, retry_count, enabled) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, \
+                 $15, $16, $17, $18, $19, $20) \
+         ON CONFLICT (id) DO UPDATE SET \
+             name = EXCLUDED.name, \
+             description = EXCLUDED.description, \
+             match_host = EXCLUDED.match_host, \
+             match_path = EXCLUDED.match_path, \
+             match_path_type = EXCLUDED.match_path_type, \
+             match_headers = EXCLUDED.match_headers, \
+             match_methods = EXCLUDED.match_methods, \
+             priority = EXCLUDED.priority, \
+             upstream = EXCLUDED.upstream, \
+             strip_path = EXCLUDED.strip_path, \
+             add_headers = EXCLUDED.add_headers, \
+             remove_headers = EXCLUDED.remove_headers, \
+             rate_limit_requests = EXCLUDED.rate_limit_requests, \
+             rate_limit_window_secs = EXCLUDED.rate_limit_window_secs, \
+             rate_limit_key = EXCLUDED.rate_limit_key, \
+             rate_limit_header = EXCLUDED.rate_limit_header, \
+             timeout_secs = EXCLUDED.timeout_secs, \
+             retry_count = EXCLUDED.retry_count, \
+             enabled = EXCLUDED.enabled, \
+             updated_at = NOW()",
+    )
+    .bind(id)
+    .bind(&route.name)
+    .bind(&route.description)
+    .bind(&route.match_.host)
+    .bind(&route.match_.path)
+    .bind(path_type_str(&route.match_.path_type))
+    .bind(sqlx::types::Json(&route.match_.headers))
+    .bind(&route.match_.methods)
+    .bind(route.priority)
+    .bind(&route.upstream)
+    .bind(route.strip_path)
+    .bind(sqlx::types::Json(&route.add_headers))
+    .bind(&route.remove_headers)
+    .bind(rate_limit_requests)
+    .bind(rate_limit_window_secs)
+    .bind(rate_limit_key)
+    .bind(rate_limit_header)
+    .bind(storable("timeout_secs", route.timeout_secs)?)
+    .bind(storable("retry_count", route.retry_count)?)
+    .bind(route.enabled)
+    .execute(pool)
+    .await?;
+
+    Ok(Route {
+        id: Some(id),
+        ..route.clone()
+    })
+}
+
+/// Delete a route. Returns whether a row was removed.
+pub async fn delete_route(pool: &PgPool, id: Uuid) -> ProxyResult<bool> {
+    let result = sqlx::query("DELETE FROM proxy_routes WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Insert an upstream and its backends, or replace them if the id is stored.
+///
+/// The upstream and its backend set are written in one transaction, and the
+/// backends are replaced wholesale rather than merged: `Upstream::backends` is
+/// the complete set, so a backend dropped from the value has to disappear from
+/// the database. Doing that outside a transaction would leave a window where
+/// the upstream has no backends at all and every request through it fails.
+pub async fn save_upstream(pool: &PgPool, upstream: &Upstream) -> ProxyResult<Upstream> {
+    let id = upstream.id.unwrap_or_else(|| upstream.resolved_id());
+    let health = &upstream.health_check;
+
+    let mut tx = pool.begin().await?;
+
+    sqlx::query(
+        "INSERT INTO proxy_upstreams \
+            (id, name, description, lb_strategy, health_check_enabled, \
+             health_check_path, health_check_interval_secs, \
+             health_check_timeout_secs, healthy_threshold, unhealthy_threshold, \
+             enabled) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) \
+         ON CONFLICT (id) DO UPDATE SET \
+             name = EXCLUDED.name, \
+             description = EXCLUDED.description, \
+             lb_strategy = EXCLUDED.lb_strategy, \
+             health_check_enabled = EXCLUDED.health_check_enabled, \
+             health_check_path = EXCLUDED.health_check_path, \
+             health_check_interval_secs = EXCLUDED.health_check_interval_secs, \
+             health_check_timeout_secs = EXCLUDED.health_check_timeout_secs, \
+             healthy_threshold = EXCLUDED.healthy_threshold, \
+             unhealthy_threshold = EXCLUDED.unhealthy_threshold, \
+             enabled = EXCLUDED.enabled, \
+             updated_at = NOW()",
+    )
+    .bind(id)
+    .bind(&upstream.name)
+    .bind(&upstream.description)
+    .bind(lb_strategy_str(&upstream.lb_strategy))
+    .bind(health.enabled)
+    .bind(&health.path)
+    .bind(storable(
+        "health_check_interval_secs",
+        health.interval_secs,
+    )?)
+    .bind(storable("health_check_timeout_secs", health.timeout_secs)?)
+    .bind(storable("healthy_threshold", health.healthy_threshold)?)
+    .bind(storable("unhealthy_threshold", health.unhealthy_threshold)?)
+    .bind(upstream.enabled)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query("DELETE FROM proxy_upstream_backends WHERE upstream_id = $1")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+    let mut stored = Vec::with_capacity(upstream.backends.len());
+    for backend in &upstream.backends {
+        let backend_id = backend.id.unwrap_or_else(Uuid::new_v4);
+        sqlx::query(
+            "INSERT INTO proxy_upstream_backends \
+                (id, upstream_id, address, scheme, weight, http_version, enabled) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(backend_id)
+        .bind(id)
+        .bind(&backend.address)
+        .bind(&backend.scheme)
+        .bind(storable("weight", backend.weight)?)
+        .bind(http_version_str(&backend.http_version))
+        .bind(backend.enabled)
+        .execute(&mut *tx)
+        .await?;
+
+        stored.push(Backend {
+            id: Some(backend_id),
+            ..backend.clone()
+        });
+    }
+
+    tx.commit().await?;
+
+    Ok(Upstream {
+        id: Some(id),
+        backends: stored,
+        ..upstream.clone()
+    })
+}
+
+/// Delete an upstream and, by cascade, its backends. Returns whether a row was
+/// removed.
+pub async fn delete_upstream(pool: &PgPool, id: Uuid) -> ProxyResult<bool> {
+    let result = sqlx::query("DELETE FROM proxy_upstreams WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The enum mappings are the part that can silently corrupt a config: a
+    // wrong string round-trips as a *different valid* value rather than an
+    // error. Every variant, both directions.
+
+    #[test]
+    fn lb_strategy_round_trips_every_variant() {
+        for strategy in [
+            LoadBalanceStrategy::RoundRobin,
+            LoadBalanceStrategy::LeastConnections,
+            LoadBalanceStrategy::Weighted,
+            LoadBalanceStrategy::Random,
+            LoadBalanceStrategy::Sticky,
+        ] {
+            let stored = lb_strategy_str(&strategy);
+            assert_eq!(
+                lb_strategy_from(stored).unwrap(),
+                strategy,
+                "via {stored:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn path_type_round_trips_every_variant() {
+        for path_type in [
+            PathMatchType::Prefix,
+            PathMatchType::Exact,
+            PathMatchType::Regex,
+        ] {
+            let stored = path_type_str(&path_type);
+            assert_eq!(path_type_from(stored).unwrap(), path_type, "via {stored:?}");
+        }
+    }
+
+    #[test]
+    fn http_version_round_trips_every_variant() {
+        for version in [UpstreamHttpVersion::Http11, UpstreamHttpVersion::H2c] {
+            let stored = http_version_str(&version);
+            assert_eq!(
+                http_version_from(stored).unwrap(),
+                version,
+                "via {stored:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rate_limit_key_round_trips_every_variant() {
+        for key in [
+            RateLimitKey::ClientIp,
+            RateLimitKey::Route,
+            RateLimitKey::Header("x-api-key".into()),
+        ] {
+            let (kind, header) = rate_limit_key_columns(&key);
+            let back = rate_limit_key_from(kind, header.map(str::to_owned)).unwrap();
+            assert_eq!(
+                format!("{back:?}"),
+                format!("{key:?}"),
+                "via {kind:?}/{header:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_header_variant_stores_a_header() {
+        assert_eq!(rate_limit_key_columns(&RateLimitKey::ClientIp).1, None);
+        assert_eq!(rate_limit_key_columns(&RateLimitKey::Route).1, None);
+        assert_eq!(
+            rate_limit_key_columns(&RateLimitKey::Header("x-tenant".into())).1,
+            Some("x-tenant")
+        );
+    }
+
+    #[test]
+    fn unknown_enum_values_are_refused_not_defaulted() {
+        // The bug this guards against is `unwrap_or_default()`, which would
+        // turn an unreadable row into a plausible, wrong configuration.
+        assert!(lb_strategy_from("round-robin").is_err());
+        assert!(lb_strategy_from("").is_err());
+        assert!(path_type_from("glob").is_err());
+        assert!(
+            http_version_from("h2").is_err(),
+            "alias is not the stored form"
+        );
+        assert!(rate_limit_key_from("ip", None).is_err());
+    }
+
+    #[test]
+    fn a_header_key_without_a_header_is_an_error() {
+        assert!(rate_limit_key_from("header", None).is_err());
+    }
+
+    #[test]
+    fn negative_integers_from_the_database_are_refused() {
+        assert!(positive("weight", -1).is_err());
+        assert_eq!(positive("weight", 0).unwrap(), 0);
+        assert_eq!(positive("weight", 7).unwrap(), 7);
+    }
+
+    #[test]
+    fn oversized_integers_are_refused_before_they_wrap() {
+        assert!(storable("timeout_secs", u32::MAX).is_err());
+        assert_eq!(storable("timeout_secs", 30).unwrap(), 30);
+        assert_eq!(storable("timeout_secs", i32::MAX as u32).unwrap(), i32::MAX);
+    }
 }

--- a/crates/postrust-proxy/src/config/mod.rs
+++ b/crates/postrust-proxy/src/config/mod.rs
@@ -8,7 +8,10 @@ mod file;
 mod reload;
 mod types;
 
-pub use database::load_from_database;
+pub use database::{
+    delete_route, delete_upstream, load_from_database, load_routes, load_upstreams, save_route,
+    save_upstream,
+};
 pub use file::load_from_file;
 pub use reload::ConfigReloader;
 pub use types::*;

--- a/crates/postrust-proxy/tests/config_persistence.rs
+++ b/crates/postrust-proxy/tests/config_persistence.rs
@@ -1,0 +1,426 @@
+//! Database round-trips for the global proxy configuration tables.
+//!
+//! These need a live PostgreSQL, so they are `#[ignore]`d and run by the CI
+//! job that has one:
+//!
+//!     DATABASE_URL=postgres://postgres:postgres@localhost:5432/postrust_test \
+//!         cargo test -p postrust-proxy --test config_persistence -- --ignored
+//!
+//! Each test applies the migration itself rather than relying on the schema
+//! having been loaded. It is `CREATE TABLE IF NOT EXISTS` throughout, so that
+//! is idempotent, and it means these run against any empty database without a
+//! setup step to forget.
+//!
+//! Every test namespaces its rows by a fresh UUID so the file can run in
+//! parallel with itself and with anything else using the same database.
+//!
+//! What these are for: the unit tests in `config::database` cover the enum
+//! mappings, but a mapping can be perfect while the SQL is wrong. Only a real
+//! round-trip shows that what was written is what comes back.
+
+use std::collections::HashMap;
+
+use postrust_proxy::config::{
+    delete_route, delete_upstream, load_routes, load_upstreams, save_route, save_upstream, Backend,
+    HealthCheckConfig, LoadBalanceStrategy, PathMatchType, RateLimitKey, Route, RouteMatch,
+    RouteRateLimit, Upstream, UpstreamHttpVersion,
+};
+use sqlx::{Executor, PgPool};
+use uuid::Uuid;
+
+const MIGRATION: &str = include_str!("../migrations/20260901000001_proxy_config.sql");
+
+async fn pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set for the database-backed tests");
+    let pool = PgPool::connect(&url)
+        .await
+        .expect("could not connect to DATABASE_URL");
+    pool.execute(MIGRATION)
+        .await
+        .expect("could not apply the proxy config migration");
+    pool
+}
+
+/// A name no other test run will collide with.
+fn unique(prefix: &str) -> String {
+    format!("{prefix}-{}", Uuid::new_v4())
+}
+
+fn route(name: &str, upstream: &str) -> Route {
+    Route {
+        id: Some(Uuid::new_v4()),
+        name: name.to_owned(),
+        description: None,
+        match_: RouteMatch::default(),
+        priority: 100,
+        upstream: upstream.to_owned(),
+        strip_path: false,
+        add_headers: HashMap::new(),
+        remove_headers: Vec::new(),
+        rate_limit: None,
+        timeout_secs: 30,
+        retry_count: 0,
+        enabled: true,
+    }
+}
+
+fn upstream(name: &str) -> Upstream {
+    Upstream {
+        id: Some(Uuid::new_v4()),
+        name: name.to_owned(),
+        description: None,
+        lb_strategy: LoadBalanceStrategy::RoundRobin,
+        backends: Vec::new(),
+        health_check: HealthCheckConfig::default(),
+        enabled: true,
+    }
+}
+
+async fn find_route(pool: &PgPool, name: &str) -> Option<Route> {
+    load_routes(pool)
+        .await
+        .expect("load_routes failed")
+        .into_iter()
+        .find(|r| r.name == name)
+}
+
+async fn find_upstream(pool: &PgPool, name: &str) -> Option<Upstream> {
+    load_upstreams(pool)
+        .await
+        .expect("load_upstreams failed")
+        .into_iter()
+        .find(|u| u.name == name)
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn a_saved_route_comes_back_field_for_field() {
+    let pool = pool().await;
+    let name = unique("full");
+
+    let mut saved = route(&name, "api");
+    saved.description = Some("everything set".into());
+    saved.match_ = RouteMatch {
+        host: Some("api.example.com".into()),
+        path: Some("/v1".into()),
+        path_type: PathMatchType::Exact,
+        headers: HashMap::from([("x-tenant".to_string(), "acme".to_string())]),
+        methods: Some(vec!["GET".into(), "POST".into()]),
+    };
+    saved.priority = 250;
+    saved.strip_path = true;
+    saved.add_headers = HashMap::from([("x-added".to_string(), "1".to_string())]);
+    saved.remove_headers = vec!["x-internal".into()];
+    saved.timeout_secs = 45;
+    saved.retry_count = 3;
+    saved.enabled = false;
+
+    save_route(&pool, &saved).await.expect("save failed");
+    let loaded = find_route(&pool, &name).await.expect("route not loaded");
+
+    assert_eq!(loaded.id, saved.id);
+    assert_eq!(loaded.description, saved.description);
+    assert_eq!(loaded.match_.host, saved.match_.host);
+    assert_eq!(loaded.match_.path, saved.match_.path);
+    assert_eq!(loaded.match_.path_type, saved.match_.path_type);
+    assert_eq!(loaded.match_.headers, saved.match_.headers);
+    assert_eq!(loaded.match_.methods, saved.match_.methods);
+    assert_eq!(loaded.priority, saved.priority);
+    assert_eq!(loaded.upstream, saved.upstream);
+    assert_eq!(loaded.strip_path, saved.strip_path);
+    assert_eq!(loaded.add_headers, saved.add_headers);
+    assert_eq!(loaded.remove_headers, saved.remove_headers);
+    assert_eq!(loaded.timeout_secs, saved.timeout_secs);
+    assert_eq!(loaded.retry_count, saved.retry_count);
+    assert_eq!(loaded.enabled, saved.enabled);
+
+    delete_route(&pool, saved.id.unwrap()).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn no_rate_limit_stays_absent() {
+    let pool = pool().await;
+    let name = unique("no-limit");
+    let saved = route(&name, "api");
+
+    save_route(&pool, &saved).await.expect("save failed");
+    let loaded = find_route(&pool, &name).await.expect("route not loaded");
+
+    assert!(
+        loaded.rate_limit.is_none(),
+        "a route saved without a rate limit came back with one"
+    );
+
+    delete_route(&pool, saved.id.unwrap()).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn every_rate_limit_key_survives_the_round_trip() {
+    let pool = pool().await;
+
+    for key in [
+        RateLimitKey::ClientIp,
+        RateLimitKey::Route,
+        RateLimitKey::Header("x-api-key".into()),
+    ] {
+        let name = unique("limit");
+        let mut saved = route(&name, "api");
+        saved.rate_limit = Some(RouteRateLimit {
+            requests: 120,
+            window_secs: 60,
+            key: key.clone(),
+        });
+
+        save_route(&pool, &saved).await.expect("save failed");
+        let loaded = find_route(&pool, &name).await.expect("route not loaded");
+        let limit = loaded.rate_limit.expect("rate limit was dropped");
+
+        assert_eq!(limit.requests, 120);
+        assert_eq!(limit.window_secs, 60);
+        assert_eq!(
+            format!("{:?}", limit.key),
+            format!("{key:?}"),
+            "rate limit key changed in the database"
+        );
+
+        delete_route(&pool, saved.id.unwrap()).await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn saving_the_same_id_twice_updates_rather_than_duplicating() {
+    let pool = pool().await;
+    let name = unique("upsert");
+    let mut saved = route(&name, "api");
+
+    save_route(&pool, &saved).await.expect("first save failed");
+    saved.priority = 900;
+    saved.upstream = "other".into();
+    save_route(&pool, &saved).await.expect("second save failed");
+
+    let matching: Vec<_> = load_routes(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.name == name)
+        .collect();
+
+    assert_eq!(matching.len(), 1, "the second save inserted a second row");
+    assert_eq!(matching[0].priority, 900);
+    assert_eq!(matching[0].upstream, "other");
+
+    delete_route(&pool, saved.id.unwrap()).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn routes_load_highest_priority_first() {
+    let pool = pool().await;
+    let tag = Uuid::new_v4();
+
+    let mut ids = Vec::new();
+    for priority in [10, 500, 250] {
+        let mut r = route(&format!("prio-{tag}-{priority}"), "api");
+        r.priority = priority;
+        save_route(&pool, &r).await.expect("save failed");
+        ids.push(r.id.unwrap());
+    }
+
+    let ours: Vec<i32> = load_routes(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.name.contains(&tag.to_string()))
+        .map(|r| r.priority)
+        .collect();
+
+    assert_eq!(
+        ours,
+        vec![500, 250, 10],
+        "routes are matched in priority order, so they must load in it"
+    );
+
+    for id in ids {
+        delete_route(&pool, id).await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn an_upstream_and_its_backends_come_back_together() {
+    let pool = pool().await;
+    let name = unique("up");
+
+    let mut saved = upstream(&name);
+    saved.description = Some("two backends".into());
+    saved.lb_strategy = LoadBalanceStrategy::LeastConnections;
+    saved.health_check = HealthCheckConfig {
+        enabled: false,
+        path: "/healthz".into(),
+        interval_secs: 15,
+        timeout_secs: 3,
+        healthy_threshold: 4,
+        unhealthy_threshold: 5,
+    };
+    saved.backends = vec![
+        Backend {
+            id: Some(Uuid::new_v4()),
+            address: "10.0.0.1:8080".into(),
+            scheme: "http".into(),
+            weight: 7,
+            enabled: true,
+            http_version: UpstreamHttpVersion::Http11,
+        },
+        Backend {
+            id: Some(Uuid::new_v4()),
+            address: "10.0.0.2:8080".into(),
+            scheme: "https".into(),
+            weight: 3,
+            enabled: false,
+            // The reason this column exists: h2c has no ALPN, so it has to be
+            // declared, and a round-trip that lost it would silently downgrade
+            // the backend to HTTP/1.1.
+            http_version: UpstreamHttpVersion::H2c,
+        },
+    ];
+
+    save_upstream(&pool, &saved).await.expect("save failed");
+    let loaded = find_upstream(&pool, &name)
+        .await
+        .expect("upstream not loaded");
+
+    assert_eq!(loaded.lb_strategy, saved.lb_strategy);
+    assert!(!loaded.health_check.enabled);
+    assert_eq!(loaded.health_check.path, "/healthz");
+    assert_eq!(loaded.health_check.interval_secs, 15);
+    assert_eq!(loaded.health_check.timeout_secs, 3);
+    assert_eq!(loaded.health_check.healthy_threshold, 4);
+    assert_eq!(loaded.health_check.unhealthy_threshold, 5);
+    assert_eq!(loaded.backends.len(), 2);
+
+    let h2c = loaded
+        .backends
+        .iter()
+        .find(|b| b.address == "10.0.0.2:8080")
+        .expect("second backend missing");
+    assert_eq!(h2c.http_version, UpstreamHttpVersion::H2c);
+    assert_eq!(h2c.scheme, "https");
+    assert_eq!(h2c.weight, 3);
+    assert!(!h2c.enabled);
+
+    delete_upstream(&pool, saved.id.unwrap()).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn saving_an_upstream_replaces_its_backend_set() {
+    let pool = pool().await;
+    let name = unique("replace");
+
+    let mut saved = upstream(&name);
+    saved.backends = vec![
+        Backend {
+            id: Some(Uuid::new_v4()),
+            address: "10.0.0.1:8080".into(),
+            scheme: "http".into(),
+            weight: 1,
+            enabled: true,
+            http_version: UpstreamHttpVersion::Http11,
+        },
+        Backend {
+            id: Some(Uuid::new_v4()),
+            address: "10.0.0.2:8080".into(),
+            scheme: "http".into(),
+            weight: 1,
+            enabled: true,
+            http_version: UpstreamHttpVersion::Http11,
+        },
+    ];
+    save_upstream(&pool, &saved).await.expect("save failed");
+
+    // Drop one and save again: `backends` is the whole set, so the removed one
+    // has to disappear rather than linger and keep taking traffic.
+    saved.backends.remove(1);
+    save_upstream(&pool, &saved).await.expect("resave failed");
+
+    let loaded = find_upstream(&pool, &name)
+        .await
+        .expect("upstream not loaded");
+    assert_eq!(
+        loaded.backends.len(),
+        1,
+        "a backend removed from the value stayed in the database"
+    );
+    assert_eq!(loaded.backends[0].address, "10.0.0.1:8080");
+
+    delete_upstream(&pool, saved.id.unwrap()).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn deleting_an_upstream_takes_its_backends_with_it() {
+    let pool = pool().await;
+    let name = unique("cascade");
+
+    let mut saved = upstream(&name);
+    saved.backends = vec![Backend {
+        id: Some(Uuid::new_v4()),
+        address: "10.0.0.9:8080".into(),
+        scheme: "http".into(),
+        weight: 1,
+        enabled: true,
+        http_version: UpstreamHttpVersion::Http11,
+    }];
+    save_upstream(&pool, &saved).await.expect("save failed");
+    let id = saved.id.unwrap();
+
+    assert!(delete_upstream(&pool, id).await.unwrap());
+
+    let orphans: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM proxy_upstream_backends WHERE upstream_id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(orphans, 0, "backends outlived their upstream");
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn deleting_reports_whether_anything_was_there() {
+    let pool = pool().await;
+    let saved = route(&unique("gone"), "api");
+    let id = saved.id.unwrap();
+
+    save_route(&pool, &saved).await.expect("save failed");
+    assert!(delete_route(&pool, id).await.unwrap(), "first delete");
+    assert!(
+        !delete_route(&pool, id).await.unwrap(),
+        "deleting a route that is already gone reported success"
+    );
+    assert!(
+        !delete_upstream(&pool, Uuid::new_v4()).await.unwrap(),
+        "deleting an upstream that never existed reported success"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL"]
+async fn a_route_saved_without_an_id_gets_one() {
+    let pool = pool().await;
+    let name = unique("no-id");
+    let mut saved = route(&name, "api");
+    saved.id = None;
+
+    let stored = save_route(&pool, &saved).await.expect("save failed");
+    let id = stored.id.expect("save_route returned a route with no id");
+
+    let loaded = find_route(&pool, &name).await.expect("route not loaded");
+    assert_eq!(loaded.id, Some(id));
+
+    delete_route(&pool, id).await.unwrap();
+}

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -49,14 +49,11 @@ Not caution for its own sake. Three specific things:
 8 associated functions, 5 structs, 2 methods. `dead_code` adds 4 more. A 1.0.0
 would freeze all of it as-is.
 
-**Parts of it answer successfully without doing anything.**
-`config::database::load_from_database` returns an empty route set rather than
-querying, so a proxy configured against a database starts, logs nothing wrong,
-and refuses every request. The admin API's route and upstream mutations return
-`200`/`201` after changing only the in-memory config; a restart discards them.
-SaaS domain provisioning does not trigger ACME. These are marked in the source,
-and each needs to be implemented, made to fail loudly, or removed before the
-crate can promise anything.
+**Automatic SSL provisioning is not implemented.** A domain can be configured
+with `ssl_provider = "acme"` and the schema tracks an `ssl_status`, but nothing
+in the crate has ever talked to a certificate authority. A verified domain is
+left `pending` with a warning rather than claiming to be provisioning. See
+[SaaS Domain Management](./saas-domains.md).
 
 **It has only just grown its transport layer.** TLS, HTTP/2, WebSocket and
 RFC 8441 extended CONNECT all landed in `1.0.0-alpha.2`. They are measured, by


### PR DESCRIPTION
The last two proxy stubs that answered successfully while doing nothing. Both now real, and verified against a live PostgreSQL rather than just compiled.

## What was broken

**`config::load_from_database` never queried anything.**

```rust
async fn load_routes(_pool: &PgPool) -> ProxyResult<Vec<Route>> {
    // TODO: Implement database query
    // For now, return empty
    Ok(Vec::new())
}
```

A proxy pointed at a database started, logged nothing wrong, and answered every request with 503 — the same failure file-configured routing had before `1.0.0-alpha.2`, in the other half of the same module.

**The admin API did not persist.** Route, upstream and backend create/update/delete replied `201`/`200` after mutating only the in-memory config, behind eight `// TODO: Persist to database` comments. Every change vanished on restart, having reported success.

## The schema

`migrations/20260901000001_proxy_config.sql` adds `proxy_routes`, `proxy_upstreams` and `proxy_upstream_backends` — global proxy configuration, distinct from the tenant-scoped `proxy_domain_*` tables. Columns mirror `Route`, `Upstream` and `Backend` field for field, so a config loaded from here and one parsed from TOML are the same value.

Two constraints carry real weight:

```sql
CONSTRAINT proxy_routes_rate_limit_whole CHECK (
    num_nonnulls(rate_limit_requests, rate_limit_window_secs, rate_limit_key) IN (0, 3)
),
CONSTRAINT proxy_routes_rate_limit_header CHECK (
    (rate_limit_key = 'header') = (rate_limit_header IS NOT NULL)
)
```

`Option<RouteRateLimit>` is all-or-nothing. Without the first, a half-written rate limit loads as *no* rate limit — a limit that silently stops applying. I checked both bite before writing any Rust against them: three valid shapes accepted, four invalid ones rejected by the named constraint.

## The code

- **Loading**: backends come back in one grouped query rather than one per upstream. Routes load in priority order, because that is the order they are matched in.
- **`save_upstream`** writes the upstream and replaces its whole backend set in a transaction, so the upstream is never briefly left with no backends and failing every request.
- **Decoding is strict.** An unrecognised enum value returns an error rather than `unwrap_or_default()`. A silent default here is a route quietly matching differently, or an `h2c` backend quietly downgraded to HTTP/1.1.
- **The admin API writes through first**, then updates the running config, and returns **500** when it cannot — a create that answers 201 and is gone after a restart is worse than one that fails now and says why. With `server.database_config = false` (an explicit "configured from a file") edits stay in memory as before.
- **`update_upstream` deliberately ignores `req.backends`.** `CreateUpstreamRequest` cannot express a backend id, so applying it would re-create every backend under a fresh id, and an empty list — what a caller sends when it only means to rename — would remove them all.

## Startup loading, and why it keys off `DATABASE_URL`

`postrust-proxy` merges database config into the file config at startup. The trigger is `DATABASE_URL` being set, **not** `server.database_config` alone: that flag defaults to `true`, so keying off it would make every file-configured proxy — including the h2spec, Autobahn and HTTP Garden harnesses, none of which set it — try to reach a database that is not there.

Duplicate names across the two sources refuse to start. `Upstream::resolved_id` derives a UUID from the name, so a duplicate would collide in the routing tables and one upstream would silently take the other's traffic.

## Verification

Against a real PostgreSQL 16.14, not just `cargo check`:

- **10 round-trip tests** in `tests/config_persistence.rs`: every field of a route, all three `RateLimitKey` variants, `h2c` backends, priority ordering, upsert-not-duplicate, backend-set replacement, delete cascade, and delete reporting whether anything was there. They apply the migration themselves — idempotent `CREATE TABLE IF NOT EXISTS` — so they need no setup step and run in CI's existing database-backed job unchanged. Rows are namespaced by UUID so they run in parallel.
- **End to end**: a TOML config with **zero** routes, one route in the database, and the built binary forwarding a real request:

```
loaded configuration from the database routes=1 upstreams=1
Loaded 1 routes and 1 upstreams
HTTP proxy listening on 127.0.0.1:19099
$ curl http://127.0.0.1:19099/hello
origin saw /hello
```

Before this change that request was a 503.

Full local CI: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p postrust-server --features admin-ui`, `cargo test --workspace` (24 suites, 0 failures). Proxy unit tests **75 passed** (up from 66), plus the 10 database tests.

## Not in this PR

ACME issuance is still not implemented, and is now the only remaining "not implemented" in the crate. It needs an ACME client and a background worker rather than a request-scoped endpoint — `docker-compose.yml` already carries the Pebble harness for it. `docs/stability.md` is updated to name that as the reason the proxy stays on `0.x`, since the config stubs it used to cite are gone.