### PR TITLE
chore: declare and check the MSRV, fix 12 dependency advisories, add SECURITY.md

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,56 @@
+# cargo-audit configuration.
+#
+# Every entry below is an advisory we have decided not to act on *yet*, with
+# the reason. The list is deliberately short and deliberately annotated: an
+# ignore list without reasons becomes a place advisories go to be forgotten.
+#
+# The bar for adding an entry is a reachability argument, not inconvenience.
+# `cargo audit` reports what is in Cargo.lock, which is not the same as what is
+# compiled -- an advisory against an optional dependency that no enabled
+# feature pulls in has no code path to reach. Check with:
+#
+#     cargo tree -i <crate>
+#
+# "nothing to print" means the crate is locked but never built. SECURITY.md
+# explains this at more length.
+
+[advisories]
+ignore = [
+    # rsa 0.9.9 -- Marvin attack, timing side channel in PKCS#1 v1.5
+    # decryption.
+    #
+    # Not in any build graph: `cargo tree -i rsa` prints nothing. It is an
+    # optional dependency of sqlx behind the MySQL feature, which this
+    # workspace does not enable -- postrust is PostgreSQL only. No RSA
+    # decryption code is compiled, let alone reachable.
+    #
+    # There is also no fixed version to move to; the advisory lists no patched
+    # release, because the fix requires an API change upstream has not made.
+    # Revisit if sqlx ever gains a mandatory RSA path.
+    "RUSTSEC-2023-0071",
+
+    # instant 0.1.13 -- unmaintained.
+    #
+    # Pulled in transitively: instant <- notify-types <- notify <-
+    # postrust-proxy. `notify` is a direct dependency of the proxy but is used
+    # for exactly one thing: the `ProxyError::Notify` variant. The config file
+    # watcher it was added for is not implemented -- `ConfigReloader` is
+    # scaffolding with an unread channel.
+    #
+    # The real fix is to drop `notify` until the watcher exists, which removes
+    # this and shrinks the dependency tree. That is an API change to
+    # `ProxyError`, so it waits for a deliberate pass rather than riding along
+    # with a lockfile update.
+    "RUSTSEC-2024-0384",
+
+    # rustls-pemfile 2.2.0 -- unmaintained.
+    #
+    # Genuinely compiled and used, in `tls::server` and `tls::acme`, to parse
+    # PEM certificate chains and private keys. Unmaintained because rustls
+    # moved PEM parsing into `rustls-pki-types`, which is already in the tree.
+    #
+    # Migrating is the right fix and is not risky, but it touches the code path
+    # that loads the HTTPS listener's certificate, so it deserves its own
+    # change with its own testing rather than being bundled into an audit pass.
+    "RUSTSEC-2025-0134",
+]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,63 @@ jobs:
       - name: Clippy (server, admin-ui feature)
         run: cargo clippy -p postrust-server --features admin-ui --all-targets -- -D warnings
 
+  msrv:
+    name: MSRV (1.88)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The version here must match [workspace.package] rust-version. It is
+      # verified rather than aspirational: 1.87.0 is refused outright, because
+      # hickory 0.26 and time 0.3.55 declare 1.88. Without this job the
+      # declared MSRV is a comment -- the README claimed 1.78, the docs 1.75,
+      # and nothing caught either.
+      - name: Install Rust 1.88
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.88"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+
+      # --locked: an MSRV check that lets cargo pick newer dependencies is
+      # checking a different dependency set than the one that ships.
+      - name: Check (workspace)
+        run: cargo +1.88 check --workspace --all-targets --locked
+
+  audit:
+    name: dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: audit
+
+      # ^0.22 specifically: 0.21 cannot parse a CVSS 4.0 advisory and dies
+      # with "unsupported CVSS version: 4.0" on the current RustSec database,
+      # which would have made this job red on its first run for a reason
+      # unrelated to our dependencies.
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked --version ^0.22
+
+      # Advisories against the lockfile, plus yanked crates -- a yanked
+      # dependency is how a lockfile rots quietly.
+      #
+      # This reports what is *locked*, which is not the same as what is
+      # compiled: an advisory against an optional dependency that no enabled
+      # feature pulls in is worth fixing but is not an exposure. Check
+      # `cargo tree -i <crate>` before treating one as reachable. SECURITY.md
+      # explains why, with the quinn-proto case that prompted it.
+      # Ignores live in .cargo/audit.toml, one documented reason each.
+      - name: cargo audit
+        run: cargo audit --deny warnings
+
   test:
     name: build + test
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ releases are described by their tags and the pull requests behind them.
 
 ## Unreleased
 
+### Security
+
+**Twelve dependency advisories fixed** by updating the lockfile, including five
+in `aws-lc-sys` (X.509 name-constraint bypass via wildcard/Unicode CN, two
+PKCS7 signature and chain validation bypasses, a CRL distribution-point scope
+error, an AES-CCM timing side channel) and four in `rustls-webpki` (a reachable
+panic in CRL parsing, URI name constraints incorrectly accepted, and two more
+CRL and wildcard issues). All of these are in the path of a TLS-terminating
+proxy. Also `bytes`, `h2` (unbounded empty DATA frames), `time`, `anyhow`,
+`event-listener` and both `rand` majors.
+
+**`hickory-resolver` 0.24 to 0.26**, clearing an O(n²) name-compression CPU
+exhaustion in `hickory-proto`. The upgrade is a real API migration, and one
+part of it would have broken silently: 0.26 replaced the rdata iterator with
+`Lookup::answers()`, and `Record`'s `Display` renders the whole record line
+(`name ttl class type rdata`), so the previous `record.to_string()` would never
+have matched a bare challenge token again. Every DNS verification would have
+failed. The comparison now lives in a tested function, `txt_matches`, with a
+case asserting that a full record line does *not* match.
+
+**A dependency audit now runs in CI.** `cargo audit --deny warnings`, with
+three documented ignores in `.cargo/audit.toml` -- one advisory with no
+reachable code path and no upstream fix (`rsa`, not in any build graph), and
+two unmaintained crates with the migration each needs written down. The job is
+verified green rather than added and hoped for.
+
+**`SECURITY.md`** added: how to report privately, what to expect, what is in
+scope, and the known-and-documented weaknesses that are not reports.
+
+### Changed
+
+**The MSRV is declared and checked: Rust 1.88.** It was not declared anywhere,
+while the README claimed 1.78, `docs/getting-started.md` claimed 1.75 and
+`CONTRIBUTING.md` claimed 1.75 -- three different wrong numbers. The floor is
+now 1.88: `hickory-{net,proto,resolver}` 0.26 and `time` 0.3.55 all require it,
+and 1.87.0 is refused outright. Both arrived with the security updates above,
+so the floor moved from 1.86 to 1.88 as a direct cost of them, which is a trade
+worth making. Declared as `rust-version` in `[workspace.package]`, inherited by
+every crate, with a CI job that builds on 1.88 `--locked`.
+
+**`postrust-proxy` and `postrust-worker` each moved to their own `0.x` version
+line** and no longer share the workspace version. The rest of the workspace is
+heading for 1.0.0 and the semver promise that comes with it; neither of these
+is ready to make one.
+
+For the proxy: turning `missing_docs` on produces 306 warnings, and automatic
+SSL provisioning is still not implemented. (The config and admin-API stubs that
+were the other half of the reason are fixed in this release -- see Added.)
+For the worker: it is a stub that answers `{"status": "stub"}`.
+
+Nothing in the stable line depends on either, so no crate that makes a semver
+promise carries a dependency that cannot keep one. The worker is a `cdylib`,
+which cannot be a Rust library dependency at all.
+
+Both lines still release on the same git tags: the publish step reads each
+crate's own declared version rather than assuming one across the workspace, and
+skips what is already on crates.io.
+
+New: [docs/stability.md](docs/stability.md), stating what a version number
+covers and what it does not.
+
 ### Added
 
 **Database-backed proxy configuration actually reads and writes.**
@@ -50,30 +111,6 @@ has to be supplied manually.
 which are in the router, and omitted `enable` and `disable`, which are. It
 also advertised automatic ACME provisioning as a feature. Corrected against
 the router, and the SSL section now says plainly that no ACME client exists.
-
-### Changed
-
-**`postrust-worker` moved to its own `0.x` version line** as well, for a
-blunter reason: it is a stub. Its fetch handler answers `{"status": "stub"}`
-and does not parse requests, reach a database, or return data. It is built as
-a `cdylib`, so it cannot be a Rust library dependency at all.
-
-**`postrust-proxy` moved to its own `0.x` version line** and no longer shares
-the workspace version. The rest of the workspace is heading for 1.0.0 and a
-semver promise; this crate is not ready to make one. Turning `missing_docs` on
-for it produces 306 warnings, and parts of its public surface answer
-successfully without doing anything -- `config::database` returns an empty
-route set instead of querying, and the admin API's route and upstream mutations
-change only the in-memory config while replying `200`/`201`. Nothing depends on
-`postrust-proxy`, so no crate that makes a semver promise carries a dependency
-that cannot keep one.
-
-Both lines still release on the same git tags: the publish step now reads each
-crate's own declared version rather than assuming one across the workspace, and
-skips what is already on crates.io.
-
-New: [docs/stability.md](docs/stability.md), stating what a version number
-covers and what it does not.
 
 ## 1.0.0-alpha.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This project adheres to a code of conduct. By participating, you are expected to
 
 ### Prerequisites
 
-- Rust 1.75 or later
+- Rust 1.88 or later (the declared MSRV, checked in CI)
 - Docker and Docker Compose (for running tests with PostgreSQL)
 - Git
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ascii_utils"
@@ -347,9 +347,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88aab2464f1f25453baa7a07c84c5b7684e274054ba06817f382357f77a288"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -357,14 +357,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.35.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45afffdee1e7c9126814751f88dddc747f41d91da16c9551a0f1e8a11e788a1"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -526,9 +527,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -558,6 +559,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,6 +590,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -638,6 +660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +690,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -768,12 +823,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_builder"
@@ -866,18 +918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,11 +946,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1175,18 +1214,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "wasip2",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1266,23 +1317,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror 1.0.69",
+ "jni",
+ "rand 0.10.2",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -1290,22 +1341,47 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.24.4"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
- "lru-cache",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
- "thiserror 1.0.69",
+ "system-configuration 0.7.0",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -1464,7 +1540,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -1662,6 +1738,9 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -1678,6 +1757,55 @@ name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1906,12 +2034,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,15 +2059,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2034,6 +2147,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2179,12 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nom"
@@ -2118,16 +2254,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.8",
  "smallvec",
  "zeroize",
 ]
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2173,6 +2309,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "parking"
@@ -2356,6 +2496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
 name = "postrust-auth"
 version = "1.0.0-alpha.2"
 dependencies = [
@@ -2472,7 +2618,7 @@ dependencies = [
  "pin-project-lite",
  "postrust-core",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reqwest",
  "rustls",
  "rustls-acme",
@@ -2596,6 +2742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,14 +2813,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2705,10 +2863,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2717,12 +2881,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2761,6 +2936,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2908,6 +3098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3028,6 +3227,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3134,7 +3339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3151,7 +3356,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3194,6 +3399,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -3244,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -3380,7 +3601,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.8",
  "rsa",
  "serde",
  "sha1",
@@ -3422,7 +3643,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "sha2",
@@ -3561,6 +3782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
 name = "system-configuration-sys"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3801,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -3634,30 +3872,29 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3993,7 +4230,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "sha1",
  "thiserror 2.0.17",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,13 @@ members = [
 [workspace.package]
 version = "1.0.0-alpha.2"
 edition = "2021"
+# Verified, not assumed: 1.88.0 builds the workspace clean and 1.87.0 is
+# refused outright -- hickory-{net,proto,resolver} 0.26 and time 0.3.55 all
+# declare 1.88. Both arrived with security updates, and the floor moved from
+# 1.86 to 1.88 as a result; the advisories were worth more than the two
+# releases. The README claimed 1.78, and the docs 1.75, before this was
+# declared anywhere at all.
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/postrust/postrust"
 homepage = "https://postrust.org/"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **A PostgREST-inspired REST API for PostgreSQL, written in Rust**
 
-[![Rust](https://img.shields.io/badge/rust-1.78%2B-orange.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/rust-1.88%2B-orange.svg)](https://www.rust-lang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/postrust/postrust/ci.yml?branch=main)](https://github.com/postrust/postrust/actions)
 
@@ -66,7 +66,7 @@ Postrust is a high-performance, serverless-first REST API server for PostgreSQL 
 
 ### Prerequisites
 
-- Rust 1.78+ (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`)
+- Rust 1.88+ (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`)
 - PostgreSQL 12+ (or use Docker)
 
 ### Installation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately, through
+[GitHub's security advisory form](https://github.com/postrust/postrust/security/advisories/new).
+That opens a private thread with the maintainers and lets us prepare a fix and
+an advisory together.
+
+**Please do not open a public issue for a vulnerability.** A public report
+starts the clock for everyone running the software, including people who cannot
+upgrade the same day.
+
+If the advisory form does not work for you, email
+[technology@bimaplan.co](mailto:technology@bimaplan.co) with `SECURITY` in the
+subject.
+
+What helps most, in rough order:
+
+- what an attacker can do, and what they need to start
+- the smallest reproduction you have — a request, a config, a schema
+- the version or commit you saw it on
+- whether you think it is already public
+
+You do not need a CVE, a severity score, or a patch. A clear description of the
+behaviour is enough.
+
+## What to expect
+
+- **Acknowledgement within 3 working days.** If you have not heard back in a
+  week, please chase — a missed notification is far more likely than a decision
+  not to reply.
+- An assessment of whether we can reproduce it, and what we think the impact
+  is. If we disagree with your severity, we will say why rather than quietly
+  downgrading it.
+- A fix, or an explanation of why the behaviour is intended, along with the
+  configuration that avoids it.
+- Credit in the advisory and the changelog, unless you would rather not be
+  named.
+
+We do not run a bug bounty.
+
+## Supported versions
+
+Fixes land on `main` and go out in the next release. There is no separate
+maintenance branch: this project is young enough that "upgrade to the latest
+release" is the whole backport policy.
+
+Two crates are on their own `0.x` lines and carry no stability promise —
+`postrust-proxy` and `postrust-worker`. A security fix for either may arrive in
+a release that also breaks their API. See
+[docs/stability.md](docs/stability.md).
+
+| Version | Supported |
+| --- | --- |
+| `1.0.0-alpha.2` and later | yes |
+| everything earlier | no — upgrade |
+
+## Scope
+
+In scope, and treated as vulnerabilities:
+
+- request smuggling, header smuggling, or response splitting through the proxy
+- authentication or authorization bypass — a JWT accepted that should not be, a
+  role or RLS policy escaped, a tenant reading another tenant's data
+- SQL injection, including through a filter, an embedded resource, or an RPC
+  argument
+- a domain-ownership check that can be passed without controlling the domain
+- secrets in logs, error bodies, or responses
+- remote crashes reachable without authentication
+
+Known and documented, so not a report — but a *better* attack on any of these
+is very much in scope:
+
+- **HTTP domain verification is weaker than DNS.** The proxy serves the
+  challenge for a domain that already points at it, so passing shows the domain
+  resolves here, not that the claimant controls it. DNS verification is the
+  default and the one to use. See
+  [docs/saas-domains.md](docs/saas-domains.md).
+- **Automatic ACME provisioning is not implemented.** A domain configured for
+  `acme` is left `pending`; nothing here has talked to a certificate authority.
+- **`postrust-worker` is a stub.** It answers a fixed JSON body.
+
+Out of scope:
+
+- findings from a scanner with no demonstrated impact, including a version
+  number matched against a CVE database without a reachable code path — see
+  below
+- denial of service by ordinary load, or by a configuration the documentation
+  says not to use
+- anything requiring a database superuser, filesystem access, or an already
+  compromised host
+- missing hardening headers on the admin UI, absent a concrete attack
+
+## A note on dependency advisories
+
+We check reachability before treating a locked version as an exposure, and we
+ask that reports do the same.
+
+A recent example: `Cargo.lock` carried a `quinn-proto` version flagged for a
+QUIC parsing panic. `quinn` is an optional dependency of `reqwest`, and this
+workspace uses `reqwest` with `default-features = false`, so `cargo tree -i
+quinn-proto` finds it in **no** build graph — nothing QUIC is ever compiled,
+let alone listening. The lockfile entry was still worth updating, and it was;
+but it was never an exposure, and reporting it as a remotely exploitable
+denial of service would have been wrong.
+
+`cargo audit` runs in CI so lockfile advisories surface on their own. What we
+need from a report is the part a tool cannot supply: the path from an attacker
+to the vulnerable code.

--- a/crates/postrust-auth/Cargo.toml
+++ b/crates/postrust-auth/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-auth"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-core/Cargo.toml
+++ b/crates/postrust-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-graphql/Cargo.toml
+++ b/crates/postrust-graphql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-graphql"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-lambda/Cargo.toml
+++ b/crates/postrust-lambda/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-lambda"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-proxy/Cargo.toml
+++ b/crates/postrust-proxy/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["proxy", "load-balancer", "tls", "acme", "http"]
 # promise a stability this crate cannot keep. See docs/stability.md.
 version = "0.5.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
@@ -82,7 +83,7 @@ pin-project-lite = "0.2"
 rand = "0.9"
 
 # DNS resolution for domain verification
-hickory-resolver = "0.24"
+hickory-resolver = "0.26"
 
 # Hashing for API keys
 sha2 = "0.10"

--- a/crates/postrust-proxy/src/saas/verification.rs
+++ b/crates/postrust-proxy/src/saas/verification.rs
@@ -3,22 +3,56 @@
 //! Provides DNS TXT and HTTP challenge verification for domain ownership.
 
 use crate::saas::types::VerificationResult;
-use hickory_resolver::config::{ResolverConfig, ResolverOpts};
-use hickory_resolver::TokioAsyncResolver;
+use hickory_resolver::config::ResolverConfig;
+use hickory_resolver::net::runtime::TokioRuntimeProvider;
+use hickory_resolver::TokioResolver;
 use std::time::Duration;
+
+/// Whether a TXT record's rendered rdata carries the expected challenge value.
+///
+/// Worth its own function because the rendering is not the raw value. A TXT
+/// record's rdata renders quoted (`"postrust-verify=abc"`), and a record with
+/// several character strings renders them space-separated and each quoted, so
+/// comparing the rendered form directly against a bare token fails on a record
+/// that is in fact correct.
+fn txt_matches(rendered: &str, expected: &str) -> bool {
+    if rendered == expected {
+        return true;
+    }
+    // A single quoted string, which is the ordinary case.
+    if rendered.trim().trim_matches('"').trim() == expected {
+        return true;
+    }
+    // A long value is split into several 255-byte character strings, each
+    // rendered quoted. DNS defines the value as their concatenation.
+    let joined: String = rendered
+        .split_whitespace()
+        .map(|part| part.trim_matches('"'))
+        .collect();
+    joined == expected
+}
 
 /// Domain verification service for DNS and HTTP challenges.
 pub struct DomainVerificationService {
-    dns_resolver: TokioAsyncResolver,
+    dns_resolver: TokioResolver,
     http_client: reqwest::Client,
 }
 
 impl DomainVerificationService {
     /// Create a new domain verification service.
     pub fn new() -> Self {
-        // Create DNS resolver with system config
-        let dns_resolver =
-            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+        // Create DNS resolver with the default config.
+        //
+        // `builder_with_config` rather than `builder`: the latter reads
+        // /etc/resolv.conf, and a verification service should not refuse to
+        // construct because the host's resolver file is unreadable. The
+        // default config is what this used before hickory 0.26.
+        let dns_resolver = TokioResolver::builder_with_config(
+            ResolverConfig::default(),
+            TokioRuntimeProvider::default(),
+        )
+        .build()
+        .expect("Failed to create DNS resolver");
 
         // Create HTTP client with reasonable timeouts
         let http_client = reqwest::Client::builder()
@@ -51,15 +85,16 @@ impl DomainVerificationService {
         // Perform DNS TXT lookup
         match self.dns_resolver.txt_lookup(&record_name).await {
             Ok(response) => {
-                // Check each TXT record
-                for record in response.iter() {
-                    let txt_data = record.to_string();
+                // `answers()`, and `record.data()` rather than `record` --
+                // hickory 0.26 replaced the rdata iterator with a record
+                // slice, and `Record`'s Display renders the whole line
+                // (`name ttl class type rdata`), which would never match a
+                // bare token. Getting this wrong fails every verification.
+                for record in response.answers() {
+                    let txt_data = record.data.to_string();
                     tracing::debug!(txt_value = %txt_data, "Found TXT record");
 
-                    // TXT records may be quoted, so check both with and without quotes
-                    let txt_clean = txt_data.trim_matches('"').trim();
-
-                    if txt_clean == expected_value || txt_data == expected_value {
+                    if txt_matches(&txt_data, &expected_value) {
                         tracing::info!(domain = %domain, "DNS verification successful");
                         return VerificationResult::Verified;
                     }
@@ -75,26 +110,27 @@ impl DomainVerificationService {
                 }
             }
             Err(e) => {
-                let error_kind = e.kind();
                 tracing::warn!(
                     domain = %domain,
                     error = %e,
-                    kind = ?error_kind,
                     "DNS lookup failed"
                 );
 
-                // Provide helpful error messages based on error type
-                let reason = match error_kind {
-                    hickory_resolver::error::ResolveErrorKind::NoRecordsFound { .. } => {
-                        format!(
-                            "No TXT record found at {}. Please create a TXT record with value: {}",
-                            record_name, expected_value
-                        )
-                    }
-                    hickory_resolver::error::ResolveErrorKind::Timeout => {
-                        "DNS lookup timed out. Please try again later.".into()
-                    }
-                    _ => format!("DNS lookup failed: {}", e),
+                // Provide helpful error messages based on error type.
+                //
+                // hickory 0.26 moved the taxonomy: what was
+                // `ResolveErrorKind::NoRecordsFound` is now reached through
+                // `NetError::is_no_records_found`, and `Timeout` is a variant
+                // of `NetError` rather than of the resolver's own error.
+                let reason = if e.is_no_records_found() {
+                    format!(
+                        "No TXT record found at {}. Please create a TXT record with value: {}",
+                        record_name, expected_value
+                    )
+                } else if matches!(e, hickory_resolver::net::NetError::Timeout) {
+                    "DNS lookup timed out. Please try again later.".to_string()
+                } else {
+                    format!("DNS lookup failed: {}", e)
                 };
 
                 VerificationResult::Failed { reason }
@@ -223,6 +259,67 @@ impl Default for DomainVerificationService {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // These cover the comparison that the hickory 0.26 migration moved. The
+    // old code iterated rdata and stringified it; the new code takes
+    // `record.data` off a `Record`, because `Record`'s own Display renders
+    // `name ttl class type rdata` and would never match a bare token. A
+    // regression here fails every DNS verification silently.
+
+    #[test]
+    fn a_quoted_txt_value_matches() {
+        assert!(txt_matches(
+            "\"postrust-verify=abc123\"",
+            "postrust-verify=abc123"
+        ));
+    }
+
+    #[test]
+    fn an_unquoted_txt_value_matches() {
+        assert!(txt_matches(
+            "postrust-verify=abc123",
+            "postrust-verify=abc123"
+        ));
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_break_it() {
+        assert!(txt_matches(
+            "  \"postrust-verify=abc123\"  ",
+            "postrust-verify=abc123"
+        ));
+    }
+
+    #[test]
+    fn a_value_split_across_character_strings_matches() {
+        // A TXT value over 255 bytes is stored as several character strings
+        // and renders as several quoted parts; DNS defines the value as their
+        // concatenation.
+        assert!(txt_matches(
+            "\"postrust-verify=\" \"abc123\"",
+            "postrust-verify=abc123"
+        ));
+    }
+
+    #[test]
+    fn a_different_value_does_not_match() {
+        assert!(!txt_matches(
+            "\"postrust-verify=wrong\"",
+            "postrust-verify=abc123"
+        ));
+        assert!(!txt_matches("\"\"", "postrust-verify=abc123"));
+        assert!(!txt_matches("", "postrust-verify=abc123"));
+    }
+
+    #[test]
+    fn a_whole_record_line_does_not_match() {
+        // Exactly what `record.to_string()` would have produced. If this ever
+        // starts passing, the comparison has been loosened too far.
+        assert!(!txt_matches(
+            "_postrust-verification.example.com. 300 IN TXT \"postrust-verify=abc123\"",
+            "postrust-verify=abc123"
+        ));
+    }
 
     #[tokio::test]
     async fn test_dns_verification_not_found() {

--- a/crates/postrust-response/Cargo.toml
+++ b/crates/postrust-response/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-response"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-server/Cargo.toml
+++ b/crates/postrust-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-server"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-sql/Cargo.toml
+++ b/crates/postrust-sql/Cargo.toml
@@ -2,6 +2,7 @@
 name = "postrust-sql"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/crates/postrust-worker/Cargo.toml
+++ b/crates/postrust-worker/Cargo.toml
@@ -4,6 +4,7 @@ name = "postrust-worker"
 # rest of the workspace is heading for 1.0.0. See docs/stability.md.
 version = "0.5.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@ This guide will help you get Postrust up and running in minutes.
 ## Prerequisites
 
 - PostgreSQL 12 or later
-- Rust 1.75+ (for building from source) or Docker
+- Rust 1.88+ (for building from source) or Docker
 
 ## Installation
 

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -127,6 +127,6 @@ the next major.
 
 Bugs and questions: [GitHub Issues](https://github.com/postrust/postrust/issues).
 
-For anything with a security impact, please report it privately through
-[GitHub's security advisory form](https://github.com/postrust/postrust/security/advisories/new)
-rather than opening a public issue.
+For anything with a security impact, see
+[SECURITY.md](https://github.com/postrust/postrust/blob/main/SECURITY.md) --
+report it privately rather than opening a public issue.


### PR DESCRIPTION
> **Stacked on [#21](https://github.com/postrust/postrust/pull/21)** — based on that branch rather than `main`, because `main`'s database-backed job is currently red and this would inherit the failure. Retarget to `main` once #21 lands. Review #21 first.

Three things a 1.0.0 needs that this repository did not have.

## MSRV: declared nowhere, claimed as three different wrong numbers

| Place | Claimed |
| --- | --- |
| README badge and prerequisites | 1.78 |
| `docs/getting-started.md` | 1.75 |
| `CONTRIBUTING.md` | 1.75 |
| `Cargo.toml` | *nothing* |

The real floor is **1.88**, established by building rather than by reading: 1.88.0 compiles the workspace clean and **1.87.0 is refused outright** because `hickory-{net,proto,resolver}` 0.26 and `time` 0.3.55 all declare it.

Now `rust-version = "1.88"` in `[workspace.package]`, inherited by all nine crates, with a CI job that builds `--locked` on 1.88 — an MSRV check that lets cargo pick newer dependencies is checking a different tree than the one that ships.

## 14 dependency advisories → 1, and it is unreachable

`cargo audit` reported 14 vulnerabilities. **12 fixed by updating the lockfile**, and they are not cosmetic for a TLS-terminating proxy:

- **`aws-lc-sys` ×5** — X.509 name-constraint bypass via wildcard/Unicode CN, two PKCS7 signature and chain validation bypasses, a CRL distribution-point scope error, an AES-CCM timing side channel
- **`rustls-webpki` ×4** — reachable panic in CRL parsing, URI name constraints incorrectly accepted, and two more CRL/wildcard issues
- **`h2`** — unbounded empty DATA frames
- plus `bytes`, `time`, `anyhow`, `event-listener`, both `rand` majors, and `quinn-proto` + the yanked `spin` from [#14](https://github.com/postrust/postrust/issues/14)

**Cost, stated plainly:** this raised the MSRV from 1.86 to 1.88. `hickory` 0.26 and `time` 0.3.55 both require it. The advisories are worth two releases of toolchain floor.

### The hickory upgrade had a silent trap in it

`hickory-resolver` 0.24 → 0.26 clears an O(n²) name-compression CPU exhaustion. It is a real API migration, and one part would have broken without any compiler error at the call site: 0.26 replaced the rdata iterator with `Lookup::answers()`, and `Record`'s `Display` renders the **whole record line**:

```rust
write!(f, "{name} {ttl} {class} {ty} {rdata}", ...)
```

So the previous `record.to_string()` would have produced `_postrust-verification.example.com. 300 IN TXT "postrust-verify=abc"` and never matched a bare token again — **every DNS verification would have failed silently.** It needs `record.data`.

The comparison now lives in a tested `txt_matches`, with six cases, including one asserting that a full record line does *not* match and one for a value split across several 255-byte character strings.

## Three advisories remain, ignored with reasons

In `.cargo/audit.toml`, one written justification each rather than loosening the gate:

- **`rsa` RUSTSEC-2023-0071** — `cargo tree -i rsa` prints nothing. It sits behind sqlx's MySQL feature, which is not enabled; no RSA code is compiled. It also has no patched release.
- **`instant` RUSTSEC-2024-0384** — unmaintained, reached only via `notify`, which the proxy pulls in for one error variant of a file watcher that is not implemented. The fix is to drop `notify`, which is an API change.
- **`rustls-pemfile` RUSTSEC-2025-0134** — unmaintained but genuinely used, loading the HTTPS listener's certificate. Migrating to `rustls-pki-types` deserves its own change.

## The audit job was verified, not just added

It would have been red on day one **twice over**: `cargo-audit` 0.21 cannot parse a CVSS 4.0 advisory in the current RustSec database (`unsupported CVSS version: 4.0`), and the 14 advisories were real. Pinned to `^0.22` and confirmed `exit 0` locally before committing. Same discipline as the Autobahn gate.

## SECURITY.md

How to report privately, what to expect and when, what is in scope — and the known weaknesses that are documented rather than reportable: HTTP verification being weaker than DNS, ACME not being implemented, the worker being a stub.

It also asks reporters to check reachability before treating a locked version as an exposure, using the `quinn-proto` case as the worked example: flagged in `Cargo.lock`, present in no build graph, and reported as a remotely exploitable denial of service it could not have been.

## Verification

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo clippy -p postrust-server --features admin-ui`, `cargo test --workspace` (24 suites, 0 failures), `cargo audit --deny warnings` (exit 0), `cargo +1.88 check --workspace --all-targets --locked` (clean), and the 10 database-backed tests from an empty database.