### PR TITLE
docs: add the Code of Conduct the website already promised

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Code of Conduct
+
+## Our commitment
+
+Everyone should be able to take part in Postrust — filing an issue, sending a
+patch, asking a question — without being harassed for who they are.
+
+That applies regardless of age, body size, visible or invisible disability,
+ethnicity, sex characteristics, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, caste, colour, religion, or sexual identity and orientation.
+
+## What we expect
+
+- Assume the other person is acting in good faith, and say what you mean
+  plainly.
+- Give and take feedback about the work, not about the person doing it.
+- When you get something wrong, say so and fix it. Nobody here has a clean
+  record.
+- Remember that most people are reading in their second language, on a bad day,
+  in a hurry.
+
+## What is not acceptable
+
+- Sexualised language or imagery, and unwelcome sexual attention.
+- Insults, personal or political attacks, and trolling.
+- Harassment, public or private.
+- Publishing someone's private information — a physical address, an email
+  address, anything else — without their explicit permission.
+- Anything else that would reasonably be considered inappropriate in a
+  professional setting.
+
+## Scope
+
+This applies in every project space — the repository, issues, pull requests,
+discussions — and whenever someone is representing the project in public.
+
+## Reporting
+
+Report abusive, harassing, or otherwise unacceptable behaviour to
+[technology@bimaplan.co](mailto:technology@bimaplan.co).
+
+Every report will be reviewed and investigated promptly and fairly. Your
+privacy and safety as a reporter will be respected: we will not share your
+identity with the person you are reporting without asking you first.
+
+If your report is about a maintainer, say so — it will still be read, and we
+will tell you honestly if we cannot handle it impartially.
+
+## Enforcement
+
+Maintainers are responsible for clarifying and enforcing this code, and may
+remove, edit, or reject comments, commits, code, issues, and other
+contributions that do not follow it. Where we do, we will say why.
+
+Depending on what happened and whether it is a pattern, the response ranges
+from a private word, through a warning and a temporary ban from interaction,
+to a permanent ban. We will aim for the least severe response that actually
+resolves it, and we will not pretend a warning was a conversation.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, which is available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html> and
+licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The
+wording here is our own; the substance is theirs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Postrust! This document provides 
 
 ## Code of Conduct
 
-This project adheres to a code of conduct. By participating, you are expected to uphold this code. Please be respectful and constructive in all interactions.
+This project has a [Code of Conduct](CODE_OF_CONDUCT.md). By taking part you are expected to uphold it. Report unacceptable behaviour to [technology@bimaplan.co](mailto:technology@bimaplan.co).
 
 ## Getting Started
 


### PR DESCRIPTION
Fixes the 404 on the community page.

## The problem

`website/src/routes/community/index.tsx` says:

> We are committed to providing a welcoming and inclusive community. All participants are expected to follow our Code of Conduct.

and links to `github.com/postrust/postrust/blob/main/CODE_OF_CONDUCT.md`, which was not in the repository. `CONTRIBUTING.md` made the same claim — "This project adheres to a code of conduct" — without linking anything at all.

## Why write it rather than remove the claim

The commitment is already public on the site, and a project that takes security reports and invites contributions should have one. Removing the link would have been walking back a promise; the cheaper and more honest fix is to keep the promise.

## What's here

Adapted from [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html) (CC BY 4.0, attributed at the bottom of the file). The substance is theirs; the wording is ours, so it reads like the rest of the repository rather than like a pasted template.

Reporting goes to the same address `SECURITY.md` already uses. Two things are stated that boilerplate usually leaves out:

- what happens if the report is **about a maintainer** — it still gets read, and we say honestly if we can't handle it impartially
- that we aim for the least severe response that actually resolves it, and **won't pretend a warning was a conversation**

`CONTRIBUTING.md` now links the file instead of gesturing at it.

## Verification

Every `blob/main/...` link across the site and docs now resolves — I swept them, and this was the only dangling one. Repository governance files are complete: LICENSE, README, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT.

Documentation only; no code changes.

## Note on timing

This landed after `v1.0.0-beta.1` was tagged, so it isn't in that release. That doesn't matter for the 404: the website link resolves against `main`, not against a tag, so it fixes as soon as this merges.