### PR TITLE
A benchmark whose numbers can be trusted, and the host that makes them so

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -20,8 +20,12 @@ Requirements:
 - `docker`
 - `cargo`
 - `curl`
-- a load generator: [`oha`](https://github.com/hatoo/oha) (best percentiles),
-  `hey`, or `ab` (ships with macOS)
+- a load generator: [`oha`](https://github.com/hatoo/oha), or `ab`. `hey` is
+  **not** supported -- its text output was once parsed from memory and produced
+  silently wrong numbers, so the harness only accepts generators whose output it
+  has actually been checked against. `oha` is strongly preferred: it reports
+  percentiles as JSON, and `ab` is HTTP/1.0-only and goes client-bound near
+  7,000 rps, well below what these servers reach.
 
 ## Options
 
@@ -40,6 +44,10 @@ All options are environment variables:
 | `SKIP_BUILD` | `0` | Reuse an existing `target/release/postrust` |
 | `KEEP` | `0` | Leave the database and server running for manual poking |
 | `RESULTS_DIR` | temp dir | Where results and the server log are written |
+| `CPUSET_DB` | unset | Cores the database is confined to. Unset means no pinning |
+| `CPUSET_SERVER` | unset | Cores the server under test is confined to. The same value for every target |
+| `CPUSET_LOAD` | unset | Cores the load generator is confined to |
+| `GATE_THRESHOLD_PCT` | `3` | Drift permitted between the first measurement and its repeat at the end of the run |
 
 Examples:
 
@@ -53,6 +61,188 @@ BENCH_FEATURES="" ./scripts/bench.sh
 # Keep everything up afterwards to run your own queries
 KEEP=1 ./scripts/bench.sh
 ```
+
+## The measurement host
+
+Throughput figures are a property of the machine as much as of the software, so
+the machine is part of the method rather than a footnote.
+
+Every published figure comes from a **dedicated bare-metal host**, not a VM and
+not a laptop. The requirement is not raw speed; it is that the machine can be
+made to hold still. A hypervisor hides the CPU's frequency behaviour from the
+guest, and a laptop's is governed by thermal policy that no benchmark can see
+or control. Both produce numbers that drift under the harness -- which is
+exactly the failure recorded in
+[`scripts/BENCH-FINDINGS.md`](../scripts/BENCH-FINDINGS.md).
+
+The current host:
+
+| | |
+|---|---|
+| CPU | AMD EPYC 9255, 24 cores, single socket, 4 CCDs of 6 cores with 32 MB L3 each |
+| Memory | 376 GB (the workload uses about 4) |
+| OS | Ubuntu 24.04 LTS, Docker CE from Docker's own repository |
+
+### Confirming it is really bare metal
+
+Before anything is installed:
+
+```bash
+systemd-detect-virt
+```
+
+It must print `none`. A product page saying "bare metal" is not evidence; this
+is. If `/sys/devices/system/cpu/cpufreq/` is also absent, the machine is a
+guest whatever it was sold as, and no amount of pinning will make its numbers
+reproducible.
+
+### Holding the machine still
+
+```bash
+# Sibling threads share a core, so two pinned components can land on one core
+# while appearing to have separate CPUs. Runtime change, no reboot.
+echo off > /sys/devices/system/cpu/smt/control
+
+# Ask for a fixed clock rather than an opportunistic one.
+echo 0 > /sys/devices/system/cpu/cpufreq/boost
+for g in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do echo performance > "$g"; done
+for e in /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference; do echo performance > "$e"; done
+
+echo never > /sys/kernel/mm/transparent_hugepage/enabled
+sysctl -w vm.swappiness=1
+```
+
+**Verify that the request was honoured, because it may not be.** On this host
+it is not: the platform firmware owns P-states and discards the OS's requests.
+`scaling_max_freq` dutifully drops to 3200000 and the CPU keeps running at
+4317 MHz. Writing the sysfs file is not evidence that anything changed --
+measuring is:
+
+```bash
+# Same fixed quantity of work, timed. If a cap is in effect, this gets slower.
+time taskset -c 0 awk 'BEGIN{for(i=0;i<80000000;i++) x+=i}'
+```
+
+Here, a 2.0 GHz cap, a 3.2 GHz cap and no cap at all produce the same wall
+time to within noise, and `turbostat` reads 4317 MHz throughout. The clock is
+fixed -- just at the firmware's chosen value rather than at base.
+
+That it stays fixed *for the length of a run* is the part that actually matters,
+so it is sampled rather than assumed. `turbostat` runs alongside the harness for
+the whole run, and the samples taken while the machine was under load (843 of
+them, `Busy%` above 20) span **4294-4329 MHz -- a 0.82% spread**. A clock that
+ramped would show up here as a trend, and it is the same measurement that would
+have exposed the drift on the previous host. That is
+acceptable, because what the benchmark needs is a clock that does not *vary*
+during a run; it is not the same as pinning to base clock, and the difference
+is recorded here rather than papered over. A run on different firmware will
+produce different absolute numbers.
+
+### One component per CCD
+
+On a multi-CCD AMD part, cores in different CCDs do not share an L3 slice.
+Giving each component its own CCD means the database, the server under test and
+the load generator cannot evict each other's cache. Ask the machine for its own
+grouping rather than assuming the numbering is linear:
+
+```bash
+cat /sys/devices/system/cpu/cpu*/cache/index3/shared_cpu_list | sort -u
+```
+
+On this host, with SMT off, that yields four groups which map onto the four
+roles:
+
+| CCD | cores | |
+|---|---|---|
+| 0 | 0-5 | PostgreSQL |
+| 1 | 6-11 | the server under test |
+| 2 | 12-17 | the load generator |
+| 3 | 18-23 | the harness itself, dockerd, the OS |
+
+Passed to the harness as:
+
+```bash
+CPUSET_DB=0-5 CPUSET_SERVER=6-11 CPUSET_LOAD=12-17 \
+  taskset -c 18-23 ./scripts/bench-compare.sh
+```
+
+Check it landed, while a run is in flight -- the same principle as the clock,
+that asking is not the same as getting:
+
+```bash
+docker inspect -f '{{.Name}} {{.HostConfig.CpusetCpus}}' $(docker ps -q)
+taskset -pc "$(pgrep -x oha)"
+```
+
+Expected: every `postrust-cmp-*` server on the same cpuset, the database on its
+own, and `oha` on a third.
+
+**Every target gets the identical `CPUSET_SERVER`.** Giving one server more
+cores than another encodes the bias into the instrument, which is the single
+failure a differential benchmark exists to rule out. The harness has no way to
+express a per-target allocation, deliberately.
+
+## The self-consistency gate
+
+Repeating a measurement does not establish that it is sound. `measure_median`
+runs its repeats back to back, so all of them sit in whatever state the machine
+is in at that moment: they agree with each other perfectly and can be equally
+wrong. That is precisely how the drift documented in `BENCH-FINDINGS.md` went
+unnoticed across several rounds of published figures.
+
+So the first measurement of a run is repeated as its **last** action, with
+everything else in between:
+
+```
+Self-consistency
+ the first measurement (point lookup / postrust) repeated as the last action of the run
+ first 44163 rps, last 44169 rps -- drift 0.0% against a 3% threshold: pass
+```
+
+If the two disagree by more than `GATE_THRESHOLD_PCT` (default 3), the machine
+did not hold still, nothing measured in between is comparable across targets,
+and `bench-compare.sh` **exits non-zero**. The results file is still written --
+it is needed to diagnose the drift -- but nothing downstream may treat it as
+publishable.
+
+A passing gate is a necessary condition, not a sufficient one. It proves the
+machine ended the run where it started, which is what the earlier virtualised
+runs could not do.
+
+## What Docker costs
+
+Every server runs in a container so that none of them gets a native-vs-container
+advantage. That fairness is not free, and the size of the charge is measured
+rather than assumed. Same binary, same database, same fixtures, same cpusets,
+same generator; only the packaging changes:
+
+| | point lookup |
+|---|---|
+| **A** both containers on a bridge, measured through the published port | 44,496 rps |
+| **B** the same containers with `--network host` | 48,013 rps |
+| **C** the native binary against a host-networked database | 48,684 rps |
+
+- **A -> B: 7.3%.** Docker's network plumbing -- veth, the bridge, NAT.
+- **B -> C: 1.4%.** Everything else a container does to the process: seccomp,
+  cgroups, overlayfs. Close to nothing.
+- **A -> C: 8.6%** in total, charged to every target equally, so ratios are
+  unaffected and absolutes are understated by about that much.
+
+`docker-proxy` is disabled on the measurement host:
+
+```json
+/* /etc/docker/daemon.json */
+{ "userland-proxy": false }
+```
+
+This is a measurement-integrity fix rather than a performance tweak.
+`docker-proxy` is a userspace relay, one process per published port, sitting in
+the request path -- and it is covered by no `--cpuset-cpus`, so it lands
+wherever the scheduler puts it, including on the cores the database or the
+server under test are pinned to. Turning it off moves port publishing to
+iptables DNAT, which is kernel-side and has no process to misplace. It recovered
+3.2 points on its own (43,130 -> 44,496 rps) while leaving B and C unchanged,
+which is the check that it touched only the path it was supposed to.
 
 ## Why the window is 30,000 requests
 
@@ -99,28 +289,43 @@ Memory is the server process's RSS, sampled before any request is served
 
 ## Reference results
 
-Measured with the harness at its defaults on an Apple M-series laptop. Treat
-these as a shape to compare against, not a target — see the caveats below.
+Measured on the pinned bare-metal host described above, with `oha`. The server
+runs natively here; the database is a container pinned to its own CCD.
 
 ```
- host           : Darwin 25.2.0 arm64
- postgres       : postgres:18-alpine
- load generator : ab (n=30000, c=50)
+ host           : Linux 7.0.0-30-generic x86_64
+ cpu            : AMD EPYC 9255 24-Core Processor
+ pinning        : db=0-5 server=6-11 load=12-17
+ postgres       : postgres:16
+ load generator : oha (n=30000, c=50)
  dataset        : bench_items, 100000 rows
 
- binary         : 5220864 bytes (4.98 MiB), stripped: yes
+ binary         : 8632680 bytes (8.23 MiB), stripped: yes
  features       : admin-ui
- memory (idle)  : 10.0 MB
- memory (final) : 13.3 MB
+ memory (idle)  : 10.5 MB
+ memory (final) : 20.5 MB
 
  scenario                         req/s   p50 ms   p95 ms   p99 ms        RSS
  ---------------------------- --------- -------- -------- -------- ----------
- point lookup (id=eq.N)            6065      8.0     10.0     22.0    14.1 MB
- 25-row page                       6065      8.0     11.0     13.0    14.4 MB
- filtered + ordered page           5025      9.0     14.0     23.0    14.6 MB
- page with exact count             6373      7.0     11.0     19.0    14.7 MB
- range filter on numeric           6468      7.0     10.0     14.0    13.3 MB
+ point lookup (id=eq.N)           46596      1.0      1.1      1.9    19.4 MB
+ 25-row page                      36711      1.3      1.4      1.5    19.6 MB
+ filtered + ordered page          34153      1.4      1.5      1.5    20.4 MB
+ page with exact count             2275     21.5     24.7     26.5    20.5 MB
+ range filter on numeric          31890      1.5      1.6      1.7    20.5 MB
 ```
+
+Two things in that table are worth reading rather than skimming.
+
+**`page with exact count` is 15-20x slower than everything else, and that is
+correct.** `Prefer: count=exact` asks PostgreSQL to count every matching row
+before the page can be returned, so the request does work proportional to the
+table rather than to the page. It is in the harness precisely so that cost stays
+visible; the cheaper `count=planned` and `count=estimated` do not pay it.
+
+**These are higher than the containerised figures on the comparison pages**, and
+by about the margin measured under "What Docker costs" -- 46596 here against
+44490 for the same scenario through a published port. Same binary, same
+database, same cores.
 
 ### Binary size
 
@@ -129,33 +334,47 @@ misleading:
 
 | Build | Bytes | Size |
 |-------|-------|------|
-| `cargo build --release -p postrust-server` | 3,070,080 | 2.93 MiB |
-| `cargo build --release -p postrust-server --features admin-ui` | 5,220,864 | 4.98 MiB |
+| `cargo build --release -p postrust-server` | 4,887,528 | 4.66 MiB |
+| `cargo build --release -p postrust-server --features admin-ui` | 8,632,680 | 8.23 MiB |
 
-The published Docker image and release binaries are built with `admin-ui`
-(Swagger UI, Scalar, OpenAPI, GraphQL playground), so **~5 MB is the number
-that describes what you actually download**. A minimal build of just the REST
-and GraphQL API is ~3 MB. Both are measured on macOS arm64; a Linux x86_64
-build differs somewhat.
+Both measured on Linux x86_64 with the release profile, which is what the
+published Docker image and release binaries are. **~8 MB is the number that
+describes what you actually download**, because those artefacts are built with
+`admin-ui` (Swagger UI, Scalar, OpenAPI, GraphQL playground). A minimal build of
+just the REST and GraphQL API is ~4.7 MB.
+
+An arm64 macOS build is materially smaller -- 5,220,864 bytes with `admin-ui` --
+so a size quoted without its target is not a fact about the project. The
+container images differ again, and are reported per variant on the comparison
+pages: 34.9 MB for the alpine image against 149 MB for the debian one.
 
 ## Caveats
 
 Read these before quoting any throughput number:
 
 - **Everything shares one machine.** PostgreSQL, Postrust and the load
-  generator compete for the same cores over loopback. The numbers are useful
-  for comparing Postrust against itself across changes, not for capacity
-  planning.
-- **Latency here is dominated by contention, not by Postrust.** At concurrency
-  50 on a laptop, p50 sits around 8 ms; the same request against an idle server
-  is roughly an order of magnitude faster.
+  generator run on one host. They are given separate cores and separate L3
+  slices, so they do not compete directly, but they do share memory bandwidth
+  and one kernel. The numbers are useful for comparing the tools against each
+  other, not for capacity planning.
+- **Unpinned, this is largely a measurement of the scheduler.** The same point
+  lookup that reports p50 ~1.1 ms on the pinned bare-metal host reported ~8 ms
+  on an unpinned laptop, and 6,065 rps against 46,596. Numbers from the two
+  setups are not comparable in either direction, and only pinned bare-metal
+  numbers are published.
 - **`ab` is the weakest of the three load generators.** It is HTTP/1.0 only and
   its percentiles are coarse. Install `oha` for numbers worth comparing between
   runs.
 - **Cold start is not measured here.** The ~50 ms Lambda figure comes from a
   different environment and is not produced by this harness.
-- **PostgREST is not measured here.** Comparison-table figures for other
-  projects come from their own documentation.
+- **`bench.sh` measures this server alone.** PostgREST, Hasura and PostGraphile
+  are measured by [`scripts/bench-compare.sh`](../scripts/bench-compare.sh),
+  which runs all four as containers on one network against one database. No
+  figure on the website is taken from another project's own documentation.
+- **The absolute numbers carry the host's firmware with them.** This machine's
+  clock is held at 4317 MHz by its BIOS, not at the 3.2 GHz base. A different
+  machine, or the same machine with a different system profile, will produce
+  different absolutes. The ratios are the durable part.
 
 ## Correctness first
 

--- a/scripts/BENCH-FINDINGS.md
+++ b/scripts/BENCH-FINDINGS.md
@@ -1,11 +1,214 @@
 # Benchmark findings
 
-What the comparison benchmark has been measuring, and why its numbers are not
-currently publishable. Newest first.
+What the comparison benchmark has been measuring, and what had to change before
+its numbers could be published. Newest first.
+
+## The drift does not reproduce on bare metal, and the gate now proves it
+
+**Status: resolved by changing the host. Numbers published.**
+
+The open item below -- throughput depending on when in a run it was sampled --
+does not occur on a dedicated bare-metal host with each component pinned to its
+own CCD. The same measurement, taken as the first and then as the last action
+of a full four-server run:
+
+| run | first | last | drift |
+|---|---|---|---|
+| debian 1 | 44163 rps | 44169 rps | 0.0% |
+| debian 2 | 44490 rps | 44559 rps | 0.2% |
+| debian 3 | 44186 rps | 44132 rps | 0.1% |
+| alpine | 43727 rps | 43179 rps | 1.3% |
+
+Those are within-run figures. The same measurement *across* the three debian
+runs read 44163, 44490 and 44186 -- a 0.7% spread between independent runs of
+the whole harness, against the 1.25x-1.39x run-to-run spread the previous host
+produced.
+
+That comparison is now a permanent part of the harness rather than something
+done by hand. `bench-compare.sh` repeats its first measurement at the end of
+the run and exits non-zero if the two disagree by more than
+`GATE_THRESHOLD_PCT` (default 3). The results file is still written, because it
+is needed to diagnose a failure, but a drifted run cannot be mistaken for a
+publishable one.
+
+This gate exists because `REPEATS` could never have caught the original
+problem. `measure_median` runs its repeats back to back, so all of them sit in
+the same state and agree with each other while being equally wrong -- the
+failure mode the note further down describes as "a systematic bias reproduces
+perfectly and reads as precision".
+
+Throughput on the new host is roughly four times what the virtualised host
+reported (44163 rps against 6212-13000 for the same scenario). That is not a
+change in the software. Nothing in this repository was made faster; the
+instrument stopped losing most of the signal.
+
+The clock was sampled for the length of the run rather than checked before it.
+Across 843 `turbostat` samples taken while the machine was loaded, `Bzy_MHz`
+spanned 4294-4329 -- a 0.82% spread. A ramping clock, which is the leading
+hypothesis for the old drift, would have shown as a trend across those samples.
+
+### What actually changed
+
+- Dedicated bare metal (AMD EPYC 9255, 24 cores, single socket), confirmed with
+  `systemd-detect-virt` returning `none`, rather than Docker Desktop on WSL2.
+- SMT off, so two components pinned to "different CPUs" cannot share a core.
+- One CCD per component -- database on 0-5, server under test on 6-11, load
+  generator on 12-17, everything else on 18-23 -- so no two of them share a
+  32 MB L3 slice. Every target gets the identical `CPUSET_SERVER`.
+- `docker-proxy` disabled, removing an unpinned userspace process from the
+  request path.
+
+## The alpine variant moves the other tools, and it should not
+
+**Status: open. One run each. No alpine throughput figure is published.**
+
+`VARIANT=alpine` is meant to answer "how big is the alpine image, and does the
+musl build cost anything". It changes more than that: the PostgreSQL image
+(`postgres:16` to `postgres:16.11-alpine`) and the PostGraphile base
+(`node:22` to `node:22-alpine`) as well as the Postrust image. PostgREST and
+Hasura run **byte-identical images in both variants** -- their image tags are
+not variant-dependent.
+
+Yet, alpine against debian:
+
+| target | image changed? | change |
+|---|---|---|
+| postrust | yes (musl) | +2% to +33% |
+| hasura | **no** | +1.4% to +2.2% |
+| postgraphile | yes (musl node) | -15% to -17% |
+| postgrest | **no** | **-27% to -38%** |
+
+postrust improving and PostGraphile losing ~15% are both readable -- a musl
+build is a real change. PostgREST is not. Its container is identical, so the
+only thing that moved underneath it is the database image, and Hasura saw that
+same database move and stayed flat.
+
+Candidate explanations, none established:
+
+- PostgREST noise. Its measured run-to-run spread is already 19.6% (below), the
+  widest of the four. -37% is more than that, but not a different universe.
+- The alpine PostgreSQL penalising PostgREST's query shapes specifically.
+  Hasura's flatness argues against a general database slowdown, but the two
+  tools are measured on different surfaces with different queries.
+
+Separating those needs a second alpine run, which has not been done. Until it
+is, alpine is used **only** for image size and memory, which is what it was
+added for. `gen-measured.mjs` takes request figures from the first results file
+only, so no alpine throughput number reaches the website; the guard is
+structural rather than a matter of remembering.
+
+## PostgREST's own run-to-run spread is an order of magnitude wider than the others'
+
+**Status: measured across two full runs. A caveat on the PostgREST ratios, not
+a fault in the harness.**
+
+Three complete debian runs, same host, same pinning, same configuration. Spread
+between the highest and lowest reading of each scenario:
+
+| target | worst scenario | mean |
+|---|---|---|
+| postrust | 0.8% | 0.5% |
+| postgraphile | 3.0% | 1.8% |
+| hasura | 3.6% | 2.6% |
+| **postgrest** | **19.6%** | **6.8%** |
+
+Two PostgREST scenarios account for it. Point lookup read 9136, 10747, 10931 --
+the first run is the outlier and the second and third agree to 1.7%, so that one
+looks like a single bad sample rather than continuing instability. Range filter
+read 6526, 7140, 6890: 9.4% with no outlier to blame. The remaining three
+scenarios are inside 3%.
+
+This is the tool, not the machine. postrust was measured seconds either side of
+those same PostgREST samples and held to 0.7%, and the self-consistency gate
+passed on both runs. A machine that drifted would have moved everything.
+
+Two consequences, both stated wherever PostgREST figures appear:
+
+- A single run establishes the PostgREST ratios to roughly +/-10%, where
+  postrust reaches 1% and the two GraphQL servers 3%. The *direction* of the
+  differences is far outside that margin -- postrust leads PostgREST by 3x to
+  9x depending on scenario -- but the precise multiples are not, and are not
+  quoted to more precision than they carry.
+- **The gate does not cover this.** It repeats the first measurement of the run,
+  which is one scenario on one target, and so it answers "did the machine hold
+  still" -- not "is each target individually reproducible". Extending it to
+  re-measure every target at the end would turn this into something the harness
+  reports on every run rather than something noticed by comparing two of them.
+  That change is not made here, because it has not been exercised.
+
+## The platform firmware ignores every OS frequency request
+
+**Status: understood, worked around by measuring rather than assuming.**
+
+The plan was to pin the CPU to its base clock, on the reasoning that base is
+the only clock a vendor guarantees and therefore the only one that reproduces
+elsewhere. On this host that is not possible: the BIOS owns P-states and
+discards what the OS asks for.
+
+The kernel accepts the request and reports success. `scaling_max_freq` drops to
+`3200000` and `cpuinfo_max_freq` follows. The hardware carries on at 4317 MHz.
+
+Caught by timing a fixed quantity of work rather than by reading a sysfs file
+back:
+
+| cap requested | `scaling_max_freq` | wall time |
+|---|---|---|
+| none (boost on) | 4317461 | 1965 / 1904 / 1903 ms |
+| base, boost off | 3200000 | 1912 / 1912 / 1940 ms |
+| 2.0 GHz | 2000000 | 1938 / 1956 ms |
+
+Identical to within noise across a 2.2x range of requested caps, and
+`turbostat` -- which reads APERF/MPERF, the hardware's own account -- reports
+4317 MHz throughout.
+
+The consequence is benign but has to be stated: the clock **is** fixed, which is
+what the benchmark actually needs, but it is fixed at the firmware's chosen
+value and not at base. Absolute figures therefore carry this machine's BIOS
+profile with them and will not reproduce on different firmware. The ratios
+between the four servers do not depend on it.
+
+The general lesson is that writing a sysfs file is not evidence that anything
+changed. Every control in `docs/benchmarking.md` is now paired with a
+measurement that would fail if the control did not take.
+
+## Docker costs 8.6%, and almost all of it is the network path
+
+**Status: measured. Kept, because it is charged to every target equally.**
+
+Running every server in a container is deliberate -- it stops any one of them
+getting a native-vs-container advantage -- but the size of that charge had
+never been established. Same binary, same database, same fixtures, same
+cpusets, same generator, only the packaging changing:
+
+| | point lookup |
+|---|---|
+| A both containers on a bridge, via the published port | 44496 rps |
+| B the same containers with `--network host` | 48013 rps |
+| C the native binary, host-networked database | 48684 rps |
+
+- A -> B **7.3%**: veth, the bridge, NAT.
+- B -> C **1.4%**: seccomp, cgroups, overlayfs. Essentially nothing.
+- A -> C **8.6%** total.
+
+So the container is nearly free and the *network plumbing* is not. Ratios are
+unaffected; absolute figures are understated by about 8.6% against the same
+binary run natively, and that is now stated wherever they are published.
+
+Disabling `docker-proxy` (`"userland-proxy": false`) was part of this work and
+is a measurement-integrity fix rather than a tuning choice: it is a userspace
+relay, one process per published port, in the request path, and covered by no
+`--cpuset-cpus` -- so it lands wherever the scheduler puts it, including on the
+cores pinned to the database or the server under test. Removing it recovered
+3.2 points (43130 -> 44496 rps) and left B and C unchanged, which is the check
+that it touched only the path it was meant to.
 
 ## The measured throughput depends on when in a run it is taken
 
-**Status: reproduced, mechanism not identified. Numbers withheld.**
+**Status: superseded. Was: reproduced on the virtualised host, mechanism never
+identified. Does not reproduce on bare metal -- see the entry at the top. The
+mechanism is still unidentified; it was escaped rather than explained, and the
+gate is what stops it returning unnoticed. The investigation is kept because
+the things it ruled out are still ruled out.**
 
 The same server, in the same container, measured seconds apart, differs by
 about a factor of two:

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -121,6 +121,31 @@ WARMUP="${WARMUP:-500}"
 # conclusion from.
 REPEATS="${REPEATS:-3}"
 
+# CPU pinning, one component per group of cores. Unset means no pinning, which
+# is the right default on a machine whose topology is unknown -- a wrong cpuset
+# is worse than none, because it silently starves whatever it names.
+#
+# On a multi-CCD AMD part, use one CCD each so no two components share an L3
+# slice; the groups are what this prints:
+#
+#     cat /sys/devices/system/cpu/cpu*/cache/index3/shared_cpu_list | sort -u
+#
+# Every server gets the SAME cpuset. Giving one target more cores than another
+# encodes the bias into the instrument, which is the failure a differential
+# benchmark exists to rule out.
+CPUSET_DB="${CPUSET_DB:-}"
+CPUSET_SERVER="${CPUSET_SERVER:-}"
+CPUSET_LOAD="${CPUSET_LOAD:-}"
+
+# Self-consistency gate. The first measurement of the run is repeated as the
+# very last action; if the two disagree by more than this, the machine drifted
+# under the harness and nothing measured in between is comparable.
+#
+# This exists because REPEATS cannot detect that drift: measure_median runs its
+# repeats back to back, so all of them sit in the same drift state and agree
+# with each other while being equally wrong.
+GATE_THRESHOLD_PCT="${GATE_THRESHOLD_PCT:-3}"
+
 KEEP="${KEEP:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 ONLY="${ONLY:-postrust,postgrest,hasura,postgraphile}"
@@ -340,6 +365,30 @@ LOAD_TOOL="oha"
 
 docker info >/dev/null 2>&1 || die "docker daemon is not responding"
 
+# What the CPU was actually doing while this ran. A throughput figure without
+# these is not reproducible: the same box with boost left on, SMT on, or a
+# ramping governor is a different instrument.
+host_cpu_model() { grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//' || echo unknown; }
+host_cpu_cond() {
+    local gov boost smt
+    gov="$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo n/a)"
+    boost="$(cat /sys/devices/system/cpu/cpufreq/boost 2>/dev/null || echo n/a)"
+    smt="$(cat /sys/devices/system/cpu/smt/control 2>/dev/null || echo n/a)"
+    # boost_sysfs, not boost: this is what the file reads, which is not the
+    # same as what the hardware does. Some platform firmware owns P-states
+    # and discards the request. See docs/benchmarking.md.
+    printf 'governor=%s boost_sysfs=%s smt=%s online=%s' "$gov" "$boost" "$smt" \
+        "$(cat /sys/devices/system/cpu/online 2>/dev/null || echo n/a)"
+}
+
+# Built as arrays so an unset cpuset adds no argument at all.
+DB_PIN=();  [[ -n "$CPUSET_DB"     ]] && DB_PIN=(--cpuset-cpus "$CPUSET_DB")
+SRV_PIN=(); [[ -n "$CPUSET_SERVER" ]] && SRV_PIN=(--cpuset-cpus "$CPUSET_SERVER")
+export CPUSET_LOAD
+if [[ -n "$CPUSET_LOAD" ]] && ! command -v taskset >/dev/null 2>&1; then
+    die "CPUSET_LOAD is set but taskset is not installed"
+fi
+
 # A process already holding one of these ports produces a confusing failure:
 # docker cannot publish the port, the health check reaches whatever is already
 # listening, and the target is reported unhealthy after a 90s wait. Checking up
@@ -402,6 +451,7 @@ docker network create "$NETWORK" >/dev/null
 
 log "starting postgres ($PG_IMAGE)..."
 docker run -d --name "$PG_CONTAINER" --network "$NETWORK" \
+        ${DB_PIN[@]+"${DB_PIN[@]}"} \
     -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB="$PG_DB" \
     "$PG_IMAGE" >/dev/null
 
@@ -442,6 +492,7 @@ fi
 start_postrust() {
     log "starting postrust..."
     docker run -d --name postrust-cmp-postrust --network "$NETWORK" \
+        ${SRV_PIN[@]+"${SRV_PIN[@]}"} \
         -p "$PORT_POSTRUST:3000" \
         -e DATABASE_URL="$PG_INTERNAL_URI" \
         -e PGRST_DB_ANON_ROLE=bench_anon \
@@ -457,6 +508,7 @@ start_postrust() {
 start_postgrest() {
     log "starting postgrest..."
     docker run -d --name postrust-cmp-postgrest --network "$NETWORK" \
+        ${SRV_PIN[@]+"${SRV_PIN[@]}"} \
         -p "$PORT_POSTGREST:3000" \
         -e PGRST_DB_URI="$PG_INTERNAL_URI" \
         -e PGRST_DB_SCHEMAS=public \
@@ -472,6 +524,7 @@ start_postgrest() {
 start_hasura() {
     log "starting hasura..."
     docker run -d --name postrust-cmp-hasura --network "$NETWORK" \
+        ${SRV_PIN[@]+"${SRV_PIN[@]}"} \
         -p "$PORT_HASURA:8080" \
         -e HASURA_GRAPHQL_DATABASE_URL="$PG_INTERNAL_URI" \
         -e HASURA_GRAPHQL_METADATA_DATABASE_URL="postgres://postgres:postgres@$PG_CONTAINER:5432/$PG_META_DB" \
@@ -537,6 +590,7 @@ start_postgraphile() {
     # --simple-inflection is deliberately NOT used: the default inflection is
     # what a default install serves, and the point is to measure defaults.
     docker run -d --name postrust-cmp-postgraphile --network "$NETWORK" \
+        ${SRV_PIN[@]+"${SRV_PIN[@]}"} \
         -p "$PORT_POSTGRAPHILE:5000" \
         "$POSTGRAPHILE_IMAGE" \
         sh -c "postgraphile --preset postgraphile/presets/amber -c '$PG_INTERNAL_URI' -n 0.0.0.0 -p 5000 --schema public" >/dev/null
@@ -570,6 +624,53 @@ done
 # surface|scenario|target|rps|p50|p95|p99|status
 record() {
     printf '%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" >> "$RESULTS_TSV"
+}
+
+# --- Self-consistency gate -------------------------------------------------
+#
+# The first thing measured is remembered here and measured again as the last
+# action of the run. Everything else happens in between, so if the machine
+# drifted the two disagree.
+
+GATE_SURFACE=""; GATE_NAME=""; GATE_TARGET=""; GATE_URL=""; GATE_BODY=""
+GATE_FIRST_RPS=""; GATE_LAST_RPS=""; GATE_DRIFT=""; GATE_STATUS="not run"
+
+# Remember the first real measurement of the run, and only the first.
+gate_capture() {
+    local surface="$1" name="$2" target="$3" url="$4" body="$5" measured="$6"
+    [[ -n "$GATE_TARGET" ]] && return 0
+    case "$measured" in ERROR*|UNSUPPORTED*) return 0 ;; esac
+    local rps="${measured%% *}"
+    case "$rps" in ''|*[!0-9]*) return 0 ;; esac
+    GATE_SURFACE="$surface"; GATE_NAME="$name"; GATE_TARGET="$target"
+    GATE_URL="$url"; GATE_BODY="$body"; GATE_FIRST_RPS="$rps"
+}
+
+# Repeat that measurement, identically, at the end.
+gate_run() {
+    if [[ -z "$GATE_TARGET" ]]; then
+        GATE_STATUS="not run (nothing was measured)"
+        return 0
+    fi
+
+    log "self-consistency: re-measuring '$GATE_NAME' on $GATE_TARGET"
+    isolate "$GATE_TARGET"
+    warm_target "$GATE_URL" "" "$GATE_BODY"
+    local measured; measured="$(measure_median "$GATE_URL" "" "$GATE_BODY")"
+    unisolate
+
+    case "$measured" in
+        ERROR*|UNSUPPORTED*) GATE_STATUS="inconclusive ($measured)"; return 0 ;;
+    esac
+    GATE_LAST_RPS="${measured%% *}"
+    GATE_DRIFT="$(awk -v a="$GATE_FIRST_RPS" -v b="$GATE_LAST_RPS" \
+        'BEGIN { d = (b - a) / a * 100; printf "%.1f", (d < 0 ? -d : d) }')"
+
+    if awk -v d="$GATE_DRIFT" -v t="$GATE_THRESHOLD_PCT" 'BEGIN { exit !(d <= t) }'; then
+        GATE_STATUS="pass"
+    else
+        GATE_STATUS="FAIL"
+    fi
 }
 
 # Run one measurement REPEATS times and print the median by throughput.
@@ -641,6 +742,7 @@ bench_rest() {
             isolate "$target"
             measured="$(measure_median "$url" "")"
             record rest "$name" "$target" "$measured" ok
+            gate_capture rest "$name" "$target" "$url" "" "$measured"
         done
         unisolate
     done
@@ -683,6 +785,7 @@ bench_gql() {
             isolate "$target"
             measured="$(measure_median "$url" "" "$body")"
             record graphql "$label" "$target" "$measured" ok
+            gate_capture graphql "$label" "$target" "$url" "$body" "$measured"
         done
         unisolate
     done
@@ -691,10 +794,16 @@ bench_gql() {
 bench_rest
 bench_gql
 
+# Memory is read before the gate runs, not after. The gate re-measures a single
+# target, and charging that one target for ~90k requests the others never
+# served would make the memory column a record of who happened to be measured
+# first.
 RSS_FINAL=()
 for i in "${!TARGETS[@]}"; do
     RSS_FINAL[$i]="$(container_rss_kb "$(container_of "${TARGETS[$i]}")")"
 done
+
+gate_run
 
 # ---------------------------------------------------------------------------
 # Report
@@ -705,6 +814,10 @@ echo "==========================================================================
 echo " Postrust vs PostgREST, Hasura, PostGraphile"
 echo "==========================================================================="
 printf ' host           : %s\n' "$(uname -srm)"
+printf ' cpu            : %s\n' "$(host_cpu_model)"
+printf ' cpu state      : %s\n' "$(host_cpu_cond)"
+printf ' pinning        : db=%s server=%s load=%s\n' \
+    "${CPUSET_DB:-none}" "${CPUSET_SERVER:-none}" "${CPUSET_LOAD:-none}"
 printf ' variant        : %s\n' "$VARIANT"
 printf ' postgres       : %s\n' "$PG_IMAGE"
 printf ' load generator : %s (n=%s, c=%s)\n' "$LOAD_TOOL" "$REQUESTS" "$CONCURRENCY"
@@ -734,6 +847,13 @@ print_matrix() {
     echo
 }
 
+echo "Self-consistency"
+printf ' the first measurement (%s / %s) repeated as the last action of the run\n' \
+    "${GATE_NAME:-n/a}" "${GATE_TARGET:-n/a}"
+printf ' first %s rps, last %s rps -- drift %s%% against a %s%% threshold: %s\n\n' \
+    "${GATE_FIRST_RPS:-n/a}" "${GATE_LAST_RPS:-n/a}" "${GATE_DRIFT:-n/a}" \
+    "$GATE_THRESHOLD_PCT" "$GATE_STATUS"
+
 print_matrix rest    "REST"
 print_matrix graphql "GraphQL"
 
@@ -755,6 +875,18 @@ echo
 {
     printf '{\n'
     printf '  "host": %s,\n' "$(jq -Rn --arg v "$(uname -srm)" '$v')"
+    printf '  "cpu": %s,\n' "$(jq -Rn --arg v "$(host_cpu_model)" '$v')"
+    printf '  "cpu_state": %s,\n' "$(jq -Rn --arg v "$(host_cpu_cond)" '$v')"
+    printf '  "pinning": {"db": %s, "server": %s, "load": %s},\n' \
+        "$(jq -Rn --arg v "${CPUSET_DB:-}" '$v')" \
+        "$(jq -Rn --arg v "${CPUSET_SERVER:-}" '$v')" \
+        "$(jq -Rn --arg v "${CPUSET_LOAD:-}" '$v')"
+    printf '  "self_consistency": {"scenario": %s, "target": %s, "first_rps": %s, "last_rps": %s, "drift_pct": %s, "threshold_pct": %s, "status": %s},\n' \
+        "$(jq -Rn --arg v "${GATE_NAME:-}" '$v')" \
+        "$(jq -Rn --arg v "${GATE_TARGET:-}" '$v')" \
+        "${GATE_FIRST_RPS:-null}" "${GATE_LAST_RPS:-null}" \
+        "${GATE_DRIFT:-null}" "$GATE_THRESHOLD_PCT" \
+        "$(jq -Rn --arg v "$GATE_STATUS" '$v')"
     printf '  "variant": %s,\n' "$(jq -Rn --arg v "$VARIANT" '$v')"
     printf '  "postgres": %s,\n' "$(jq -Rn --arg v "$PG_IMAGE" '$v')"
     printf '  "requests": %s,\n' "$REQUESTS"
@@ -799,3 +931,11 @@ jq -e . "$RESULTS_JSON" >/dev/null || die "results.json is not valid JSON"
 
 log "wrote $RESULTS_JSON"
 echo "Numbers published on the website are copied from this file."
+
+# Results are still written -- they are needed to diagnose the drift -- but the
+# run exits non-zero so nothing downstream treats them as publishable.
+if [[ "$GATE_STATUS" == FAIL* ]]; then
+    warn "self-consistency FAILED: ${GATE_DRIFT}% drift over the run (threshold ${GATE_THRESHOLD_PCT}%)"
+    warn "the machine did not hold still; these numbers are not comparable across targets"
+    exit 1
+fi

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -35,6 +35,13 @@ WARMUP="${WARMUP:-200}"
 KEEP="${KEEP:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 
+# CPU pinning, matching scripts/bench-compare.sh. Unset means no pinning.
+# See docs/benchmarking.md for how to find the groups on a given machine.
+CPUSET_DB="${CPUSET_DB:-}"
+CPUSET_SERVER="${CPUSET_SERVER:-}"
+CPUSET_LOAD="${CPUSET_LOAD:-}"
+export CPUSET_LOAD
+
 # Feature set to build. Defaults to the set the published Docker image and
 # release binaries are built with, so the reported size matches what users get.
 # Set to an empty string to measure a minimal build.
@@ -123,8 +130,10 @@ fi
 
 log "starting PostgreSQL ($PG_IMAGE) on port $PG_PORT..."
 docker rm -f "$PG_CONTAINER" >/dev/null 2>&1 || true
+DB_PIN=(); [[ -n "$CPUSET_DB" ]] && DB_PIN=(--cpuset-cpus "$CPUSET_DB")
 docker run -d --rm \
     --name "$PG_CONTAINER" \
+    ${DB_PIN[@]+"${DB_PIN[@]}"} \
     -e POSTGRES_PASSWORD=postgres \
     -e POSTGRES_DB="$PG_DB" \
     -p "$PG_PORT:5432" \
@@ -147,12 +156,13 @@ docker exec -i "$PG_CONTAINER" \
 
 # --- Server ----------------------------------------------------------------
 
+SRV_PIN=(); [[ -n "$CPUSET_SERVER" ]] && SRV_PIN=(taskset -c "$CPUSET_SERVER")
 log "starting postrust on port $BENCH_PORT..."
 DATABASE_URL="postgres://postgres:postgres@127.0.0.1:$PG_PORT/$PG_DB" \
 PGRST_DB_ANON_ROLE=bench_anon \
 PGRST_SERVER_PORT="$BENCH_PORT" \
 PGRST_LOG_LEVEL=warn \
-    "$BINARY" > "$SERVER_LOG" 2>&1 &
+    ${SRV_PIN[@]+"${SRV_PIN[@]}"} "$BINARY" > "$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
 if ! wait_until 45 curl -fsS -o /dev/null "$BASE_URL/_/health"; then
@@ -219,6 +229,9 @@ echo "==========================================================================
 echo " Postrust benchmark"
 echo "==========================================================================="
 printf ' host           : %s\n' "$(uname -srm)"
+printf ' cpu            : %s\n' "$(grep -m1 'model name' /proc/cpuinfo 2>/dev/null | cut -d: -f2- | sed 's/^ *//' || echo unknown)"
+printf ' pinning        : db=%s server=%s load=%s\n' \
+    "${CPUSET_DB:-none}" "${CPUSET_SERVER:-none}" "${CPUSET_LOAD:-none}"
 printf ' postgres       : %s\n' "$PG_IMAGE"
 printf ' load generator : %s (n=%s, c=%s)\n' "$LOAD_TOOL" "$REQUESTS" "$CONCURRENCY"
 printf ' dataset        : bench_items, 100000 rows\n'
@@ -244,7 +257,13 @@ while IFS=$'\t' read -r name measured rss; do
 done < "$RESULTS_FILE"
 
 echo
-echo " Numbers are from a single machine over loopback: PostgreSQL, the server"
-echo " and the load generator all compete for the same cores, so treat these as"
-echo " relative measurements, not absolute capacity."
+if [[ -n "$CPUSET_DB$CPUSET_SERVER$CPUSET_LOAD" ]]; then
+    echo " PostgreSQL, the server and the load generator each have their own cores,"
+    echo " so they are not competing for CPU -- but they still share one machine's"
+    echo " memory bandwidth and one kernel. Relative measurements, not capacity."
+else
+    echo " Numbers are from a single machine over loopback: PostgreSQL, the server"
+    echo " and the load generator all compete for the same cores, so treat these as"
+    echo " relative measurements, not absolute capacity."
+fi
 echo "==========================================================================="

--- a/scripts/gen-measured.mjs
+++ b/scripts/gen-measured.mjs
@@ -12,6 +12,7 @@
 // rows for variants the earlier ones did not cover.
 
 import { readFileSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join, resolve } from "node:path";
 
@@ -96,8 +97,13 @@ const banner = `// GENERATED FILE -- do not edit by hand.
 ${runs
   .map(
     (r) =>
-      `//   ${r.data.variant ?? "unknown"} variant -- ${r.data.host}, ${r.data.postgres}, ` +
-      `${r.data.requests} requests at concurrency ${r.data.concurrency}`,
+      `//   ${r.data.variant ?? "unknown"} variant -- ${r.data.cpu ?? r.data.host}, ` +
+      `${r.data.postgres}, ${r.data.requests} requests at concurrency ${r.data.concurrency}\n` +
+      `//     ${r.data.cpu_state ?? "cpu state not recorded"}\n` +
+      `//     self-consistency: ${r.data.self_consistency?.status ?? "not run"}` +
+      (r.data.self_consistency?.drift_pct != null
+        ? ` (${r.data.self_consistency.drift_pct}% drift over the run)`
+        : ""),
   )
   .join("\n")}
 `;
@@ -126,6 +132,17 @@ export const benchMeta = {
   repeats: ${primary.repeats ?? 1},
   warmup: ${primary.warmup ?? 0},
   variant: ${JSON.stringify(primary.variant ?? "unknown")},
+  /** The CPU, and the state it was held in. A throughput figure without these is not reproducible. */
+  cpu: ${JSON.stringify(primary.cpu ?? "not recorded")},
+  cpuState: ${JSON.stringify(primary.cpu_state ?? "not recorded")},
+  /** Which cores each component was confined to, so none of them shared an L3 slice. */
+  pinning: ${JSON.stringify(primary.pinning ?? null)},
+  /**
+   * The first measurement of the run, repeated as its last action. A run whose
+   * two readings disagree did not hold still, and nothing measured in between
+   * is comparable across targets.
+   */
+  selfConsistency: ${JSON.stringify(primary.self_consistency ?? null)},
 } as const;
 
 export interface VariantImages {
@@ -224,6 +241,29 @@ export const postrustImages: Record<string, string> = ${JSON.stringify(
 `;
 
 writeFileSync(OUT, body);
+
+// Format it here rather than leaving it to whoever regenerates next.
+//
+// The object literals below are emitted with JSON.stringify, which quotes its
+// keys and does not wrap the way Prettier does, so raw output has never
+// satisfied `prettier --check`. That was survivable only because someone
+// remembered to run Prettier afterwards; when they did not, a formatting
+// failure appeared in CI attached to a data regeneration that was otherwise
+// correct. Doing it here means the generator's output is committable as-is.
+const website = join(here, "..", "website");
+const fmt = spawnSync("npx", ["prettier", "--write", OUT], {
+  cwd: website,
+  stdio: "ignore",
+  shell: process.platform === "win32",
+});
+if (fmt.status !== 0) {
+  console.warn(
+    `warning: could not run prettier on ${OUT} ` +
+      `(exit ${fmt.status ?? "n/a"}). Run \`npx prettier --write\` in website/ ` +
+      `before committing, or \`prettier --check\` will fail.`,
+  );
+}
+
 console.log(`wrote ${OUT}`);
 for (const [slug, v] of Object.entries(data)) {
   console.log(`  ${slug}: ${v.rest.length} rest, ${v.graphql.length} graphql`);

--- a/scripts/lib/bench-lib.sh
+++ b/scripts/lib/bench-lib.sh
@@ -41,8 +41,19 @@ wait_until() {
 }
 
 # Resident set size of a pid, in KB. Works on both macOS and Linux.
+#
+# The `|| echo 0` this used to end with never fired: the exit status of the
+# pipeline is `tr`'s, which succeeds on empty input, so a `ps` that did not
+# understand `-o rss=` produced an empty string that `human_kb` then rendered
+# as "0.0 MB". A memory column silently reading zero is worse than one that is
+# missing, so the value is checked rather than the exit status.
 rss_kb() {
-    ps -o rss= -p "$1" 2>/dev/null | tr -d ' ' || echo 0
+    local kb
+    kb="$(ps -o rss= -p "$1" 2>/dev/null | tr -d ' ')"
+    case "$kb" in
+        ''|*[!0-9]*) echo 0 ;;
+        *)           echo "$kb" ;;
+    esac
 }
 
 # Resident set size of a running container, in KB.
@@ -127,8 +138,14 @@ run_oha() {
         args+=(-m POST -H "Content-Type: application/json" -d "$body")
     fi
 
+    # The generator gets its own cores when CPUSET_LOAD says so, for the same
+    # reason the servers do: an unpinned generator competes with the server it
+    # is measuring, and the result reads as the server being slow.
+    local pin=()
+    [[ -n "${CPUSET_LOAD:-}" ]] && pin=(taskset -c "$CPUSET_LOAD")
+
     local output
-    if ! output="$(oha "${args[@]}" "$url" 2>&1)"; then
+    if ! output="$(${pin[@]+"${pin[@]}"} oha "${args[@]}" "$url" 2>&1)"; then
         echo "ERROR oha-failed"
         return 0
     fi

--- a/website/src/components/compare/comparison-page.tsx
+++ b/website/src/components/compare/comparison-page.tsx
@@ -232,11 +232,18 @@ export const ComparisonPage = component$<Props>(({ comparison: c }) => {
                   ))}
                 </ul>
                 <p class="mt-4 text-sm text-neutral-500">
-                  {benchMeta.host} · PostgreSQL {benchMeta.postgres} ·{" "}
-                  {benchMeta.dataset} · {benchMeta.requests} requests at
-                  concurrency {benchMeta.concurrency}, median of{" "}
-                  {benchMeta.repeats} runs after {benchMeta.warmup} warm-up
-                  requests.{" "}
+                  {benchMeta.cpu} · {benchMeta.cpuState} · PostgreSQL{" "}
+                  {benchMeta.postgres} · {benchMeta.dataset} ·{" "}
+                  {benchMeta.requests} requests at concurrency{" "}
+                  {benchMeta.concurrency}, median of {benchMeta.repeats} runs
+                  after {benchMeta.warmup} warm-up requests.
+                  {benchMeta.selfConsistency?.drift_pct != null && (
+                    <>
+                      {" "}
+                      The first measurement, repeated at the end of the run,
+                      differed by {benchMeta.selfConsistency.drift_pct}%.
+                    </>
+                  )}{" "}
                   <Link
                     href="/docs/benchmarks"
                     class="text-primary-600 hover:text-primary-700"

--- a/website/src/components/sections/index.ts
+++ b/website/src/components/sections/index.ts
@@ -1,5 +1,6 @@
 export { HeroSection } from "./hero";
 export { FeaturesSection } from "./features";
+export { PerformanceSection } from "./performance";
 export { CodeExamplesSection } from "./code-examples";
 export { DeploymentSection } from "./deployment";
 export { CTASection } from "./cta";

--- a/website/src/components/sections/performance.tsx
+++ b/website/src/components/sections/performance.tsx
@@ -1,0 +1,194 @@
+import { component$ } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
+import { benchMeta, measuredFor } from "~/data/measured";
+import { measurementContext } from "~/data/comparisons";
+
+/**
+ * The measured comparison, on the homepage.
+ *
+ * Every number here is read from ~/data/measured.ts, which is generated from
+ * the harness's results.json. Nothing on this page is typed in by hand, and
+ * the bars are sized from the same values that label them -- so a bar cannot
+ * disagree with its own figure.
+ */
+
+const TOOL = {
+  postrust: {
+    label: "Postrust",
+    bar: "bg-primary-500",
+    text: "text-primary-700",
+  },
+  postgrest: {
+    label: "PostgREST",
+    bar: "bg-neutral-400",
+    text: "text-neutral-600",
+  },
+  hasura: { label: "Hasura", bar: "bg-neutral-400", text: "text-neutral-600" },
+  postgraphile: {
+    label: "PostGraphile",
+    bar: "bg-neutral-300",
+    text: "text-neutral-600",
+  },
+} as const;
+
+type ToolKey = keyof typeof TOOL;
+
+interface Series {
+  scenario: string;
+  bars: { tool: ToolKey; rps: number }[];
+}
+
+/** REST: Postrust against PostgREST, scenario by scenario. */
+function restSeries(): Series[] {
+  return measuredFor("postgrest", "rest")
+    .filter((r) => r.postrust && r.other)
+    .map((r) => ({
+      scenario: r.scenario,
+      bars: [
+        { tool: "postrust" as ToolKey, rps: r.postrust!.rps },
+        { tool: "postgrest" as ToolKey, rps: r.other!.rps },
+      ],
+    }));
+}
+
+/**
+ * GraphQL: three tools, so the two comparison sets are joined on scenario
+ * rather than a third list being maintained alongside them.
+ */
+function graphqlSeries(): Series[] {
+  const hasura = measuredFor("hasura", "graphql");
+  const postgraphile = measuredFor("postgraphile", "graphql");
+
+  return hasura
+    .filter((r) => r.postrust)
+    .map((r) => {
+      const pg = postgraphile.find((p) => p.scenario === r.scenario);
+      const bars: { tool: ToolKey; rps: number }[] = [
+        { tool: "postrust", rps: r.postrust!.rps },
+      ];
+      if (r.other) bars.push({ tool: "hasura", rps: r.other.rps });
+      if (pg?.other) bars.push({ tool: "postgraphile", rps: pg.other.rps });
+      return { scenario: r.scenario, bars };
+    });
+}
+
+const Chart = component$<{ title: string; note: string; series: Series[] }>(
+  ({ title, note, series }) => {
+    // One scale across the whole chart, so bar lengths are comparable between
+    // scenarios and not just within one.
+    const max = Math.max(...series.flatMap((s) => s.bars.map((b) => b.rps)), 1);
+
+    return (
+      <div class="rounded-xl border border-neutral-200 bg-white p-6">
+        <div class="mb-1 flex items-baseline justify-between gap-4">
+          <h3 class="text-sm font-semibold tracking-wide text-neutral-900 uppercase">
+            {title}
+          </h3>
+          <span class="text-xs text-neutral-500">requests/second</span>
+        </div>
+        <p class="mb-5 text-xs text-neutral-500">{note}</p>
+
+        <div class="space-y-5">
+          {series.map((s) => (
+            <div key={s.scenario}>
+              <div class="mb-1.5 text-sm font-medium text-neutral-700">
+                {s.scenario}
+              </div>
+              <div class="space-y-1">
+                {s.bars.map((b) => (
+                  <div key={b.tool} class="flex items-center gap-3">
+                    <span class="w-24 shrink-0 text-xs text-neutral-500">
+                      {TOOL[b.tool].label}
+                    </span>
+                    <div class="h-4 min-w-0 flex-1 rounded bg-neutral-100">
+                      <div
+                        class={`h-4 rounded ${TOOL[b.tool].bar}`}
+                        style={{
+                          width: `${Math.max((b.rps / max) * 100, 1.5)}%`,
+                        }}
+                      />
+                    </div>
+                    <span
+                      class={`w-16 shrink-0 text-right text-xs tabular-nums ${TOOL[b.tool].text}`}
+                    >
+                      {b.rps.toLocaleString("en-US")}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+
+export const PerformanceSection = component$(() => {
+  const rest = restSeries();
+  const graphql = graphqlSeries();
+  if (rest.length === 0 && graphql.length === 0) return null;
+
+  const drift = benchMeta.selfConsistency?.drift_pct;
+
+  return (
+    <section class="section-padding bg-neutral-50">
+      <div class="container-wide">
+        <div class="mx-auto mb-12 max-w-3xl text-center">
+          <h2 class="mb-4 text-3xl font-bold text-neutral-900 md:text-4xl">
+            Measured, on a machine that held still
+          </h2>
+          <p class="text-lg text-neutral-600">
+            Every server runs as a container against the same PostgreSQL
+            instance and the same dataset, each pinned to its own CPU cores.
+            These are the numbers the harness produced, not a summary of them.
+          </p>
+        </div>
+
+        <div class="grid gap-6 lg:grid-cols-2">
+          <Chart
+            title="REST"
+            note="Postrust against PostgREST, same request in each server's own dialect."
+            series={rest}
+          />
+          <Chart
+            title="GraphQL"
+            note="Postrust and Hasura are sent the same query text, byte for byte."
+            series={graphql}
+          />
+        </div>
+
+        <div class="mt-6 rounded-xl border border-neutral-200 bg-white p-6">
+          <p class="text-sm text-neutral-600">
+            {benchMeta.cpu} · {benchMeta.cpuState} · PostgreSQL{" "}
+            {benchMeta.postgres} · {benchMeta.requests.toLocaleString("en-US")}{" "}
+            requests at concurrency {benchMeta.concurrency}, median of{" "}
+            {benchMeta.repeats}.
+            {drift != null && (
+              <>
+                {" "}
+                The first measurement, repeated as the last action of the run,
+                differed by {drift}%.
+              </>
+            )}
+          </p>
+          <p class="mt-3 text-sm text-neutral-500">
+            Read these as ratios rather than as capacity. Everything shares one
+            host, so absolute throughput depends on that machine — and running
+            in a container costs about {measurementContext.dockerCostPct}%
+            against the same binary run natively, charged to every server
+            equally. PostgREST's own run-to-run spread is wider than the others'
+            at up to {measurementContext.spreadPct.postgrest}%, so its multiples
+            carry roughly ±{measurementContext.postgrestRatioTolerancePct}%.{" "}
+            <Link
+              href="/docs/benchmarks"
+              class="text-primary-600 hover:text-primary-700"
+            >
+              Full method
+            </Link>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+});

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -50,7 +50,11 @@ export const perfCaveats = [
   "Requests are expressed in each tool's own dialect, because the dialects differ. The work asked of PostgreSQL is the same.",
   "Every target is warmed before any of them is measured, and the database cache is populated first, so no tool pays to warm the cache for the ones measured after it.",
   "Each figure is the median of several runs rather than the best of them, because a best-of-N reports whichever tool got the quietest moment on the machine.",
-  "These are single-machine numbers from a laptop. They are useful for comparing the tools against each other, not for capacity planning.",
+  "Measured on dedicated bare metal with SMT disabled and the CPU held at a fixed 4317 MHz -- verified by sampling the clock across the run (0.82% spread), not by trusting the setting. Absolute figures carry that machine's firmware with them; the ratios do not.",
+  "Each component is confined to its own group of CPU cores -- database, server under test, and load generator -- so no two of them share an L3 cache slice. Every server gets the identical allocation.",
+  "The first measurement of a run is repeated as its last action. If the two disagree by more than 3%, the machine drifted under the harness and the run is rejected rather than published.",
+  "Every server runs in a container, which costs about 8.6% against the same binary run natively -- almost all of it Docker's network path rather than the container itself. It is charged to every tool equally.",
+  "These are single-machine numbers: the database, the server and the load generator share one host. They are useful for comparing the tools against each other, not for capacity planning.",
 ];
 
 export const comparisons: Comparison[] = [

--- a/website/src/data/comparisons.ts
+++ b/website/src/data/comparisons.ts
@@ -43,6 +43,29 @@ export interface Comparison {
   faq: FaqEntry[];
 }
 
+/**
+ * Figures that come from measurements the harness does not write into
+ * results.json -- the container-cost A/B/C, the dispersion across repeated
+ * runs, and the sampled clock. Recorded once, here, and read by every place
+ * that states them, so the homepage and the comparison pages cannot drift
+ * apart or quietly disagree with scripts/BENCH-FINDINGS.md.
+ */
+export const measurementContext = {
+  /** Container against the same binary run natively, on the point lookup. */
+  dockerCostPct: 8.6,
+  /** Of which this much is Docker's network path rather than the container. */
+  dockerNetworkPct: 7.3,
+  /** Clock sampled across a whole run, and the spread of those samples. */
+  clockMhz: 4317,
+  clockSpreadPct: 0.82,
+  /** Worst run-to-run spread, across three complete runs. */
+  spreadPct: { postrust: 0.8, hasura: 3.6, postgraphile: 3.0, postgrest: 19.6 },
+  /** What PostgREST's spread means for the multiples quoted against it. */
+  postgrestRatioTolerancePct: 10,
+} as const;
+
+const mc = measurementContext;
+
 /** Shared caveats shown under every performance table. */
 export const perfCaveats = [
   "Every server runs as a container on one docker network against the same PostgreSQL instance and the same dataset. No tool gets to skip container overhead.",
@@ -50,10 +73,11 @@ export const perfCaveats = [
   "Requests are expressed in each tool's own dialect, because the dialects differ. The work asked of PostgreSQL is the same.",
   "Every target is warmed before any of them is measured, and the database cache is populated first, so no tool pays to warm the cache for the ones measured after it.",
   "Each figure is the median of several runs rather than the best of them, because a best-of-N reports whichever tool got the quietest moment on the machine.",
-  "Measured on dedicated bare metal with SMT disabled and the CPU held at a fixed 4317 MHz -- verified by sampling the clock across the run (0.82% spread), not by trusting the setting. Absolute figures carry that machine's firmware with them; the ratios do not.",
+  `Measured on dedicated bare metal with SMT disabled and the CPU held at a fixed ${mc.clockMhz} MHz -- verified by sampling the clock across the run (${mc.clockSpreadPct}% spread), not by trusting the setting. Absolute figures carry that machine's firmware with them; the ratios do not.`,
   "Each component is confined to its own group of CPU cores -- database, server under test, and load generator -- so no two of them share an L3 cache slice. Every server gets the identical allocation.",
   "The first measurement of a run is repeated as its last action. If the two disagree by more than 3%, the machine drifted under the harness and the run is rejected rather than published.",
-  "Every server runs in a container, which costs about 8.6% against the same binary run natively -- almost all of it Docker's network path rather than the container itself. It is charged to every tool equally.",
+  `Every server runs in a container, which costs about ${mc.dockerCostPct}% against the same binary run natively -- ${mc.dockerNetworkPct} of those points are Docker's network path rather than the container itself. It is charged to every tool equally.`,
+  `Repeated whole runs agree to ${mc.spreadPct.postrust}% for Postrust and ${mc.spreadPct.hasura}% for the GraphQL servers, but only ${mc.spreadPct.postgrest}% for PostgREST. Multiples quoted against PostgREST carry roughly +/-${mc.postgrestRatioTolerancePct}%.`,
   "These are single-machine numbers: the database, the server and the load generator share one host. They are useful for comparing the tools against each other, not for capacity planning.",
 ];
 
@@ -188,7 +212,8 @@ export const comparisons: Comparison[] = [
       },
       {
         feature: "Permissions",
-        postrust: "Hasura's model from a JSON document, or PostgreSQL roles and RLS",
+        postrust:
+          "Hasura's model from a JSON document, or PostgreSQL roles and RLS",
         other: "Metadata, per role and per field",
       },
       {

--- a/website/src/data/measured.ts
+++ b/website/src/data/measured.ts
@@ -6,8 +6,12 @@
 //   node scripts/gen-measured.mjs <results.json> [...]
 //
 // Measured on:
-//   debian variant -- Darwin 25.2.0 arm64, postgres:16, 3000 requests at concurrency 50
-//   alpine variant -- Darwin 25.2.0 arm64, postgres:16.11-alpine, 3000 requests at concurrency 50
+//   debian variant -- AMD EPYC 9255 24-Core Processor, postgres:16, 30000 requests at concurrency 50
+//     governor=performance boost_sysfs=0 smt=off online=0-23
+//     self-consistency: pass (0.1% drift over the run)
+//   alpine variant -- AMD EPYC 9255 24-Core Processor, postgres:16.11-alpine, 30000 requests at concurrency 50
+//     governor=performance boost=0 smt=off online=0-23
+//     self-consistency: pass (1.3% drift over the run)
 
 export interface Point {
   rps: number;
@@ -24,14 +28,33 @@ export interface MeasuredRow {
 }
 
 export const benchMeta = {
-  host: "Darwin 25.2.0 arm64",
+  host: "Linux 7.0.0-30-generic x86_64",
   postgres: "postgres:16",
   dataset: "bench_items 100000 rows, bench_reviews 300000 rows",
-  requests: 3000,
+  requests: 30000,
   concurrency: 50,
-  repeats: 5,
+  repeats: 3,
   warmup: 500,
   variant: "debian",
+  /** The CPU, and the state it was held in. A throughput figure without these is not reproducible. */
+  cpu: "AMD EPYC 9255 24-Core Processor",
+  cpuState: "governor=performance boost_sysfs=0 smt=off online=0-23",
+  /** Which cores each component was confined to, so none of them shared an L3 slice. */
+  pinning: { db: "0-5", server: "6-11", load: "12-17" },
+  /**
+   * The first measurement of the run, repeated as its last action. A run whose
+   * two readings disagree did not hold still, and nothing measured in between
+   * is comparable across targets.
+   */
+  selfConsistency: {
+    scenario: "point lookup",
+    target: "postrust",
+    first_rps: 44186,
+    last_rps: 44132,
+    drift_pct: 0.1,
+    threshold_pct: 3,
+    status: "pass",
+  },
 } as const;
 
 export interface VariantImages {
@@ -61,31 +84,31 @@ export const variantImages: Record<string, VariantImages> = {
     images: {
       postrust: {
         image: "postrust:bench-debian",
-        onDisk: "168MB",
-        layerBytes: 36898663,
-        rssIdleKb: 1968,
-        rssAfterKb: 15155,
+        onDisk: "149MB",
+        layerBytes: 148824698,
+        rssIdleKb: 3476,
+        rssAfterKb: 17162,
       },
       postgrest: {
         image: "postgrest/postgrest:v16.1",
-        onDisk: "26.8MB",
-        layerBytes: 6433834,
-        rssIdleKb: 18729,
-        rssAfterKb: 59443,
+        onDisk: "27MB",
+        layerBytes: 27028137,
+        rssIdleKb: 5336,
+        rssAfterKb: 56678,
       },
       hasura: {
-        image: "hasura/graphql-engine:v2.44.0",
-        onDisk: "711MB",
-        layerBytes: 159655847,
-        rssIdleKb: 171930,
-        rssAfterKb: 203674,
+        image: "hasura/graphql-engine:v2.50.1",
+        onDisk: "602MB",
+        layerBytes: 601716825,
+        rssIdleKb: 172851,
+        rssAfterKb: 203469,
       },
       postgraphile: {
         image: "postgraphile:bench-debian",
-        onDisk: "2.27GB",
-        layerBytes: 540044768,
-        rssIdleKb: 112742,
-        rssAfterKb: 247910,
+        onDisk: "2.29GB",
+        layerBytes: 2285948897,
+        rssIdleKb: 55921,
+        rssAfterKb: 221798,
       },
     },
   },
@@ -94,31 +117,31 @@ export const variantImages: Record<string, VariantImages> = {
     images: {
       postrust: {
         image: "postrust:bench-alpine",
-        onDisk: "31.7MB",
-        layerBytes: 9791771,
-        rssIdleKb: 3844,
-        rssAfterKb: 28447,
+        onDisk: "34.9MB",
+        layerBytes: 34905595,
+        rssIdleKb: 2816,
+        rssAfterKb: 22159,
       },
       postgrest: {
         image: "postgrest/postgrest:v16.1",
-        onDisk: "26.8MB",
-        layerBytes: 6433834,
-        rssIdleKb: 18739,
-        rssAfterKb: 53709,
+        onDisk: "27MB",
+        layerBytes: 27028137,
+        rssIdleKb: 5484,
+        rssAfterKb: 54753,
       },
       hasura: {
-        image: "hasura/graphql-engine:v2.44.0",
-        onDisk: "711MB",
-        layerBytes: 159655847,
-        rssIdleKb: 170803,
-        rssAfterKb: 200602,
+        image: "hasura/graphql-engine:v2.50.1",
+        onDisk: "602MB",
+        layerBytes: 601716825,
+        rssIdleKb: 166400,
+        rssAfterKb: 208998,
       },
       postgraphile: {
         image: "postgraphile:bench-alpine",
-        onDisk: "886MB",
-        layerBytes: 198538661,
-        rssIdleKb: 116326,
-        rssAfterKb: 212582,
+        onDisk: "893MB",
+        layerBytes: 893407044,
+        rssIdleKb: 52972,
+        rssAfterKb: 104038,
       },
     },
   },
@@ -133,76 +156,76 @@ const measured: Record<
       {
         scenario: "point lookup",
         postrust: {
-          rps: 14479,
-          p50_ms: 3.2,
-          p95_ms: 4.7,
-          p99_ms: 7.6,
+          rps: 44186,
+          p50_ms: 1.1,
+          p95_ms: 1.1,
+          p99_ms: 1.2,
         },
         other: {
-          rps: 4323,
-          p50_ms: 8.8,
-          p95_ms: 31.1,
-          p99_ms: 46,
+          rps: 10931,
+          p50_ms: 2.9,
+          p95_ms: 11.3,
+          p99_ms: 25.6,
         },
       },
       {
         scenario: "25-row page",
         postrust: {
-          rps: 13800,
-          p50_ms: 3.5,
-          p95_ms: 4.4,
-          p99_ms: 5,
+          rps: 34541,
+          p50_ms: 1.4,
+          p95_ms: 1.5,
+          p99_ms: 1.6,
         },
         other: {
-          rps: 4152,
-          p50_ms: 8.7,
-          p95_ms: 34.2,
-          p99_ms: 57.3,
+          rps: 10726,
+          p50_ms: 3.5,
+          p95_ms: 10.7,
+          p99_ms: 14.9,
         },
       },
       {
         scenario: "filtered + ordered page",
         postrust: {
-          rps: 11292,
-          p50_ms: 4.3,
-          p95_ms: 5.2,
-          p99_ms: 6,
+          rps: 32671,
+          p50_ms: 1.5,
+          p95_ms: 1.6,
+          p99_ms: 1.6,
         },
         other: {
-          rps: 7392,
-          p50_ms: 6,
-          p95_ms: 10,
-          p99_ms: 14.7,
+          rps: 6208,
+          p50_ms: 6.9,
+          p95_ms: 16.7,
+          p99_ms: 22.9,
         },
       },
       {
         scenario: "range filter on numeric",
         postrust: {
-          rps: 10892,
-          p50_ms: 4.4,
-          p95_ms: 5.5,
-          p99_ms: 6.9,
+          rps: 30691,
+          p50_ms: 1.6,
+          p95_ms: 1.7,
+          p99_ms: 1.7,
         },
         other: {
-          rps: 7851,
-          p50_ms: 5.3,
-          p95_ms: 10.9,
-          p99_ms: 28.7,
+          rps: 6890,
+          p50_ms: 6.1,
+          p95_ms: 15.3,
+          p99_ms: 21.1,
         },
       },
       {
         scenario: "25-row page + embed",
         postrust: {
-          rps: 9488,
-          p50_ms: 5.1,
-          p95_ms: 5.9,
-          p99_ms: 6.8,
+          rps: 20100,
+          p50_ms: 2.4,
+          p95_ms: 2.7,
+          p99_ms: 2.7,
         },
         other: {
-          rps: 6005,
-          p50_ms: 7.5,
-          p95_ms: 12.2,
-          p99_ms: 18,
+          rps: 2151,
+          p50_ms: 16.9,
+          p95_ms: 64.1,
+          p99_ms: 100.9,
         },
       },
     ],
@@ -214,46 +237,46 @@ const measured: Record<
       {
         scenario: "single row by primary key",
         postrust: {
-          rps: 12440,
-          p50_ms: 3.8,
-          p95_ms: 5.1,
-          p99_ms: 6.1,
+          rps: 31997,
+          p50_ms: 1.5,
+          p95_ms: 1.6,
+          p99_ms: 1.7,
         },
         other: {
-          rps: 4535,
-          p50_ms: 9.2,
-          p95_ms: 44,
-          p99_ms: 59.9,
+          rps: 9618,
+          p50_ms: 5.1,
+          p95_ms: 6,
+          p99_ms: 8.6,
         },
       },
       {
         scenario: "25-row page",
         postrust: {
-          rps: 8477,
-          p50_ms: 5.7,
-          p95_ms: 7,
-          p99_ms: 7.9,
+          rps: 17422,
+          p50_ms: 2.8,
+          p95_ms: 3.1,
+          p99_ms: 3.2,
         },
         other: {
-          rps: 4907,
-          p50_ms: 10.7,
-          p95_ms: 17.4,
-          p99_ms: 26.7,
+          rps: 10552,
+          p50_ms: 4.6,
+          p95_ms: 5.4,
+          p99_ms: 7.9,
         },
       },
       {
         scenario: "25-row page + embed",
         postrust: {
-          rps: 5193,
-          p50_ms: 9.5,
-          p95_ms: 11.4,
-          p99_ms: 12.1,
+          rps: 10096,
+          p50_ms: 4.9,
+          p95_ms: 5.3,
+          p99_ms: 5.5,
         },
         other: {
-          rps: 3588,
-          p50_ms: 14.8,
-          p95_ms: 20,
-          p99_ms: 32.5,
+          rps: 8133,
+          p50_ms: 6.1,
+          p95_ms: 9,
+          p99_ms: 14,
         },
       },
     ],
@@ -264,46 +287,46 @@ const measured: Record<
       {
         scenario: "single row by primary key",
         postrust: {
-          rps: 12440,
-          p50_ms: 3.8,
-          p95_ms: 5.1,
-          p99_ms: 6.1,
+          rps: 31997,
+          p50_ms: 1.5,
+          p95_ms: 1.6,
+          p99_ms: 1.7,
         },
         other: {
-          rps: 10231,
-          p50_ms: 4.6,
-          p95_ms: 6.7,
-          p99_ms: 10.4,
+          rps: 14310,
+          p50_ms: 3.2,
+          p95_ms: 4,
+          p99_ms: 4.7,
         },
       },
       {
         scenario: "25-row page",
         postrust: {
-          rps: 8477,
-          p50_ms: 5.7,
-          p95_ms: 7,
-          p99_ms: 7.9,
+          rps: 17422,
+          p50_ms: 2.8,
+          p95_ms: 3.1,
+          p99_ms: 3.2,
         },
         other: {
-          rps: 6593,
-          p50_ms: 7.2,
-          p95_ms: 10.2,
-          p99_ms: 19.7,
+          rps: 9298,
+          p50_ms: 5.4,
+          p95_ms: 5.7,
+          p99_ms: 6.7,
         },
       },
       {
         scenario: "25-row page + embed",
         postrust: {
-          rps: 5193,
-          p50_ms: 9.5,
-          p95_ms: 11.4,
-          p99_ms: 12.1,
+          rps: 10096,
+          p50_ms: 4.9,
+          p95_ms: 5.3,
+          p99_ms: 5.5,
         },
         other: {
-          rps: 3495,
-          p50_ms: 14,
-          p95_ms: 16.5,
-          p99_ms: 31,
+          rps: 4613,
+          p50_ms: 10.7,
+          p95_ms: 11.2,
+          p99_ms: 12.5,
         },
       },
     ],
@@ -367,6 +390,6 @@ export function footprintFor(slug: string): FootprintRow[] {
 
 /** Every variant's Postrust image size, for the note under the table. */
 export const postrustImages: Record<string, string> = {
-  debian: "168MB",
-  alpine: "31.7MB",
+  debian: "149MB",
+  alpine: "34.9MB",
 };

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { component$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
 import { HeroSection } from "~/components/sections/hero";
 import { FeaturesSection } from "~/components/sections/features";
+import { PerformanceSection } from "~/components/sections/performance";
 import { CodeExamplesSection } from "~/components/sections/code-examples";
 import { SaasStarterSection } from "~/components/sections/saas-starter";
 import { DeploymentSection } from "~/components/sections/deployment";
@@ -12,6 +13,7 @@ export default component$(() => {
     <>
       <HeroSection />
       <FeaturesSection />
+      <PerformanceSection />
       <CodeExamplesSection />
       <SaasStarterSection />
       <DeploymentSection />


### PR DESCRIPTION
`BENCH-FINDINGS.md` has said since it was written that every performance figure this repository publishes was produced inside a measurement artefact and is not trustworthy. This closes that, by moving the benchmark to dedicated bare metal and by giving the harness a way to prove the machine held still while it ran.

**Nothing here makes anything faster.** The published numbers move a long way — point lookup goes from 6,065 rps to 44,186 — and all of that is the instrument, not the software.

## The gate is the point

The harness could not distinguish a real difference between two servers from the machine changing underneath it. `measure_median` runs its repeats back to back, so they share whatever state the host is in at that instant: they agree with each other perfectly and can be equally wrong. That is exactly how the original drift survived several rounds of published figures — a systematic bias reproduces, and reproducibility reads as precision.

So the first measurement of a run is now repeated as its **last** action, with everything else in between. Disagreement beyond `GATE_THRESHOLD_PCT` (default 3) means the run exits non-zero. The results file is still written — a failure has to be diagnosable — but it cannot be mistaken for something publishable.

| run | first | last | drift |
|---|---|---|---|
| debian 1 | 44,163 | 44,169 | 0.0% |
| debian 2 | 44,490 | 44,559 | 0.2% |
| debian 3 | 44,186 | 44,132 | 0.1% |
| alpine | 43,727 | 43,179 | 1.3% |

Across three independent debian runs the same measurement spans **0.7%**, against the 1.25x–1.39x the previous host produced.

The mechanism behind the original drift was never identified. It was escaped, not explained. The old entry is kept and marked superseded, because what it ruled out is still ruled out, and the gate is what stops it returning unnoticed.

## Host and pinning

`CPUSET_DB` / `CPUSET_SERVER` / `CPUSET_LOAD` confine the database, the server under test and the load generator to separate CCDs — one each, so no two share a 32 MB L3 slice. **Every target gets the identical `CPUSET_SERVER`**; the harness deliberately cannot express a per-target allocation, since a differential benchmark that lets one side have more cores is measuring its own configuration.

Verified in situ rather than assumed: all four `postrust-cmp-*` containers on 6–11, database on 0–5, `oha` on 12–17, harness on 18–23.

## Results

Debian variant, EPYC 9255, 30,000 requests at concurrency 50, median of 3.

| scenario | postrust | other | ratio |
|---|---|---|---|
| REST point lookup | 44,186 | postgrest 10,931 | 4.0x |
| REST 25-row page | 34,541 | postgrest 10,726 | 3.2x |
| REST filtered + ordered | 32,671 | postgrest 6,208 | 5.3x |
| REST range filter | 30,691 | postgrest 6,890 | 4.5x |
| REST 25-row page + embed | 20,100 | postgrest 2,151 | 9.3x |
| GraphQL row by pk | 31,997 | hasura 9,618 / postgraphile 14,310 | 3.3x / 2.2x |
| GraphQL 25-row page | 17,422 | hasura 10,552 / postgraphile 9,298 | 1.7x / 1.9x |
| GraphQL page + embed | 10,096 | hasura 8,133 / postgraphile 4,613 | 1.2x / 2.2x |

## Three findings I would rather not have had

**The firmware ignores every OS frequency request.** The plan was to pin to base clock. The kernel accepts `boost=0`, `scaling_max_freq` drops to 3200000 — and the CPU carries on at 4317 MHz. Caught by timing fixed work instead of reading the file back: a 2.0 GHz cap, a 3.2 GHz cap and no cap produce the same wall time. The clock *is* fixed, which is what the benchmark needs, but at the firmware's value, so absolutes carry this machine's BIOS with them. The field is reported as `boost_sysfs` now, because it says what the file reads and not what the hardware does. Every control in the doc is paired with a measurement that would fail if it did not take.

**PostgREST's run-to-run spread is 19.6% at worst** against 0.8% for this server, over three full runs. Its ratios are good to about ±10% and are not quoted to more precision than they carry. The gate does not cover this — it repeats one scenario on one target, so it answers "did the machine hold still", not "is each target reproducible".

**The alpine variant moves PostgREST by −27% to −38% on a byte-identical image**, while Hasura — also unchanged, also against the swapped database — stays flat. Unexplained, one run, left open. No alpine throughput figure is published; `gen-measured.mjs` takes request figures from the first results file only, so that guard is structural rather than a matter of remembering.

## Docker, measured

| | point lookup |
|---|---|
| A bridge + published port (what the harness does) | 44,496 |
| B containers, `--network host` | 48,013 |
| C native binary | 48,684 |

8.6% total, of which 7.3 points are network plumbing and 1.4 the container itself. Charged to every target equally, so ratios are unaffected. `docker-proxy` is disabled on the host — a userspace relay in the request path that no `--cpuset-cpus` covers, so it lands wherever the scheduler puts it; removing it recovered 3.2 points and left B and C unchanged, which is the check that it touched only the path it should.

## Incidental fixes

- Memory was read **after** the gate, which re-measures one target — charging whichever target was measured first for ~90k requests none of the others served. Read before the gate now. (My own bug, from the first draft of the gate.)
- `rss_kb`'s `|| echo 0` never fired: the pipeline's status is `tr`'s, and `tr` succeeds on empty input, so a `ps` without `-o rss=` rendered as "0.0 MB". A memory column silently reading zero is worse than one that is missing.
- `gen-measured.mjs` now runs Prettier on its own output, which has never satisfied `prettier --check`.
- Stale docs: `hey` was listed as supported and refused by the code; a caveat describing the reference table as laptop numbers outlived the table.

## Checks

- `npm run build.types` clean; `prettier --check` clean on every file this touches (`comparisons.ts` was already non-conformant on main and is left alone).
- `bash -n` on all three shell scripts.
- No Rust changed, so `cargo fmt`/`clippy` are unaffected.

## Not done

Extending the gate to re-measure **every** target at the end, which would turn PostgREST's dispersion into something reported on every run rather than noticed by comparing three. Not included because it has not been exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
