### PR TITLE
fix(ci): the Autobahn baseline records the origin instead of failing on it

### DIFF
--- a/scripts/autobahn/run.sh
+++ b/scripts/autobahn/run.sh
@@ -170,7 +170,13 @@ BASELINE_REPORT="$HERE/reports-baseline/index.json"
 if [ -f "$REPORTS/index.json" ]; then
     # Pass the baseline when one exists: it turns on the regression check, which
     # is the only rule that really speaks to the tunnel.
-    if [ "$BASELINE" != "1" ] && [ -f "$BASELINE_REPORT" ]; then
+    if [ "$BASELINE" = "1" ]; then
+        # This run *is* the reference. What the origin fails is the thing being
+        # recorded, not a verdict on it, so the summary reports and does not
+        # gate -- otherwise an imperfect origin fails the baseline step and the
+        # proxied run never gets the baseline it needs.
+        python3 "$HERE/summarize.py" "$REPORTS/index.json" --recording-baseline
+    elif [ -f "$BASELINE_REPORT" ]; then
         python3 "$HERE/summarize.py" "$REPORTS/index.json" "$BASELINE_REPORT"
     else
         python3 "$HERE/summarize.py" "$REPORTS/index.json"

--- a/scripts/autobahn/summarize.py
+++ b/scripts/autobahn/summarize.py
@@ -2,6 +2,7 @@
 """Summarise an Autobahn fuzzingclient report and decide whether to fail.
 
     summarize.py REPORT [BASELINE_REPORT]
+    summarize.py REPORT --recording-baseline
 
 The gate is deliberately narrow, because postrust is a transparent tunnel: it
 splices two upgraded byte streams and never parses a WebSocket frame. Most of
@@ -19,6 +20,14 @@ So:
                       of what this origin does; we measure the change.
   without a baseline: any FAILED fails, conservatively, since there is nothing
                       to attribute it against.
+  --recording-baseline: this report *is* the baseline, so there is nothing to
+                      attribute it against and nothing to attribute. It defines
+                      what the origin does, including what the origin fails.
+                      Failures are printed and do not gate. Judging the origin
+                      here would be backwards: a baseline run that goes red
+                      because the origin is imperfect never produces the
+                      reference the proxied run needs, and takes the whole
+                      suite down with it.
   UNIMPLEMENTED       reported as coverage, never a failure on its own. It means
                       the capability was not there to exercise, which for a
                       tunnel is a statement about the endpoint behind it.
@@ -97,8 +106,15 @@ def main(argv):
         print(__doc__)
         return 2
 
-    cases = load(argv[1])
-    baseline = load(argv[2]) if len(argv) > 2 else None
+    args = argv[1:]
+    recording_baseline = "--recording-baseline" in args
+    args = [a for a in args if a != "--recording-baseline"]
+
+    cases = load(args[0])
+    baseline = load(args[1]) if len(args) > 1 else None
+    if recording_baseline and baseline is not None:
+        print("error: --recording-baseline takes one report, not two.")
+        return 2
 
     counts = Counter(result.get("behavior", "?") for result in cases.values())
     total = sum(counts.values())
@@ -138,7 +154,11 @@ def main(argv):
             print(f"  {case}{note}")
         print()
 
-    if baseline is None:
+    if recording_baseline:
+        print("recording the baseline -- these define what the origin does.")
+        print("  the proxied run is measured against them, and fails only on")
+        print("  cases it makes worse.")
+    elif baseline is None:
         print("no baseline given -- every FAILED counts.")
         print("  run BASELINE=1 scripts/autobahn/run.sh to attribute them.")
         problems += len(failed)


### PR DESCRIPTION
The nightly Conformance workflow has failed **every night since at least 2026-09-03**, always at the same step: `Autobahn (baseline, no proxy)`.

## What was wrong

The baseline run measures the echo server with no proxy in the path, so the proxied run can be scored against it and fail only on cases the tunnel makes *worse*. That is the documented design, and for a transparent relay it is the only rule that says anything: postrust splices two byte streams and never parses a frame, so most of what Autobahn scores belongs to the origin.

But the baseline run has no baseline — it *is* the baseline — so it fell into the conservative "any FAILED counts" branch and exited 1, because the origin fails case 7.1.5.

That's backwards. What the origin fails is the thing being recorded. Judging it there means an imperfect origin fails the baseline step, the reference is never written, and the proxied run that depends on it never runs.

## The fix

`summarize.py` gains `--recording-baseline`: print the failures, say what they're for, exit 0. `run.sh` passes it when `BASELINE=1`.

```
FAILED (1):
  7.1.5

recording the baseline -- these define what the origin does.
  the proxied run is measured against them, and fails only on
  cases it makes worse.
```

## The gate that matters is untouched

Verified against synthetic reports across every path:

| case | exit |
|---|---|
| baseline run, origin fails 7.1.5 | **0** (was 1 — the bug) |
| no baseline, a FAILED present | 1 |
| proxied fails exactly what the origin does | 0 |
| proxied worse than the origin | 1 |
| proxied fails where the origin is clean | 1 |
| two reports and the flag together | 2 |

Only the first line changes. A regression through the tunnel still fails.

## A correction about the other half

I initially thought the `dialects` job was being skipped *because* transport failed. That's wrong — the two jobs share no `needs:` dependency. They're on different crons: transport nightly (`17 3 * * *`), dialects weekly (`43 4 * * 0`).

The dialects job ran on Sunday 2026-09-06 and failed at **"Fail if the published figures have drifted"** — the suites themselves passed, but the committed figures said 1423 while the run produced 1424. That job was working exactly as designed, and it is fixed by #29, which commits the current figures.

Both suites were re-run by hand on bare metal against merged main today: PostgREST 1424/1499, Hasura 454/468, both exiting 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
