### PR TITLE
docs: missing_docs on, and clean, for all seven stable crates

### DIFF
--- a/crates/postrust-auth/src/lib.rs
+++ b/crates/postrust-auth/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Provides JWT token validation and role extraction for PostgreSQL RLS.
 
+#![warn(missing_docs)]
+
 mod cache;
 mod claims;
 pub mod hasura;
@@ -80,18 +82,24 @@ impl Default for JwtConfig {
 /// is wrong".
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ClaimFault {
+    /// `exp` is in the past.
     #[error("JWT expired")]
     Expired,
 
+    /// `nbf` is in the future: the token is valid, but not yet.
     #[error("JWT not yet valid")]
     NotYetValid,
 
+    /// `iat` is in the future, which usually means the two clocks disagree
+    /// rather than that the token is forged.
     #[error("JWT issued at future")]
     IssuedInFuture,
 
+    /// `aud` is present and does not list the audience this server accepts.
     #[error("JWT not in audience")]
     NotInAudience,
 
+    /// The payload decoded but is not a JSON object of claims.
     #[error("Parsing claims failed")]
     Unparsable,
 
@@ -99,6 +107,7 @@ pub enum ClaimFault {
     #[error("The JWT '{0}' claim must be a number")]
     NotANumber(&'static str),
 
+    /// `aud` is present and is neither a string nor an array of strings.
     #[error("The JWT 'aud' claim must be a string or an array of strings")]
     AudienceNotStrings,
 }
@@ -110,12 +119,15 @@ pub enum JwtError {
     #[error("Anonymous access is disabled")]
     NoIdentity,
 
+    /// The `Authorization` header is not a bearer token this server can read.
     #[error("Unsupported token type")]
     InvalidHeaderFormat,
 
+    /// A token was presented and no secret is configured to verify it with.
     #[error("Server lacks JWT secret")]
     SecretMissing,
 
+    /// The signature did not verify under the key that was selected.
     #[error("JWT cryptographic operation failed")]
     InvalidSignature,
 

--- a/crates/postrust-core/src/api_request/types.rs
+++ b/crates/postrust-core/src/api_request/types.rs
@@ -14,11 +14,14 @@ use std::collections::{HashMap, HashSet};
 /// A fully qualified identifier with schema and name.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QualifiedIdentifier {
+    /// The schema. Empty when unqualified, leaving resolution to `search_path`.
     pub schema: String,
+    /// The relation or routine's own name.
     pub name: String,
 }
 
 impl QualifiedIdentifier {
+    /// A `schema.name` identifier.
     pub fn new(schema: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             schema: schema.into(),
@@ -45,11 +48,17 @@ impl std::fmt::Display for QualifiedIdentifier {
     }
 }
 
+/// A column name, as the request wrote it.
 pub type FieldName = String;
+/// A schema name.
 pub type Schema = String;
+/// The name a selected field is returned under, where the request renamed it.
 pub type Alias = String;
+/// A PostgreSQL type name a selected field is cast to, from `::type`.
 pub type Cast = String;
+/// The `!hint` naming which relationship or which function signature to use.
 pub type Hint = String;
+/// A text-search configuration name, from `fts(english)`.
 pub type Language = String;
 
 // ============================================================================
@@ -80,11 +89,14 @@ pub type JsonPath = Vec<JsonOperation>;
 /// A field reference, optionally with JSON path.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Field {
+    /// The column.
     pub name: FieldName,
+    /// Steps into the column's JSON, empty for an ordinary column.
     pub json_path: JsonPath,
 }
 
 impl Field {
+    /// A plain column reference, with no JSON path.
     pub fn simple(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -92,6 +104,7 @@ impl Field {
         }
     }
 
+    /// A column reference that reaches into the column's JSON.
     pub fn with_json_path(name: impl Into<String>, json_path: JsonPath) -> Self {
         Self {
             name: name.into(),
@@ -110,7 +123,10 @@ pub enum InvokeMethod {
     /// POST invocation (can have side effects)
     Inv,
     /// GET/HEAD invocation (read-only)
-    InvRead { headers_only: bool },
+    InvRead {
+        /// The request was HEAD, so the body is computed and discarded.
+        headers_only: bool,
+    },
 }
 
 /// Type of mutation operation.
@@ -142,21 +158,32 @@ pub enum Resource {
 pub enum DbAction {
     /// SELECT from a table/view
     RelationRead {
+        /// The relation being read.
         qi: QualifiedIdentifier,
+        /// The request was HEAD: headers are computed, the body discarded.
         headers_only: bool,
     },
     /// INSERT/UPDATE/DELETE on a table
     RelationMut {
+        /// The relation being written.
         qi: QualifiedIdentifier,
+        /// Which write.
         mutation: Mutation,
     },
     /// Call a stored function
     Routine {
+        /// The function being called.
         qi: QualifiedIdentifier,
+        /// How it was invoked, which decides whether it may write.
         invoke_method: InvokeMethod,
     },
     /// Read schema metadata
-    SchemaRead { schema: Schema, headers_only: bool },
+    SchemaRead {
+        /// The schema being described.
+        schema: Schema,
+        /// The request was HEAD.
+        headers_only: bool,
+    },
 }
 
 /// The action to perform, which may or may not require database access.
@@ -168,7 +195,9 @@ pub enum Action {
     RelationInfo(QualifiedIdentifier),
     /// OPTIONS on a function
     RoutineInfo {
+        /// The function being described.
         qi: QualifiedIdentifier,
+        /// How it would be invoked.
         invoke_method: InvokeMethod,
     },
     /// OPTIONS on root (returns OpenAPI spec)
@@ -296,14 +325,20 @@ impl FtsOperator {
 /// Value for IS comparisons.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IsValue {
+    /// `is.null`
     Null,
+    /// `is.notnull`
     NotNull,
+    /// `is.true`
     True,
+    /// `is.false`
     False,
+    /// `is.unknown`
     Unknown,
 }
 
 impl IsValue {
+    /// The SQL keyword this compares against.
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::Null => "NULL",
@@ -319,11 +354,20 @@ impl IsValue {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Operation {
     /// Simple binary operation: `col.neq.value`
-    Simple { op: SimpleOperator, value: String },
+    Simple {
+        /// The operator.
+        op: SimpleOperator,
+        /// Its right-hand operand, unparsed: the column's type decides how it
+        /// is read.
+        value: String,
+    },
     /// Quantified operation: `col.eq.value` or `col.eq(any).{arr}`
     Quant {
+        /// The operator.
         op: QuantOperator,
+        /// `any` or `all`, where the request supplied one.
         quantifier: Option<OpQuantifier>,
+        /// The operand, unparsed.
         value: String,
     },
     /// IN list: `col.in.(a,b,c)`
@@ -334,8 +378,11 @@ pub enum Operation {
     IsDistinctFrom(String),
     /// Full-text search: `col.fts(english).query`
     Fts {
+        /// Which of the text-search functions to build the query with.
         op: FtsOperator,
+        /// The text-search configuration, where the request named one.
         language: Option<Language>,
+        /// The search text.
         value: String,
     },
 }
@@ -350,6 +397,7 @@ pub struct OpExpr {
 }
 
 impl OpExpr {
+    /// The operation as written.
     pub fn new(operation: Operation) -> Self {
         Self {
             negated: false,
@@ -357,6 +405,7 @@ impl OpExpr {
         }
     }
 
+    /// The operation under `not.`.
     pub fn negated(operation: Operation) -> Self {
         Self {
             negated: true,
@@ -372,11 +421,14 @@ impl OpExpr {
 /// A single filter on a field.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Filter {
+    /// The column being filtered, with any JSON path into it.
     pub field: Field,
+    /// The comparison applied to it.
     pub op_expr: OpExpr,
 }
 
 impl Filter {
+    /// One column compared one way.
     pub fn new(field: Field, op_expr: OpExpr) -> Self {
         Self { field, op_expr }
     }
@@ -385,7 +437,9 @@ impl Filter {
 /// Boolean logic operator.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LogicOperator {
+    /// Every child must hold.
     And,
+    /// At least one child must hold.
     Or,
 }
 
@@ -394,8 +448,11 @@ pub enum LogicOperator {
 pub enum LogicTree {
     /// A boolean expression combining children
     Expr {
+        /// Whether the whole node is negated, as in `not.and(...)`.
         negated: bool,
+        /// How the children combine.
         op: LogicOperator,
+        /// The operands.
         children: Vec<LogicTree>,
     },
     /// A leaf filter
@@ -438,6 +495,7 @@ impl LogicTree {
         }
     }
 
+    /// Combine children with `AND`, not negated.
     pub fn and(children: Vec<LogicTree>) -> Self {
         Self::Expr {
             negated: false,
@@ -446,6 +504,7 @@ impl LogicTree {
         }
     }
 
+    /// Combine children with `OR`, not negated.
     pub fn or(children: Vec<LogicTree>) -> Self {
         Self::Expr {
             negated: false,
@@ -454,6 +513,7 @@ impl LogicTree {
         }
     }
 
+    /// A tree of exactly one filter.
     pub fn filter(filter: Filter) -> Self {
         Self::Stmt(filter)
     }
@@ -466,14 +526,20 @@ impl LogicTree {
 /// Aggregate functions.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AggregateFunction {
+    /// `sum()`
     Sum,
+    /// `avg()`
     Avg,
+    /// `max()`
     Max,
+    /// `min()`
     Min,
+    /// `count()`
     Count,
 }
 
 impl AggregateFunction {
+    /// The SQL function name.
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::Sum => "SUM",
@@ -500,17 +566,27 @@ pub enum JoinType {
 pub enum SelectItem {
     /// Select a column, possibly with aggregation
     Field {
+        /// The column, with any JSON path into it.
         field: Field,
+        /// An aggregate applied to it, from `col.sum()`.
         aggregate: Option<AggregateFunction>,
+        /// A cast applied to the aggregate's result, distinct from `cast`,
+        /// which applies to the column before aggregating.
         aggregate_cast: Option<Cast>,
+        /// A cast applied to the column, from `col::text`.
         cast: Option<Cast>,
+        /// The key this is returned under, where the request renamed it.
         alias: Option<Alias>,
     },
     /// Embed a related resource
     Relation {
+        /// The related resource, as the request named it.
         relation: FieldName,
+        /// The key the embed is returned under, where renamed.
         alias: Option<Alias>,
+        /// Which relationship to follow, where several connect the two.
         hint: Option<Hint>,
+        /// Whether a parent with no children is kept. Defaults to `Left`.
         join_type: Option<JoinType>,
         /// Columns and further embeds selected on the related resource.
         ///
@@ -523,8 +599,11 @@ pub enum SelectItem {
     /// than under a key of their own, so unlike [`Self::Relation`] there is no
     /// alias: nothing is being named.
     SpreadRelation {
+        /// The related resource, as the request named it.
         relation: FieldName,
+        /// Which relationship to follow, where several connect the two.
         hint: Option<Hint>,
+        /// Whether a parent with no children is kept. Defaults to `Left`.
         join_type: Option<JoinType>,
         /// Columns and further embeds selected on the related resource.
         ///
@@ -564,12 +643,15 @@ impl SelectItem {
 /// Sort direction.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum OrderDirection {
+    /// Ascending, PostgreSQL's default.
     #[default]
     Asc,
+    /// Descending.
     Desc,
 }
 
 impl OrderDirection {
+    /// The `ORDER BY` keyword.
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::Asc => "ASC",
@@ -581,11 +663,14 @@ impl OrderDirection {
 /// NULL ordering.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderNulls {
+    /// Nulls sort before non-nulls.
     First,
+    /// Nulls sort after non-nulls.
     Last,
 }
 
 impl OrderNulls {
+    /// The `NULLS FIRST` / `NULLS LAST` clause.
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::First => "NULLS FIRST",
@@ -599,20 +684,29 @@ impl OrderNulls {
 pub enum OrderTerm {
     /// Order by a field
     Field {
+        /// The column to sort on.
         field: Field,
+        /// Ascending or descending. Absent leaves PostgreSQL's default.
         direction: Option<OrderDirection>,
+        /// Where nulls sort. Absent leaves PostgreSQL's default, which depends
+        /// on the direction.
         nulls: Option<OrderNulls>,
     },
     /// Order by a field from an embedded relation
     Relation {
+        /// The embedded resource holding the column.
         relation: FieldName,
+        /// The column to sort on.
         field: Field,
+        /// Ascending or descending.
         direction: Option<OrderDirection>,
+        /// Where nulls sort.
         nulls: Option<OrderNulls>,
     },
 }
 
 impl OrderTerm {
+    /// Sort on a column, leaving direction and null placement to PostgreSQL.
     pub fn field(name: impl Into<String>) -> Self {
         Self::Field {
             field: Field::simple(name),
@@ -621,6 +715,7 @@ impl OrderTerm {
         }
     }
 
+    /// Sort on a column, descending.
     pub fn field_desc(name: impl Into<String>) -> Self {
         Self::Field {
             field: Field::simple(name),
@@ -637,7 +732,9 @@ impl OrderTerm {
 /// A range for pagination (offset and limit).
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Range {
+    /// Rows to skip before the first returned.
     pub offset: i64,
+    /// How many rows at most. `None` is unbounded.
     pub limit: Option<i64>,
     /// Whether `offset` was asked for rather than defaulted to.
     ///
@@ -651,6 +748,7 @@ pub struct Range {
 }
 
 impl Range {
+    /// A range from an explicit offset and limit, as query parameters give.
     pub fn new(offset: i64, limit: Option<i64>) -> Self {
         Self {
             offset,
@@ -683,12 +781,17 @@ impl Range {
 pub enum Payload {
     /// Parsed JSON with extracted keys
     ProcessedJson {
+        /// The body as received, passed to PostgreSQL unaltered.
         raw: bytes::Bytes,
+        /// The union of the keys across every object in the body, which is
+        /// what decides the column list when `?columns=` was not given.
         keys: HashSet<String>,
     },
     /// URL-encoded form data
     ProcessedUrlEncoded {
+        /// The decoded pairs, in the order they were sent.
         data: Vec<(String, String)>,
+        /// The distinct keys among them.
         keys: HashSet<String>,
     },
     /// Raw JSON (used with &columns parameter)
@@ -727,6 +830,7 @@ pub enum MediaType {
     Other(String),
     /// Singular JSON object (vnd.pgrst.object)
     SingularJson {
+        /// `;nulls=null`: an empty result is `null` rather than a 406.
         nullable: bool,
         /// `;nulls=stripped`: omit keys whose value is null.
         strip_nulls: bool,
@@ -738,13 +842,18 @@ pub enum MediaType {
     },
     /// EXPLAIN plan output
     Plan {
+        /// The media type the plan is *for*: the plan describes the query that
+        /// would have produced this.
         base: Box<MediaType>,
+        /// How the plan itself is rendered.
         format: PlanFormat,
+        /// `EXPLAIN` options the request asked for.
         options: Vec<PlanOption>,
     },
 }
 
 impl MediaType {
+    /// The `Content-Type` this is answered with.
     pub fn content_type(&self) -> &str {
         match self {
             Self::ApplicationJson => "application/json",
@@ -818,17 +927,24 @@ impl MediaType {
 /// EXPLAIN plan format.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PlanFormat {
+    /// `EXPLAIN (FORMAT JSON)`.
     Json,
+    /// `EXPLAIN (FORMAT TEXT)`, PostgreSQL's default rendering.
     Text,
 }
 
 /// EXPLAIN plan options.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PlanOption {
+    /// Run the query and report actual timings, not just the plan.
     Analyze,
+    /// Include additional per-node detail.
     Verbose,
+    /// Report planner settings that differ from their defaults.
     Settings,
+    /// Report buffer usage. Requires `Analyze`.
     Buffers,
+    /// Report WAL usage. Requires `Analyze`.
     Wal,
 }
 
@@ -839,7 +955,9 @@ pub enum PlanOption {
 /// Resolution strategy for upsert conflicts.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PreferResolution {
+    /// `resolution=merge-duplicates`: a conflicting row is updated.
     MergeDuplicates,
+    /// `resolution=ignore-duplicates`: a conflicting row is left alone.
     IgnoreDuplicates,
 }
 
@@ -869,8 +987,11 @@ pub enum PreferCount {
 /// Transaction handling.
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum PreferTransaction {
+    /// `tx=commit`, the default.
     #[default]
     Commit,
+    /// `tx=rollback`: the work is done, reported, and thrown away. Useful for
+    /// seeing what a mutation would do without doing it.
     Rollback,
 }
 
@@ -900,14 +1021,24 @@ pub enum PreferHandling {
 /// Parsed Prefer headers.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct Preferences {
+    /// How an upsert resolves a conflicting row.
     pub resolution: Option<PreferResolution>,
+    /// Whether a mutation returns the rows it touched.
     pub representation: PreferRepresentation,
+    /// Whether, and how exactly, to count the full result set.
     pub count: Option<PreferCount>,
+    /// Whether the transaction commits.
     pub transaction: PreferTransaction,
+    /// What an omitted column means on insert: its default, or null.
     pub missing: PreferMissing,
+    /// Whether an unrecognised preference is an error.
     pub handling: PreferHandling,
+    /// `timezone=`: the session time zone for this request.
     pub timezone: Option<String>,
+    /// `max-affected=`: refuse the write if it would touch more rows.
     pub max_affected: Option<i64>,
+    /// Preferences that were sent and not understood. Reported under
+    /// `handling=strict`, ignored otherwise.
     pub invalid: Vec<String>,
     /// Every preference the server understood, in the order it was sent.
     ///

--- a/crates/postrust-core/src/config.rs
+++ b/crates/postrust-core/src/config.rs
@@ -583,12 +583,18 @@ pub struct RoleSettings {
 /// entry reads the same as the environment variable.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum IsolationLevel {
+    /// PostgreSQL's default. A statement sees rows committed before it began.
     ReadCommitted,
+    /// Every statement in the transaction sees the same snapshot.
     RepeatableRead,
+    /// As `RepeatableRead`, and concurrent transactions are additionally
+    /// guaranteed to be equivalent to some serial order. May abort with a
+    /// serialization failure, which the client is expected to retry.
     Serializable,
 }
 
 impl IsolationLevel {
+    /// The spelling PostgreSQL's `SET TRANSACTION ISOLATION LEVEL` expects.
     pub fn to_sql(&self) -> &'static str {
         match self {
             Self::ReadCommitted => "READ COMMITTED",
@@ -634,8 +640,12 @@ impl IsolationLevel {
 /// and behaving as one of the others.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OpenApiMode {
+    /// No OpenAPI document is served.
     Disabled,
+    /// The document describes only what the requesting role may reach, so two
+    /// roles asking are answered differently.
     FollowPrivileges,
+    /// The document describes the whole exposed schema, whoever is asking.
     IgnorePrivileges,
 }
 
@@ -669,14 +679,24 @@ impl OpenApiMode {
 /// Log levels.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LogLevel {
+    /// Only failures that stop the server. Mapped onto `ERROR`, which is the
+    /// least severe level `tracing` offers.
     Crit,
+    /// Requests that failed, and faults that did not stop the server.
     Error,
+    /// Configuration that was ignored, and conditions worth noticing.
     Warn,
+    /// Start-up, schema reloads, and one line per request.
     Info,
+    /// The generated SQL and the decisions behind it.
     Debug,
 }
 
 impl LogLevel {
+    /// The `tracing` level this maps onto.
+    ///
+    /// `Crit` and `Error` both become `ERROR`: PostgREST distinguishes them
+    /// and `tracing` has nothing more severe to map `Crit` onto.
     pub fn to_tracing(&self) -> tracing::Level {
         match self {
             Self::Crit | Self::Error => tracing::Level::ERROR,

--- a/crates/postrust-core/src/embed.rs
+++ b/crates/postrust-core/src/embed.rs
@@ -98,7 +98,9 @@ pub struct EmbedPlan {
 /// The table a many-to-many relationship is joined through.
 #[derive(Clone, Debug)]
 pub struct EmbedJunction {
+    /// Schema holding the junction table.
     pub schema: String,
+    /// The junction table's name.
     pub table: String,
     /// `(parent column, junction column)` for each column the parent joins on.
     ///
@@ -802,6 +804,11 @@ pub fn group_from_aggregated(
     grouped
 }
 
+/// Group child rows by the value of one of their columns.
+///
+/// The join is done in SQL and the rows come back flat; this puts each child
+/// under the parent it belongs to. Keyed by the rendered value, so a parent
+/// with no children gets no entry rather than an empty one.
 pub fn group_by_key(
     children: Vec<serde_json::Value>,
     foreign_column: &str,

--- a/crates/postrust-core/src/error.rs
+++ b/crates/postrust-core/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     // ========================================================================
     // Request Parsing Errors (4xx)
     // ========================================================================
+    /// The request path does not name a resource this API serves.
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 
@@ -25,6 +26,8 @@ pub enum Error {
     #[error("Use of aggregate functions is not allowed")]
     AggregatesNotAllowed,
 
+    /// A query parameter this API does not accept, or one whose value is not
+    /// valid for it.
     #[error("Invalid query parameter: {0}")]
     InvalidQueryParam(String),
 
@@ -47,12 +50,16 @@ pub enum Error {
         expected: String,
     },
 
+    /// A request header whose value this server cannot read. Names the header
+    /// only; the value may carry credentials.
     #[error("Invalid header: {0}")]
     InvalidHeader(&'static str),
 
+    /// The body did not parse, or does not fit the resource it was sent to.
     #[error("{0}")]
     InvalidBody(String),
 
+    /// An HTTP method this API does not implement for any resource.
     #[error("Unsupported HTTP method: {0}")]
     UnsupportedMethod(String),
 
@@ -70,10 +77,13 @@ pub enum Error {
     /// to correct the request and they are part of the API's own contract.
     #[error("Invalid schema: {requested}")]
     UnacceptableSchema {
+        /// The schema the profile header named.
         requested: String,
+        /// The schemas that are exposed, so the client can correct itself.
         exposed: Vec<String>,
     },
 
+    /// A column the request named that the relation does not have.
     #[error("Could not find the '{column}' column of '{relation}' in the schema cache")]
     UnknownColumn {
         /// The column the request named.
@@ -82,26 +92,36 @@ pub enum Error {
         relation: String,
     },
 
+    /// A `Range` header or `limit`/`offset` pair that cannot be satisfied.
     #[error("Requested range not satisfiable")]
     InvalidRange(String),
 
+    /// Content negotiation found nothing both sides accept.
     #[error("None of these media types are available: {0}")]
     InvalidMediaType(String),
 
+    /// A function argument the signature requires and the call omitted.
     #[error("Missing required parameter: {0}")]
     MissingParameter(String),
 
+    /// The request admits more than one reading and the server will not guess.
     #[error("Ambiguous request: {0}")]
     AmbiguousRequest(String),
 
     /// Several signatures of a function fit the arguments equally well.
     #[error("Could not choose the best candidate function between: {}", .candidates.join(", "))]
-    AmbiguousFunction { candidates: Vec<String> },
+    AmbiguousFunction {
+        /// The signatures that fit, as the client would have to distinguish
+        /// them.
+        candidates: Vec<String>,
+    },
 
     /// Several relationships connect the two resources and none was named.
     #[error("Could not embed because more than one relationship was found for '{origin}' and '{target}'")]
     AmbiguousRelationship {
+        /// The resource being embedded from.
         origin: String,
+        /// The resource being embedded.
         target: String,
         /// Each candidate as `(cardinality, description)`.
         candidates: Vec<(String, String)>,
@@ -136,18 +156,22 @@ pub enum Error {
     #[error("{0}")]
     JwtClaim(String),
 
+    /// Nothing said who is asking, and no anonymous role is configured to be.
     #[error("Anonymous access is disabled")]
     MissingAuth,
 
+    /// The caller is known and the role it resolved to may not do this.
     #[error("Insufficient permissions: {0}")]
     InsufficientPermissions(String),
 
     // ========================================================================
     // Resource Errors (404)
     // ========================================================================
+    /// Nothing at this path, where no more specific variant applies.
     #[error("Resource not found: {0}")]
     NotFound(String),
 
+    /// No table, view or foreign table of this name in the exposed schema.
     #[error("Table not found: {name}")]
     TableNotFound {
         /// The name the request asked for, schema-qualified.
@@ -196,9 +220,12 @@ pub enum Error {
     #[error("geometry column is missing")]
     MissingGeometryColumn,
 
+    /// A column named in the request that the relation does not have. Prefer
+    /// [`Error::UnknownColumn`], which also says which relation was searched.
     #[error("Column not found: {0}")]
     ColumnNotFound(String),
 
+    /// Nothing connects the two resources, so the embed cannot be planned.
     #[error("Could not find a relationship between '{origin}' and '{target}' in the schema cache")]
     RelationshipNotFound {
         /// The table the embedding started from.
@@ -289,36 +316,49 @@ pub enum Error {
     // ========================================================================
     // Schema Cache Errors
     // ========================================================================
+    /// A request arrived before the schema had been read. Transient at
+    /// start-up; persistent means the initial load failed.
     #[error("Schema cache not loaded")]
     SchemaCacheNotLoaded,
 
+    /// Reading the schema from PostgreSQL failed. Usually a missing privilege
+    /// on the catalogue rather than a fault in the schema itself.
     #[error("Schema cache load failed: {0}")]
     SchemaCacheLoadFailed(String),
 
     // ========================================================================
     // Database Errors (500/4xx depending on type)
     // ========================================================================
+    /// PostgreSQL refused the statement. The SQLSTATE decides the HTTP status,
+    /// so this is not always a 500.
     #[error("Database error: {0}")]
     Database(#[from] DatabaseError),
 
+    /// No connection could be obtained: the pool is exhausted, or the database
+    /// is unreachable.
     #[error("Connection pool error: {0}")]
     ConnectionPool(String),
 
     // ========================================================================
     // Internal Errors (500)
     // ========================================================================
+    /// A fault in this server. Always a bug; the message is for its log rather
+    /// than for the client to act on.
     #[error("Internal error: {0}")]
     Internal(String),
 
+    /// The server was started with a setting it cannot act on.
     #[error("Configuration error: {0}")]
     Config(String),
 
     // ========================================================================
     // Plan Errors
     // ========================================================================
+    /// The request parsed and no execution plan could be built from it.
     #[error("Invalid plan: {0}")]
     InvalidPlan(String),
 
+    /// An embed that cannot be planned, where no more specific variant fits.
     #[error("Embedding error: {0}")]
     EmbeddingError(String),
 }
@@ -629,10 +669,6 @@ impl Error {
     }
 }
 
-/// How a function's argument list reads in an error message.
-///
-/// PostgREST words the no-argument case differently rather than printing an
-/// empty list, and the messages are matched verbatim by clients.
 /// How the message spells the type of a single unnamed JSON parameter.
 ///
 /// It is the one media type that can also carry named arguments, so it reads
@@ -647,6 +683,10 @@ pub fn names_only_one_param(single_param: Option<&str>) -> bool {
     matches!(single_param, Some(other) if other != JSON_PARAM)
 }
 
+/// How a function's argument list reads in an error message.
+///
+/// PostgREST words the no-argument case differently rather than printing an
+/// empty list, and the messages are matched verbatim by clients.
 pub fn function_signature(name: &str, params: &[String]) -> String {
     match params.is_empty() {
         true => format!("{} without parameters", name),
@@ -666,12 +706,20 @@ fn describe_params(params: &[String]) -> String {
 #[derive(Error, Debug)]
 #[error("Database error [{code}]: {message}")]
 pub struct DatabaseError {
+    /// The five-character SQLSTATE. This decides the HTTP status, so it is the
+    /// field that matters most.
     pub code: String,
+    /// PostgreSQL's primary message.
     pub message: String,
+    /// PostgreSQL's detail field, where it sent one.
     pub details: Option<String>,
+    /// PostgreSQL's hint field, where it sent one.
     pub hint: Option<String>,
+    /// The constraint that was violated, for the integrity SQLSTATEs.
     pub constraint: Option<String>,
+    /// The table the failure concerns, where PostgreSQL identified one.
     pub table: Option<String>,
+    /// The column the failure concerns, where PostgreSQL identified one.
     pub column: Option<String>,
 }
 

--- a/crates/postrust-core/src/lib.rs
+++ b/crates/postrust-core/src/lib.rs
@@ -28,6 +28,7 @@
 //! let (sql, params) = build_query(&plan)?;
 //! ```
 
+#![warn(missing_docs)]
 // The `Error` enum carries a rich `DatabaseError` payload (PostgREST-style error
 // bodies), which makes it larger than clippy's `Result`/enum size thresholds.
 // Boxing it would ripple through every construction site for little benefit, so

--- a/crates/postrust-core/src/plan/mod.rs
+++ b/crates/postrust-core/src/plan/mod.rs
@@ -34,12 +34,17 @@ pub enum DbActionPlan {
     Read(ReadPlanTree),
     /// Mutation operation (INSERT/UPDATE/DELETE)
     MutateRead {
+        /// The write to perform.
         mutate: MutatePlan,
+        /// What to read back afterwards. `None` when the client asked for no
+        /// representation, in which case nothing is selected.
         read: Option<ReadPlanTree>,
     },
     /// RPC call
     Call {
+        /// The function call.
         call: CallPlan,
+        /// How to shape what the function returned, when it returns rows.
         read: Option<ReadPlanTree>,
     },
 }

--- a/crates/postrust-core/src/plan/types.rs
+++ b/crates/postrust-core/src/plan/types.rs
@@ -167,14 +167,22 @@ impl CoercibleFilter {
 pub enum CoercibleLogicTree {
     /// Boolean expression
     Expr {
+        /// Whether the whole node is negated (`not.and(...)`).
         negated: bool,
+        /// How the children combine.
         op: LogicOperator,
+        /// The operands.
         children: Vec<CoercibleLogicTree>,
     },
     /// Leaf filter
     Stmt(CoercibleFilter),
     /// NULL check for embedding
-    NullEmbed { negated: bool, field_name: String },
+    NullEmbed {
+        /// Whether the test is inverted: the embed must *not* be null.
+        negated: bool,
+        /// The embedded field being tested.
+        field_name: String,
+    },
 }
 
 impl CoercibleLogicTree {

--- a/crates/postrust-core/src/schema_cache/relationship.rs
+++ b/crates/postrust-core/src/schema_cache/relationship.rs
@@ -304,17 +304,23 @@ impl Relationship {
 pub enum Cardinality {
     /// One-to-Many: parent has many children
     O2M {
+        /// The foreign key constraint this was read from.
         constraint: String,
+        /// `(parent column, child column)` for each column in the key.
         columns: Vec<(String, String)>,
     },
     /// Many-to-One: child has one parent
     M2O {
+        /// The foreign key constraint this was read from.
         constraint: String,
+        /// `(child column, parent column)` for each column in the key.
         columns: Vec<(String, String)>,
     },
     /// One-to-One
     O2O {
+        /// The foreign key constraint this was read from.
         constraint: String,
+        /// `(this table's column, other table's column)` for each column.
         columns: Vec<(String, String)>,
         /// Whether this table is the parent in the relationship
         is_parent: bool,

--- a/crates/postrust-core/src/schema_cache/routine.rs
+++ b/crates/postrust-core/src/schema_cache/routine.rs
@@ -152,6 +152,11 @@ pub enum FuncVolatility {
 }
 
 impl FuncVolatility {
+    /// Read from `pg_proc.provolatile`, which is `i`, `s` or `v`.
+    ///
+    /// Anything else is treated as volatile: that is the assumption which
+    /// forbids the most, so an unrecognised value cannot make a function look
+    /// safer to call than it is.
     pub fn from_char(c: char) -> Self {
         match c {
             'i' => Self::Immutable,

--- a/crates/postrust-graphql/src/error.rs
+++ b/crates/postrust-graphql/src/error.rs
@@ -5,26 +5,36 @@ use thiserror::Error;
 /// Errors that can occur during GraphQL operations.
 #[derive(Debug, Error)]
 pub enum GraphQLError {
+    /// The schema could not be built from the database's metadata. A fault in
+    /// the translation, not in the request: no query has been seen yet.
     #[error("Schema generation failed: {0}")]
     SchemaGeneration(String),
 
+    /// The built schema was rejected, or a lookup into it failed.
     #[error("Schema error: {0}")]
     SchemaError(String),
 
+    /// The query parsed and resolving it failed.
     #[error("Query execution failed: {0}")]
     QueryExecution(String),
 
+    /// A `where` argument that does not describe a filter this server can
+    /// express -- an unknown operator, or an operand of the wrong shape.
     #[error("Invalid filter: {0}")]
     InvalidFilter(String),
 
+    /// A PostgreSQL type with no GraphQL equivalent to map it onto.
     #[error("Type mapping error: {0}")]
     TypeMapping(String),
 
+    /// The field needs an identity and the request carried none.
     #[error("Authentication required")]
     AuthenticationRequired,
 
+    /// PostgreSQL refused the query. Its message is carried verbatim.
     #[error("Database error: {0}")]
     Database(String),
 }
 
+/// `Result` with this crate's error type as the default failure.
 pub type Result<T> = std::result::Result<T, GraphQLError>;

--- a/crates/postrust-graphql/src/lib.rs
+++ b/crates/postrust-graphql/src/lib.rs
@@ -3,6 +3,8 @@
 //! This crate provides GraphQL API generation from PostgreSQL schema,
 //! including queries, mutations, and subscriptions.
 
+#![warn(missing_docs)]
+
 pub mod error;
 pub mod scalar;
 pub mod types;

--- a/crates/postrust-graphql/src/names.rs
+++ b/crates/postrust-graphql/src/names.rs
@@ -180,12 +180,16 @@ impl RolePermissions {
 /// without restriction.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct RolePermissions {
+    /// Which rows the role may read. Absent means it may read none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub select: Option<SelectPermission>,
+    /// What the role may insert. Absent means it may insert nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub insert: Option<InsertPermission>,
+    /// Which rows the role may change. Absent means it may change none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub update: Option<UpdatePermission>,
+    /// Which rows the role may delete. Absent means it may delete none.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delete: Option<DeletePermission>,
 }
@@ -258,6 +262,7 @@ pub struct InsertPermission {
 /// has to satisfy.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct UpdatePermission {
+    /// The columns the role may write.
     #[serde(default)]
     pub columns: ColumnSet,
 
@@ -271,6 +276,8 @@ pub struct UpdatePermission {
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub check: serde_json::Value,
 
+    /// Columns forced to a fixed value on every update, whatever the request
+    /// asked for. Hasura's `set`, used for things like an updated-at stamp.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub set: HashMap<String, serde_json::Value>,
 }
@@ -278,6 +285,7 @@ pub struct UpdatePermission {
 /// Which rows a role may delete.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct DeletePermission {
+    /// Which rows may be deleted. Null means every row the role can see.
     #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
     pub filter: serde_json::Value,
 }

--- a/crates/postrust-graphql/src/role.rs
+++ b/crates/postrust-graphql/src/role.rs
@@ -247,7 +247,10 @@ pub fn has_backend_only(names: &NameOverrides, role: &str) -> bool {
 /// unrestricted read: no permission document, or an administrator.
 #[derive(Clone, Copy)]
 pub struct Caller<'a> {
+    /// The role to narrow rows to. `None` is the unrestricted read.
     pub role: Option<&'a str>,
+    /// Session variables the permissions may refer to, such as
+    /// `x-hasura-user-id`.
     pub session: &'a std::collections::HashMap<String, String>,
 }
 
@@ -271,7 +274,12 @@ pub enum Fault {
     /// role's own schema, which has no such field -- so reaching it means
     /// something was built that should not have been, and the safe answer is
     /// to refuse rather than to read every row.
-    NoPermission { role: String, table: String },
+    NoPermission {
+        /// The role that was asking.
+        role: String,
+        /// The table it has no select permission on.
+        table: String,
+    },
     /// A permission names a session variable the caller does not carry.
     MissingSessionVariable(String),
 }
@@ -308,9 +316,13 @@ pub const CHECK_FAILED: &str = "check constraint of an insert/update permission 
 /// Which of the four grants is being asked about.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Verb {
+    /// Reading rows.
     Select,
+    /// Adding rows.
     Insert,
+    /// Changing existing rows.
     Update,
+    /// Removing rows.
     Delete,
 }
 

--- a/crates/postrust-graphql/src/schema/object.rs
+++ b/crates/postrust-graphql/src/schema/object.rs
@@ -113,6 +113,10 @@ impl TableObjectType {
         }
     }
 
+    /// Build the field for a table, under a name chosen by the caller.
+    ///
+    /// Separate from the unnamed constructor because a custom table name has
+    /// to reach the field before its type name is derived from it.
     pub fn from_table_named(
         table: &Table,
         base_name: &str,

--- a/crates/postrust-graphql/src/subscription/broker.rs
+++ b/crates/postrust-graphql/src/subscription/broker.rs
@@ -304,12 +304,16 @@ impl NotifyBroker {
 /// Errors that can occur in the broker.
 #[derive(Debug, thiserror::Error)]
 pub enum BrokerError {
+    /// The listening connection failed, or could not be established.
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    /// A channel was addressed that the broker is not listening on.
     #[error("Channel not found: {0}")]
     ChannelNotFound(String),
 
+    /// `run` was called on a broker that is already running. Two listeners on
+    /// one broker would each deliver every notification.
     #[error("Broker is already running")]
     AlreadyRunning,
 }

--- a/crates/postrust-lambda/src/lib.rs
+++ b/crates/postrust-lambda/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Re-exports for Lambda handler implementation.
 
+#![warn(missing_docs)]
+
 pub use postrust_auth;
 pub use postrust_core;
 pub use postrust_response;

--- a/crates/postrust-response/src/lib.rs
+++ b/crates/postrust-response/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Handles content negotiation and response formatting for JSON, CSV, and other formats.
 
+#![warn(missing_docs)]
+
 mod headers;
 pub use headers::parse_guc_headers;
 mod json;
@@ -65,6 +67,11 @@ impl Response {
         }
     }
 
+    /// Set a header, replacing any already present under that name.
+    ///
+    /// A name or value that is not valid as an HTTP header is dropped rather
+    /// than reported: these are built from database output, and one bad GUC
+    /// should not fail an otherwise good response.
     pub fn set_header(&mut self, name: &str, value: &str) {
         if let Ok(v) = HeaderValue::from_str(value) {
             self.headers.insert(
@@ -419,17 +426,23 @@ pub struct QueryResult {
 /// Response formatting error.
 #[derive(Debug, thiserror::Error)]
 pub enum FormatError {
+    /// The rows could not be serialised. Reported as 500: the request was
+    /// answerable and this server failed to render the answer.
     #[error("JSON serialization error: {0}")]
     Json(#[from] serde_json::Error),
 
+    /// A singular response was asked for and no row matched.
     #[error("Resource not found")]
     NotFound,
 
+    /// A singular response was asked for and more than one row matched, which
+    /// is 406 rather than 500: the rows are fine, the requested shape is not.
     #[error("Multiple rows returned for singular response")]
     MultipleRows,
 }
 
 impl FormatError {
+    /// The HTTP status this failure is answered with.
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Json(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/postrust-server/src/lenient_uri.rs
+++ b/crates/postrust-server/src/lenient_uri.rs
@@ -97,6 +97,7 @@ pub struct LenientStream<T> {
 }
 
 impl<T> LenientStream<T> {
+    /// Wrap a stream, rewriting request targets as they pass through.
     pub fn new(inner: T) -> Self {
         Self {
             inner,

--- a/crates/postrust-server/src/lib.rs
+++ b/crates/postrust-server/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `admin-ui` - Enables the admin UI with OpenAPI documentation,
 //!   Swagger UI, Scalar, and GraphQL Playground at `/admin`.
 
+#![warn(missing_docs)]
 // Every fallible function in this crate returns `postrust_core::Error`, which
 // is a wide enum by design: a PostgREST error carries its code, message,
 // details and hint. Boxing it to satisfy the lint would put an allocation on

--- a/crates/postrust-sql/src/identifier.rs
+++ b/crates/postrust-sql/src/identifier.rs
@@ -48,11 +48,15 @@ pub fn quote_literal(s: &str) -> String {
 /// Qualified identifier (schema.name).
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct QualifiedIdentifier {
+    /// The schema. Empty when the identifier is unqualified, in which case
+    /// resolution is left to the connection's `search_path`.
     pub schema: String,
+    /// The object's own name, unqualified and unquoted.
     pub name: String,
 }
 
 impl QualifiedIdentifier {
+    /// A `schema.name` identifier.
     pub fn new(schema: impl Into<String>, name: impl Into<String>) -> Self {
         Self {
             schema: schema.into(),
@@ -60,6 +64,10 @@ impl QualifiedIdentifier {
         }
     }
 
+    /// A bare `name`, to be resolved against the connection's `search_path`.
+    ///
+    /// Prefer [`new`](Self::new) wherever the schema is known: which object a
+    /// bare name reaches depends on session state rather than on the query.
     pub fn unqualified(name: impl Into<String>) -> Self {
         Self {
             schema: String::new(),

--- a/crates/postrust-sql/src/lib.rs
+++ b/crates/postrust-sql/src/lib.rs
@@ -3,6 +3,8 @@
 //! Provides a safe way to construct SQL queries without string concatenation,
 //! using parameterized queries to prevent SQL injection.
 
+#![warn(missing_docs)]
+
 mod builder;
 mod delete;
 mod expr;


### PR DESCRIPTION
The seven crates that carry a semver promise had no documentation lint, and **231 public items were undocumented** — struct fields, enum variants, constructors — on an API about to be frozen at 1.0.0. `postrust-proxy`, which promises nothing, has had `#![warn(missing_docs)]` since its own documentation pass.

Now all seven have it, and all seven are clean.

| crate | items documented |
|---|---|
| postrust-core | 185 |
| postrust-graphql | 27 |
| postrust-auth | 9 |
| postrust-response | 5 |
| postrust-sql | 4 |
| postrust-server | 1 |
| postrust-lambda | 0 (already clean) |

CI runs clippy with `-D warnings`, so `warn` is enforcing.

## What the docs say

Not restatements of the item name. Where a name already says what a thing is, the doc says what it is *for*, or what is easy to get wrong:

- Error variants get the condition that produces them, and where it isn't obvious, why they carry the status they do — `MultipleRows` is a 406 rather than a 500 because the rows are fine and the requested shape is not.
- `IsolationLevel::Serializable` notes it can abort with a serialization failure and that the client is expected to retry.
- `FuncVolatility::from_char` says an unrecognised value is treated as volatile, because that is the assumption that forbids the most — an unknown value cannot make a function look safer to call than it is.
- `QualifiedIdentifier::unqualified` points at `new` and says why: which object a bare name reaches depends on session state rather than on the query.
- `DatabaseError::code` says the SQLSTATE is the field that decides the HTTP status.

## One pre-existing bug fixed

In `postrust-core/src/error.rs`, the doc block describing `function_signature` sat above `JSON_PARAM`. So that constant's rendered documentation opened with a sentence about function argument lists, and `function_signature` had no documentation at all. Moved to the item it describes.

## The diff

The only non-documentation change is struct fields going from single-line to multi-line braces, which is what rustfmt does once a field carries a doc comment.

## Checks

`cargo fmt --all -- --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · the same with `--features admin-ui` clean · **755 passed, 0 failed** across 25 binaries.

Closes the `missing_docs` item flagged as unstarted in #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
