### PR TITLE
docs: the front page claims only what has been measured, and the registry instructions work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  # Docker Hub is the only registry images are published to.
   # docs/deployment.md, charts/postrust/values.yaml and the website all tell
-  # people to run `postrust/postrust`, which is Docker Hub. Until this was
-  # added nothing published there, so every one of those instructions was
-  # wrong -- `helm install` could not pull its own default image.
+  # people to run `postrust/postrust`, which is here, so this is the one that
+  # has to work -- `helm install` cannot pull its own default image otherwise.
   DOCKERHUB_IMAGE: postrust/postrust
 
 jobs:
@@ -88,7 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     env:
       # Whether Docker Hub is configured, as a plain boolean. The `secrets`
       # context is not dependably available in a step-level `if`, and the
@@ -116,17 +113,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Docker Hub is the only registry now, so a missing secret means the
+      # release would publish nothing at all. Say so here rather than let the
+      # push fail further down with an authorization error that reads like a
+      # bad password.
+      - name: Require Docker Hub credentials
+        run: |
+          if [ "${HAS_DOCKERHUB}" != "true" ]; then
+            echo "::error::DOCKERHUB_TOKEN is not set, so this release would publish no images." \
+                 "Set DOCKERHUB_USERNAME and DOCKERHUB_TOKEN, with a token scoped Read & Write."
+            exit 1
+          fi
 
-      # Optional, so a fork or a repository without the secrets still releases
-      # to GHCR instead of failing outright.
       - name: Log in to Docker Hub
-        if: env.HAS_DOCKERHUB == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -136,12 +135,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          # `enable=` drops the Docker Hub tags entirely when the secret is
-          # absent, so the same build pushes to one registry or two without a
-          # second build step.
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-            name=docker.io/${{ env.DOCKERHUB_IMAGE }},enable=${{ env.HAS_DOCKERHUB }}
+          images: docker.io/${{ env.DOCKERHUB_IMAGE }}
           flavor: ${{ matrix.flavor }}
           tags: |
             type=semver,pattern={{version}}
@@ -165,9 +159,9 @@ jobs:
           cache-to: type=gha,mode=max,scope=${{ matrix.variant }}
 
   # A push succeeding proves the workflow could write, not that anybody else
-  # can read. GHCR packages are private by default, which is a way for a
-  # release to go green while `docker pull` fails for every user. So the tags
-  # are pulled back with no credentials at all.
+  # can read -- a private repository is a way for a release to go green while
+  # `docker pull` fails for every user. So the tags are pulled back with no
+  # credentials at all.
   #
   # Its own job, and not a gate on the release: by the time this runs the
   # crates are already on crates.io, so withholding the GitHub Release would
@@ -177,13 +171,10 @@ jobs:
     needs: image
     if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
-    env:
-      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - name: Pull anonymously
         run: |
           set -uo pipefail
-          docker logout ghcr.io >/dev/null 2>&1 || true
           docker logout >/dev/null 2>&1 || true
 
           version="${GITHUB_REF_NAME#v}"
@@ -199,20 +190,12 @@ jobs:
             fi
           }
 
-          check "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${version}"
-          check "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${version}-alpine"
-
-          if [ "${HAS_DOCKERHUB}" = "true" ]; then
-            check "docker.io/${{ env.DOCKERHUB_IMAGE }}:${version}"
-            check "docker.io/${{ env.DOCKERHUB_IMAGE }}:${version}-alpine"
-          else
-            echo "::warning::DOCKERHUB_TOKEN is not set, so nothing was published to Docker Hub." \
-                 "docs/deployment.md and the Helm chart both default to postrust/postrust there."
-          fi
+          check "docker.io/${{ env.DOCKERHUB_IMAGE }}:${version}"
+          check "docker.io/${{ env.DOCKERHUB_IMAGE }}:${version}-alpine"
 
           if [ "$failed" -ne 0 ]; then
-            echo "::error::Set the package visibility to Public: " \
-                 "https://github.com/orgs/postrust/packages/container/postrust/settings"
+            echo "::error::The repository at https://hub.docker.com/r/${{ env.DOCKERHUB_IMAGE }}" \
+                 "has to be public, and the push has to have actually happened."
             exit 1
           fi
 
@@ -246,11 +229,4 @@ jobs:
             ```
             docker pull ${{ env.DOCKERHUB_IMAGE }}:${{ github.ref_name }}
             docker pull ${{ env.DOCKERHUB_IMAGE }}:${{ github.ref_name }}-alpine
-            ```
-
-            Or from GitHub Container Registry:
-
-            ```
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}-alpine
             ```

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,7 +38,7 @@ discussions — and whenever someone is representing the project in public.
 ## Reporting
 
 Report abusive, harassing, or otherwise unacceptable behaviour to
-[technology@bimaplan.co](mailto:technology@bimaplan.co).
+[founder@postrust.org](mailto:founder@postrust.org).
 
 Every report will be reviewed and investigated promptly and fairly. Your
 privacy and safety as a reporter will be respected: we will not share your

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Postrust! This document provides 
 
 ## Code of Conduct
 
-This project has a [Code of Conduct](CODE_OF_CONDUCT.md). By taking part you are expected to uphold it. Report unacceptable behaviour to [technology@bimaplan.co](mailto:technology@bimaplan.co).
+This project has a [Code of Conduct](CODE_OF_CONDUCT.md). By taking part you are expected to uphold it. Report unacceptable behaviour to [founder@postrust.org](mailto:founder@postrust.org).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Postrust is a serverless-first REST API server for PostgreSQL databases. Inspire
 
 **Why Postrust?**
 
-- **Serverless-first**: Native support for AWS Lambda and Cloudflare Workers
-- **Measured**: Conformance against PostgREST's and Hasura's own test corpora, re-run on a schedule. Throughput figures are withdrawn until the harness can be trusted — see [Benchmarks](#benchmarks)
+- **Serverless-first**: A native AWS Lambda adapter with connection pooling (Cloudflare Workers is a stub, pending Hyperdrive)
+- **Measured**: Conformance against PostgREST's and Hasura's own test corpora, re-run on a schedule, and throughput measured on a pinned bare-metal host behind a self-consistency gate — see [Benchmarks](#benchmarks)
 - **Compatible**: Familiar PostgREST-style API; near drop-in with an opt-in [compatibility mode](#postgrest-compatibility) (see [Differences from PostgREST](#differences-from-postgrest))
 - **Type-safe**: Parameterized queries prevent SQL injection by design
 - **Lightweight**: Single binary with no runtime dependencies
@@ -88,9 +88,13 @@ cargo build --release
 # Start PostgreSQL and Postrust
 docker-compose up -d
 
-# API is available at http://localhost:3000
-curl http://localhost:3000/users
+# API is available at http://localhost:3000, mounted under /api by default
+curl http://localhost:3000/api/users
 ```
+
+The REST surface is served under `/api` unless
+[compatibility mode](#postgrest-compatibility) is enabled, which moves it to
+the root. The examples further down use root-level paths and assume that mode.
 
 ### Configuration
 
@@ -550,38 +554,88 @@ postrust/
 
 ## Benchmarks
 
-**Throughput figures are withdrawn pending re-measurement.**
+AMD EPYC 9255, `governor=performance smt=off`, PostgreSQL 16, 30,000 requests
+at concurrency 50, median of 3 runs. The database, the server under test and
+the load generator each get their own CCD, and every target gets the identical
+core allocation. Figures are the harness's own output, via
+[`website/src/data/measured.ts`](website/src/data/measured.ts).
 
-The comparison benchmark was found to report the order of a run as much as the
-speed of a server: the same server, in the same container, measured seconds
-apart differed by about a factor of two, and scenarios measured earlier in a
-run read lower than ones measured later. The mechanism is not identified.
-Thermal throttling, measurement order, host load, a cold database, the bulk
-load, checkpointing, server and PostgreSQL start-up, container pausing and
-Docker's port forwarding are each ruled out by direct test.
+REST, against PostgREST v16.1 (requests/second, and median latency):
 
-[`scripts/BENCH-FINDINGS.md`](scripts/BENCH-FINDINGS.md) records the
-investigation. Numbers will return once they reproduce on a host without a
-virtualised Docker network, and once a measurement repeated at the start and
-the end of a run agrees with itself.
+| Scenario | Postrust | PostgREST | Ratio |
+|----------|---------:|----------:|------:|
+| point lookup | 44,324 (1.1 ms) | 10,958 (2.8 ms) | 4.0x |
+| 25-row page | 34,633 (1.4 ms) | 10,488 (4.0 ms) | 3.3x |
+| filtered + ordered page | 32,701 (1.5 ms) | 6,306 (6.6 ms) | 5.2x |
+| range filter on numeric | 30,837 (1.6 ms) | 7,099 (6.1 ms) | 4.3x |
+| 25-row page + embed | 20,093 (2.4 ms) | 2,152 (16.8 ms) | 9.3x |
 
-Size is not affected by any of this, and is deterministic:
+GraphQL, against Hasura v2.50.1 and PostGraphile, sent the same query text byte
+for byte:
+
+| Scenario | Postrust | Hasura | PostGraphile |
+|----------|---------:|-------:|-------------:|
+| single row by primary key | 32,146 | 9,650 (3.3x) | 14,127 (2.3x) |
+| 25-row page | 17,411 | 10,379 (1.7x) | 9,003 (1.9x) |
+| 25-row page + embed | 10,092 | 8,024 (1.3x) | 4,498 (2.2x) |
+
+### What these numbers are worth
+
+Read them as ratios rather than as capacity, and as a comparison of whole
+designs rather than of HTTP layers.
+
+- **Much of the REST gap is where each design does the work.** PostgREST wraps
+  every query in a CTE, computes a `count()`, builds the JSON inside PostgreSQL
+  and reads three GUCs via `current_setting` — on every request, whether or not
+  any of it was asked for. Postrust renders JSON itself. That is a real
+  difference and a real cost users pay, but it is *not* evidence that this
+  server's HTTP layer is four times faster.
+- **PostgREST's run-to-run spread is up to 19.6%**, against 0.8% for Postrust,
+  so multiples quoted against it carry roughly ±10%.
+- **A container costs about 8.6%** against the same binary run natively,
+  charged to every target equally.
+- **Absolutes carry this machine's BIOS.** The firmware ignores the OS
+  frequency request, so the clock is fixed but at the firmware's value.
+
+### The gate
+
+The first measurement of a run is repeated as the run's **last** action, and a
+disagreement beyond 3% fails the run. On the run above the two readings agreed
+to **0.1%**. Every target is also fetched and compared before anything is
+timed: mismatched row counts fail the run, because unequal work measured
+precisely is still unequal work.
+
+This matters more than the figures. A deliberately short 2,000-request window
+makes the same REST comparison read **13.1x instead of 4.0x**, from a run that
+looks perfectly healthy. The gate is what stands between a number like that and
+this table. An earlier set of figures was withdrawn for exactly that reason;
+[`scripts/BENCH-FINDINGS.md`](scripts/BENCH-FINDINGS.md) keeps that
+investigation, including the eight causes ruled out and the mechanism that was
+never identified.
+
+### Size and memory
+
+Deterministic, and unaffected by any of the above:
 
 | Resource | Measured |
 |----------|----------|
 | Binary size (`--features admin-ui`, as shipped) | 5,220,864 bytes (4.98 MiB) |
 | Binary size (default features) | 3,070,080 bytes (2.93 MiB) |
+| Image size (Alpine) | 34.9 MB |
+| RSS, idle / after the run (Alpine) | 2.8 MB / 21.6 MB |
 
-The method is unchanged and documented in
-[Benchmarking](docs/benchmarking.md), and the harness still runs:
+For comparison on the same host, PostgREST holds 53.5 MB RSS after the run,
+Hasura 204 MB and PostGraphile 102 MB.
+
+The method is documented in [Benchmarking](docs/benchmarking.md), and the
+harness runs:
 
 ```bash
 ./scripts/bench.sh
 ```
 
-What it measures against other servers is trustworthy in shape but not yet in
-number. Conformance is a separate matter and is unaffected: it measures whether
-two servers give the same answer, not how fast.
+Conformance is a separate matter: it measures whether two servers give the same
+answer, not how fast.
 
 ## Comparison with PostgREST
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ starts the clock for everyone running the software, including people who cannot
 upgrade the same day.
 
 If the advisory form does not work for you, email
-[technology@bimaplan.co](mailto:technology@bimaplan.co) with `SECURITY` in the
+[founder@postrust.org](mailto:founder@postrust.org) with `SECURITY` in the
 subject.
 
 What helps most, in rough order:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -89,14 +89,12 @@ sudo systemctl status postrust
 
 ## Docker
 
-Two registries carry the same images, and two variants of each build:
+Images are published to Docker Hub, in two variants of each build:
 
 | | |
 |---|---|
-| `postrust/postrust:1.0.0` | Docker Hub, Debian base |
-| `postrust/postrust:1.0.0-alpine` | Docker Hub, Alpine base -- much smaller |
-| `ghcr.io/postrust/postrust:1.0.0` | GitHub Container Registry, Debian |
-| `ghcr.io/postrust/postrust:1.0.0-alpine` | GitHub Container Registry, Alpine |
+| `postrust/postrust:1.0.0` | Debian base |
+| `postrust/postrust:1.0.0-alpine` | Alpine base -- much smaller |
 
 `latest` and `latest-alpine` track the newest stable release and never a
 prerelease. `1.0` follows the newest patch of that minor.

--- a/website/src/components/layout/footer.tsx
+++ b/website/src/components/layout/footer.tsx
@@ -27,19 +27,13 @@ export const Footer = component$(() => {
       { href: "https://x.com/postrustorg", label: "Twitter / X", external: true },
       { href: "/community", label: "Contributing" },
     ],
-    company: [
-      { href: "/blog", label: "Blog" },
-      { href: "/about", label: "About" },
-      { href: "/privacy", label: "Privacy Policy" },
-      { href: "/terms", label: "Terms of Service" },
-    ],
   };
 
   return (
     <footer class="bg-neutral-950 text-neutral-300">
       <div class="container-wide section-padding">
         {/* Main Footer */}
-        <div class="grid grid-cols-2 md:grid-cols-5 gap-8 lg:gap-12">
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-8 lg:gap-12">
           {/* Brand */}
           <div class="col-span-2 md:col-span-1">
             <Link href="/" class="flex items-center gap-2 mb-4">
@@ -154,21 +148,6 @@ export const Footer = component$(() => {
             </ul>
           </div>
 
-          <div>
-            <h4 class="text-sm font-semibold text-white mb-4">Company</h4>
-            <ul class="space-y-3">
-              {footerLinks.company.map((link) => (
-                <li key={link.href}>
-                  <Link
-                    href={link.href}
-                    class="text-sm text-neutral-400 hover:text-white transition-colors"
-                  >
-                    {link.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
         </div>
 
         {/* Bottom Bar */}

--- a/website/src/components/sections/features.tsx
+++ b/website/src/components/sections/features.tsx
@@ -3,13 +3,13 @@ import { component$ } from "@builder.io/qwik";
 const features = [
   {
     icon: "bolt",
-    title: "Blazing Fast",
-    description: "Written in Rust for maximum performance. Sub-millisecond response times and minimal memory footprint.",
+    title: "Fast, and Measured",
+    description: "44,324 requests/second on a point lookup at 1.1 ms median, on a host held still and gated for self-consistency. The method and the caveats are published with the figures.",
   },
   {
     icon: "cloud",
-    title: "Serverless-First",
-    description: "Native support for AWS Lambda. Single binary with ~50ms cold starts. No container overhead.",
+    title: "Runs on Lambda",
+    description: "A native AWS Lambda adapter with connection pooling, from the same binary that runs standalone. Cloudflare Workers is a stub pending Hyperdrive.",
   },
   {
     icon: "graphql",
@@ -39,7 +39,7 @@ const features = [
   {
     icon: "code",
     title: "PostgREST Compatible",
-    description: "Same query syntax and filtering operators. An opt-in compatibility mode serves canonical PostgREST paths and response shapes for drop-in migrations.",
+    description: "Same query syntax and filtering operators. An opt-in compatibility mode serves canonical PostgREST paths and response shapes, and matches on 1,424 of PostgREST's own 1,499 test cases.",
   },
   {
     icon: "api",
@@ -49,7 +49,7 @@ const features = [
   {
     icon: "package",
     title: "Single Binary",
-    description: "~5MB binary with no runtime dependencies. Deploy anywhere - Docker, Lambda, bare metal.",
+    description: "4.98 MiB with the admin UI, 2.93 MiB without, and no runtime dependencies. Deploy anywhere - Docker, Lambda, bare metal.",
   },
 ];
 

--- a/website/src/components/sections/hero.tsx
+++ b/website/src/components/sections/hero.tsx
@@ -30,22 +30,23 @@ export const HeroSection = component$(() => {
 
           {/* Subheadline */}
           <p class="text-lg md:text-xl text-neutral-600 max-w-2xl mx-auto mb-10">
-            High-performance REST & GraphQL API server for PostgreSQL,
-            written in Rust. Native AWS Lambda support with ~50ms cold starts.{" "}
+            One Rust binary that serves a PostgreSQL schema over REST and
+            GraphQL, with a native AWS Lambda adapter. It answers{" "}
             <Link
               href="/docs/conformance"
               class="underline decoration-neutral-300 underline-offset-4 hover:decoration-primary-600 hover:text-primary-700"
             >
-              Drop-in PostgREST replacement
-            </Link>
-            , and it speaks{" "}
+              PostgREST&rsquo;s dialect
+            </Link>{" "}
+            and{" "}
             <Link
               href="/docs/conformance/hasura"
               class="underline decoration-neutral-300 underline-offset-4 hover:decoration-primary-600 hover:text-primary-700"
             >
-              Hasura&rsquo;s GraphQL dialect
+              Hasura&rsquo;s
             </Link>
-            . Both measured against the servers they replace.
+            , and how closely is not a matter of opinion: each is measured by
+            replaying that server&rsquo;s own test suite against both.
           </p>
 
           {/* CTAs */}
@@ -88,19 +89,18 @@ export const HeroSection = component$(() => {
               <div class="p-6 text-left">
                 <pre class="text-sm md:text-base font-mono">
                   <code>
-                    <span class="text-neutral-500"># Start in seconds with Docker</span>
+                    <span class="text-neutral-500"># Postgres and the server, from a clone</span>
                     {"\n"}
                     <span class="text-green-400">$</span>
-                    <span class="text-neutral-100"> docker run -p 3000:3000 \</span>
+                    <span class="text-neutral-100"> git clone https://github.com/postrust/postrust</span>
                     {"\n"}
-                    <span class="text-neutral-100">    -e DATABASE_URL="postgres://..." \</span>
-                    {"\n"}
-                    <span class="text-neutral-100">    postrust/postrust</span>
+                    <span class="text-green-400">$</span>
+                    <span class="text-neutral-100"> cd postrust && docker compose up -d</span>
                     {"\n\n"}
                     <span class="text-neutral-500"># Your API is ready!</span>
                     {"\n"}
                     <span class="text-green-400">$</span>
-                    <span class="text-neutral-100"> curl localhost:3000/users</span>
+                    <span class="text-neutral-100"> curl localhost:3000/api/users</span>
                     {"\n"}
                     <span class="text-accent-400">[{`{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}`}]</span>
                   </code>
@@ -121,7 +121,7 @@ export const HeroSection = component$(() => {
               <svg class="w-5 h-5 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>
               </svg>
-              <span>~50ms Lambda Cold Start</span>
+              <span>95% of PostgREST&rsquo;s test suite</span>
             </div>
             <div class="flex items-center gap-2">
               <svg class="w-5 h-5 text-accent-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/website/src/routes/enterprise/index.tsx
+++ b/website/src/routes/enterprise/index.tsx
@@ -1,4 +1,4 @@
-import { component$, useSignal } from "@builder.io/qwik";
+import { component$ } from "@builder.io/qwik";
 import type { DocumentHead } from "@builder.io/qwik-city";
 
 const enterpriseFeatures = [
@@ -44,8 +44,6 @@ const iconPaths: Record<string, string> = {
 };
 
 export default component$(() => {
-  const formSubmitted = useSignal(false);
-
   return (
     <div class="min-h-screen bg-white">
       {/* Hero */}
@@ -108,144 +106,73 @@ export default component$(() => {
           <div class="max-w-2xl mx-auto">
             <div class="text-center mb-12">
               <h2 class="text-3xl font-bold text-neutral-900 mb-4">
-                Contact Sales
+                Talk to us
               </h2>
               <p class="text-lg text-neutral-600">
-                Tell us about your needs and we'll get back to you within one business day.
+                Support and consulting for teams running Postrust in
+                production.
               </p>
             </div>
 
-            {formSubmitted.value ? (
-              <div class="bg-green-50 border border-green-200 rounded-xl p-8 text-center">
-                <div class="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                  <svg class="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                  </svg>
-                </div>
-                <h3 class="text-xl font-semibold text-neutral-900 mb-2">
-                  Thank you for reaching out!
-                </h3>
-                <p class="text-neutral-600">
-                  We've received your message and will get back to you within one business day.
-                </p>
-              </div>
-            ) : (
-              <form
-                class="bg-white rounded-2xl p-8 border border-neutral-200 shadow-sm"
-                preventdefault:submit
-                onSubmit$={() => {
-                  formSubmitted.value = true;
-                }}
+            <div class="bg-white rounded-2xl border border-neutral-200 shadow-sm p-8">
+              <p class="text-neutral-700 mb-6">
+                Enterprise support is handled by email, by the people who
+                maintain the server. There is no form and no sales team in
+                between.
+              </p>
+
+              <a
+                href="mailto:founder@postrust.org?subject=Postrust%20enterprise%20support"
+                class="inline-flex items-center gap-2 px-6 py-3 text-base font-semibold text-white bg-neutral-900 hover:bg-neutral-800 rounded-lg transition-colors"
               >
-                <div class="grid md:grid-cols-2 gap-6 mb-6">
-                  <div>
-                    <label class="block text-sm font-medium text-neutral-700 mb-2">
-                      First Name *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors"
-                      placeholder="John"
-                    />
-                  </div>
-                  <div>
-                    <label class="block text-sm font-medium text-neutral-700 mb-2">
-                      Last Name *
-                    </label>
-                    <input
-                      type="text"
-                      required
-                      class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors"
-                      placeholder="Doe"
-                    />
-                  </div>
-                </div>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                </svg>
+                founder@postrust.org
+              </a>
 
-                <div class="mb-6">
-                  <label class="block text-sm font-medium text-neutral-700 mb-2">
-                    Work Email *
-                  </label>
-                  <input
-                    type="email"
-                    required
-                    class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors"
-                    placeholder="john@company.com"
-                  />
-                </div>
-
-                <div class="mb-6">
-                  <label class="block text-sm font-medium text-neutral-700 mb-2">
-                    Company *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors"
-                    placeholder="Company Inc."
-                  />
-                </div>
-
-                <div class="mb-6">
-                  <label class="block text-sm font-medium text-neutral-700 mb-2">
-                    Team Size
-                  </label>
-                  <select class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors">
-                    <option value="">Select team size</option>
-                    <option value="1-10">1-10 employees</option>
-                    <option value="11-50">11-50 employees</option>
-                    <option value="51-200">51-200 employees</option>
-                    <option value="201-1000">201-1000 employees</option>
-                    <option value="1000+">1000+ employees</option>
-                  </select>
-                </div>
-
-                <div class="mb-8">
-                  <label class="block text-sm font-medium text-neutral-700 mb-2">
-                    How can we help? *
-                  </label>
-                  <textarea
-                    required
-                    rows={4}
-                    class="w-full px-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 outline-none transition-colors resize-none"
-                    placeholder="Tell us about your project and requirements..."
-                  ></textarea>
-                </div>
-
-                <button
-                  type="submit"
-                  class="w-full py-4 px-6 text-base font-semibold text-white bg-neutral-900 hover:bg-neutral-800 rounded-lg transition-colors"
+              <p class="mt-6 text-sm text-neutral-500">
+                It helps to include your team size, what you are running today,
+                and what you need from a support agreement. Bug reports and
+                feature requests are better off in{" "}
+                <a
+                  href="https://github.com/postrust/postrust/issues"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary-600 hover:text-primary-700"
                 >
-                  Submit Request
-                </button>
-
-                <p class="mt-4 text-center text-sm text-neutral-500">
-                  By submitting this form, you agree to our{" "}
-                  <a href="/privacy" class="text-primary-600 hover:text-primary-700">
-                    Privacy Policy
-                  </a>
-                  .
-                </p>
-              </form>
-            )}
+                  GitHub Issues
+                </a>
+                , where everyone can see them.
+              </p>
+            </div>
           </div>
         </div>
       </section>
 
-      {/* Trust */}
+      {/* Trust -- disabled until there are real logos to show.
+          Re-enable only when named companies have agreed to be listed:
+          five grey placeholders under "Trusted by teams at companies of
+          all sizes" claims social proof the project does not have yet,
+          and reads as an unfinished template.
+
+          Note: the inner `Placeholder logos` comment was dropped, since a
+          nested block comment would close this one early.
+
       <section class="section-padding">
         <div class="container-wide text-center">
           <p class="text-neutral-500 mb-8">
             Trusted by teams at companies of all sizes
           </p>
           <div class="flex flex-wrap items-center justify-center gap-12 opacity-50">
-            {/* Placeholder logos */}
             {[1, 2, 3, 4, 5].map((i) => (
               <div key={i} class="w-32 h-8 bg-neutral-200 rounded"></div>
             ))}
           </div>
         </div>
       </section>
+
+      */}
     </div>
   );
 });

--- a/website/src/routes/features/index.tsx
+++ b/website/src/routes/features/index.tsx
@@ -96,8 +96,8 @@ const featureCategories = [
         description: "Automatic reconnection and subscription recovery",
       },
       {
-        name: "Low Latency",
-        description: "Sub-millisecond notification delivery",
+        name: "Push, Not Poll",
+        description: "Delivered on PostgreSQL's LISTEN/NOTIFY, not a polling loop",
       },
     ],
   },

--- a/website/src/routes/index.tsx
+++ b/website/src/routes/index.tsx
@@ -28,7 +28,7 @@ export const head: DocumentHead = {
     {
       name: "description",
       content:
-        "High-performance PostgreSQL REST & GraphQL API server written in Rust. Native AWS Lambda support with ~50ms cold starts. Drop-in PostgREST replacement that also speaks Hasura's GraphQL dialect.",
+        "One Rust binary serving a PostgreSQL schema over REST and GraphQL, with a native AWS Lambda adapter. It answers PostgREST's dialect and Hasura's, each measured by replaying that server's own test suite.",
     },
     {
       name: "keywords",
@@ -42,7 +42,7 @@ export const head: DocumentHead = {
     {
       property: "og:description",
       content:
-        "High-performance PostgreSQL REST & GraphQL API server written in Rust. Native AWS Lambda support with ~50ms cold starts.",
+        "One Rust binary serving a PostgreSQL schema over REST and GraphQL, with a native AWS Lambda adapter. Measured against PostgREST's and Hasura's own test suites.",
     },
     {
       property: "og:type",
@@ -63,7 +63,7 @@ export const head: DocumentHead = {
     {
       name: "twitter:description",
       content:
-        "High-performance PostgreSQL REST & GraphQL API server written in Rust. Native AWS Lambda support with ~50ms cold starts.",
+        "One Rust binary serving a PostgreSQL schema over REST and GraphQL, with a native AWS Lambda adapter. Measured against PostgREST's and Hasura's own test suites.",
     },
   ],
 };

--- a/website/src/routes/pricing/index.tsx
+++ b/website/src/routes/pricing/index.tsx
@@ -52,11 +52,15 @@ const faqs = [
   },
   {
     question: "Can I use Postrust in production?",
-    answer: "Absolutely. Postrust is designed for production workloads with features like connection pooling, health checks, and comprehensive logging. Many teams run it in production today.",
+    answer: "1.0 is released and the API is stable, with connection pooling, health checks and structured logging. Be aware of what is and is not measured: 95% of PostgREST's own test suite and 97% of Hasura's pass, the remaining cases are listed on the conformance page, and only compatibility mode is covered by the PostgREST suite. Read those before you migrate something that matters.",
+  },
+  {
+    question: "Will the license change?",
+    answer: "No. The server stays MIT, there is no contributor licence agreement, and the enterprise tier is support and consulting rather than features held back from the open source build.",
   },
   {
     question: "How does Postrust compare to managed services?",
-    answer: "Postrust gives you full control over your infrastructure while being significantly more cost-effective. You can run it on your own servers, AWS Lambda, or any cloud provider without per-request pricing.",
+    answer: "You run it yourself, on your own servers, AWS Lambda or any cloud provider, with no per-request pricing and no vendor account in the request path. That is a trade: you also carry the upgrades, the monitoring and the on-call.",
   },
   {
     question: "Do you offer consulting services?",

--- a/website/src/routes/releases/index.tsx
+++ b/website/src/routes/releases/index.tsx
@@ -384,7 +384,7 @@ export default component$(() => {
                 <span class="text-sm text-neutral-400">bash</span>
               </div>
               <pre class="overflow-x-auto p-4 text-sm">
-                <code class="text-neutral-100">{`docker pull ghcr.io/postrust/postrust:v${VERSION}`}</code>
+                <code class="text-neutral-100">{`docker pull postrust/postrust:${VERSION}`}</code>
               </pre>
             </div>
             <p class="mt-3 text-sm text-neutral-500">


### PR DESCRIPTION
The benchmark pages were rebuilt in #28, #33 and #34 to publish figures with
their caveats attached. The top of the site never caught up, and argued with
them. This is the front page catching up, plus the registry instructions that
could not work.

## Two claims contradicted our own data

- **"Sub-millisecond response times."** The fastest median in `measured.ts` is
  **1.1 ms**, on the point lookup. Every scenario is slower than the claim.
  The same phrase described notification delivery on `/features`, where
  nothing measures it either.
- **"~50ms cold starts."** In the hero, a trust badge, a feature card and
  three meta descriptions -- six places. No harness, doc or results file
  produces this number. Removed rather than restated, because that is what we
  did to the throughput figures for the same reason.

## The quickstart could not work

The hero ran `docker run postrust/postrust`, which resolves a `latest` tag
that had never existed on Docker Hub, and then curled `/users`, which is only
mounted at the root under compatibility mode -- off by default, and not set by
`docker-compose`. Both replaced by the clone-and-compose path that every other
doc already uses and that builds locally. The README quickstart curl had the
same wrong path.

## GHCR is removed rather than fixed

GHCR packages are private by default and this one never was made public, so
`docker pull ghcr.io/postrust/postrust:v1.0.0` -- what the v1.0.0 release
notes told people to run -- failed for everyone except the account that
pushed it. That is what failed the verify job on the v1.0.0 re-run.

Docker Hub now carries all eight tags (`1.0.0`, `1.0`, `v1.0.0`, `latest` and
the four `-alpine` variants), each checked with an anonymous pull rather than
trusted from a green check. One registry that works beats two where the
documented one does not.

| | |
|---|---|
| `/releases` | offered the GHCR pull as the only way to try a release |
| `docs/deployment.md` | listed four tags across two registries; two were not pullable |
| `release.yml` | no longer logs in, tags, publishes or verifies against GHCR; `packages: write` dropped |
| release notes | edited on GitHub to match |

Docker Hub was optional before, because GHCR was the fallback that always
worked. With that gone a missing `DOCKERHUB_TOKEN` would publish nothing at
all, so the image job now fails up front naming the secret and the scope it
needs. Worth having: a read-only token logs in cleanly and only fails at
push, which reads like a bad password rather than a permissions problem.

The GHCR references left in the tree are third-party -- the letsencrypt pebble
images in `docker-compose.yml`, and the sample deploy pipeline in
`docs/deployment.md`, which publishes the reader's own image.

## The rest

- "Blazing Fast" becomes the figure and the host it was measured on.
- "Drop-in PostgREST replacement" becomes the 1,424 of 1,499 cases that pass.
- "Serverless-First" now says Cloudflare Workers is a stub, which the README's
  own feature table already said.
- Four dead footer links removed: `/blog`, `/about`, `/privacy` and `/terms`
  all 404. The now-empty Company column goes with them.
- Pricing said "Many teams run it in production today", which nothing in the
  repository supports. It now says what is true and what is not measured. A
  licence question was added because the Enterprise tier invites it -- MIT
  across every crate, and no CLA in the tree.
- README's Benchmarks section still announced the withdrawal. It carries the
  tables, the caveats, the gate, and the size and memory figures.

## Checks

`build.types`, `eslint` and the full website `build` clean. Rendered via SSR
preview and grepped for every removed claim across nine routes. The workflow
parses as YAML and no reference to the removed `REGISTRY` or `IMAGE_NAME`
survives. `prettier --check` clean on `/releases`; the five files it flags
under `sections/` and `layout/` were already non-conformant on `main` and are
left alone.

## Not done

The fresh-machine quickstart test. Docker is not available in the WSL distro
these changes were made in, so the compose command now on the homepage is
verified by reading `docker-compose.yml` (it builds locally, exposes 3000, and
does not set compat mode) rather than by running it. Worth running once before
launch. Related: the `test` service has no profile, so `docker compose up -d`
starts it alongside Postgres and the server -- the ACME services are profiled
and this one was missed.


---

## The enterprise form threw submissions away

Added after review. The form collected first name, last name, work email,
company and team size. Its entire submit handler set a flag -- no action, no
endpoint, no fetch, no mailto -- and then displayed:

> Thank you for reaching out!
> We've received your message and will get back to you within one business day.

Both sentences were false, to someone who had just typed their work email, and
pricing funnels "Contact Sales" straight into it. Replaced with a mailto and a
line saying what to include.

That keeps the privacy position honest: with no form, the site collects nothing
at all -- no analytics, no cookies, no storage -- so there is still nothing for
a privacy policy to describe. This is also why `/privacy` and `/terms` are not
being written as stubs. The MIT licence governs the software, and there is no
service, no account and no data collection to write terms about.

**The contact address** in `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and
`SECURITY.md` was a personal work address at an unrelated company. It is
`founder@postrust.org` in all three now. That address needs to be a working
mailbox before this merges -- a dead address in `SECURITY.md` is worse than
the one it replaced.

**"Trusted by teams at companies of all sizes"**, set over five grey
placeholder rectangles standing in for customer logos, is commented out rather
than deleted so real logos can go in later. It claimed social proof the project
does not have and read as an unfinished template. Verified absent from every
built bundle.
